### PR TITLE
fix check for errors at the end on validate w/ variables

### DIFF
--- a/terraform_validate_with_variables.sh
+++ b/terraform_validate_with_variables.sh
@@ -27,6 +27,6 @@ for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
   popd > /dev/null
 done
 
-if [[ -n "${error}" ]] ; then
+if [[ "${error}" -ne 0 ]] ; then
   exit 1
 fi


### PR DESCRIPTION
`-n` checks to see if a variable is defined.  The way the script is currently written, the `terraform_validate_with_variables` check will always fail because the last thing it does is check to see if `error` is defined and does an `exit 1` if so.  This change makes it so that we check to see `error` is not `0` instead.