### PR TITLE
Replace terraform_docs use of GNU sed with perl

### DIFF
--- a/terraform_docs.sh
+++ b/terraform_docs.sh
@@ -15,7 +15,7 @@ for file_with_path in "$@"; do
     tfvars_files+=("$file_with_path")
   fi
 
-  let "index+=1"
+  ((index+=1))
 done
 
 readonly tmp_file="tmp_$(date | md5).txt"

--- a/terraform_docs.sh
+++ b/terraform_docs.sh
@@ -33,11 +33,11 @@ for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
 
   terraform-docs md ./ > "$tmp_file"
 
-  # Replace content between markers with the placeholder - http://fahdshariff.blogspot.no/2012/12/sed-mutli-line-replacement-between-two.html
-  sed -i -n '/BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK/{p;:a;N;/END OF PRE-COMMIT-TERRAFORM DOCS HOOK/!ba;s/.*\n/I_WANT_TO_BE_REPLACED\n/};p' "$text_file"
+  # Replace content between markers with the placeholder - https://stackoverflow.com/questions/1212799/how-do-i-extract-lines-between-two-line-delimiters-in-perl#1212834
+  perl -i -ne 'if (/BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK/../END OF PRE-COMMIT-TERRAFORM DOCS HOOK/) { print $_ if /BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK/; print "I_WANT_TO_BE_REPLACED\n$_" if /END OF PRE-COMMIT-TERRAFORM DOCS HOOK/;} else { print $_ }' "$text_file"
 
-  # Replace placeholder with the content of the file - https://stackoverflow.com/a/31057013/550451
-  sed -i -e "/I_WANT_TO_BE_REPLACED/r $tmp_file" -e "//d" "$text_file"
+  # Replace placeholder with the content of the file
+  perl -i -e 'open(F, "'"$tmp_file"'"); $f = join "", <F>; while(<>){if (/I_WANT_TO_BE_REPLACED/) {print $f} else {print $_};}' "$text_file"
 
   rm -f "$tmp_file"
 


### PR DESCRIPTION
This replaces the sed commands which required GNU sed be installed with
perl versions. This should make this script more universally usable
(e.g., on macOS) without installing additional tools.

Closes #14.