### PR TITLE
Fixes use of md5 for tempfile name

### DIFF
--- a/terraform_docs.sh
+++ b/terraform_docs.sh
@@ -18,7 +18,7 @@ for file_with_path in "$@"; do
   let "index+=1"
 done
 
-readonly tmp_file="tmp_$(date | md5).txt"
+readonly tmp_file=$(mktemp)
 readonly text_file="README.md"
 
 for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do


### PR DESCRIPTION
On Linux, the `md5` command is called `md5sum`.

Instead of creating our own tempfile name, use `mktemp` which is available on both BSD and Linux.