### PR TITLE
Require terraform-docs runs in serial

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -9,6 +9,7 @@
 - id: terraform_docs
   name: Terraform docs
   description: Inserts input and output documentation into README.md (using terraform-docs).
+  require_serial: true
   entry: terraform_docs.sh
   args: [--args=--with-aggregate-type-defaults]
   language: script
@@ -18,6 +19,7 @@
 - id: terraform_docs_without_aggregate_type_defaults
   name: Terraform docs (without aggregate type defaults)
   description: Inserts input and output documentation into README.md (using terraform-docs).
+  require_serial: true
   entry: terraform_docs.sh
   language: script
   files: (\.tf)$
@@ -25,11 +27,12 @@
 
 - id: terraform_docs_replace
   name: Terraform docs (overwrite README.md)
-  language: python
+  description: Overwrite content of README.md with terraform-docs
+  require_serial: true
   entry: terraform_docs_replace
+  language: python
   files: (\.tf)$
   exclude: \.terraform\/.*$
-  description: Overwrite content of README.md with terraform-docs
 
 - id: terraform_validate_no_variables
   name: Terraform validate without variables


### PR DESCRIPTION
It turns out that `pre-commit` defaults to running hooks in parallel. This means it will take a batch of files, break them into chunks, and run those together.  The `terraform_docs.sh` script strips the filenames and runs over a set of unique paths.  That means that parallel operations can be running int he same directories. To avoid pre-commit doing parallel operations on similar file paths I've added `require_serial: true` to the hook descriptions.

For some detail, I ran into this while running on docker.  I copied a large terraform directory into a docker container and then ran the `terraform-docs` pre-commit hook to mimic our CI environment in CircleCI.  In about 10-20% of cases the hook would fail and the result would be that one or more files were deleted.  It turns out the chunking from pre-commit is non-deterministic, so sometimes similar directories would be groups and sometimes not. And when they were not grouped we had a race condition where perl would be operating on an in-place file operation when the underlying file would get removed.

I attempted to revert to using `sed` and had less failures but it would happen, just less often.  I think the combination of `perl` and `docker` is what made this show up because `perl` takes just a bit longer than `sed` and `docker` is resource constrained enough on my mac to cause the race condition to bite me.

Fortunately this is a one-line fix and users who are currently experiencing this can immediately fix it by adding the same line, per this example:

```
  - repo: git://github.com/antonbabenko/pre-commit-terraform
    rev: v1.8.1
    hooks:
      - id: terraform_docs
        require_serial: true
```