### PR TITLE
Add exit code for 'terraform validate' so pre-commit check fails

### DIFF
--- a/terraform_validate_with_variables.sh
+++ b/terraform_validate_with_variables.sh
@@ -3,6 +3,7 @@ set -e
 
 declare -a paths
 index=0
+error=0
 
 for file_with_path in "$@"; do
   file_with_path="${file_with_path// /__REPLACED__SPACE__}"
@@ -17,6 +18,7 @@ for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
   pushd "$path_uniq" > /dev/null
   if [[ -n "$(find . -maxdepth 1 -name '*.tf' -print -quit)" ]] ; then
     if ! terraform validate -check-variables=true ; then
+      error=1
       echo
       echo "Failed path: $path_uniq"
       echo "================================"
@@ -24,3 +26,7 @@ for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
   fi
   popd > /dev/null
 done
+
+if [[ -n "${error}" ]] ; then
+  exit 1
+fi


### PR DESCRIPTION
Exit code for failed 'terraform validate -check-variables=true', so it fails pre-commit check correctly.
[https://github.com/antonbabenko/pre-commit-terraform/issues/22](https://github.com/antonbabenko/pre-commit-terraform/issues/22)