### PR TITLE
Use more idiomatic bash code

### DIFF
--- a/terraform_validate.sh
+++ b/terraform_validate.sh
@@ -8,9 +8,17 @@ ERROR=0
 
 # main code entrypoint
 main() {
+  preflight_check
   get_uniq_dirs "$@"
   process_dirs
   exit "$ERROR"
+}
+
+preflight_check() {
+  [[ ${BASH_VERSINFO[0]} -ge 4 ]] || (
+    printf "\nError: Bash 4 or greater required\n\n" >&2
+    exit 1
+  )
 }
 
 # reduce the command line args to a list of valid, uniq dirs

--- a/terraform_validate.sh
+++ b/terraform_validate.sh
@@ -14,8 +14,8 @@ main() {
   exit "$ERROR"
 }
 
-
-# reduce the command line args to a list of valid, uniq dirs
+# reduce the command line args to a list of valid dirs
+# ensure unique by storing in associative array
 get_uniq_dirs() {
   local file
   local abs_file
@@ -44,6 +44,7 @@ test_dir() {
   local dir="$1" ; shift
   (
     cd "$dir"
+    # check for presence of tf files
     if stat -t -- *.tf >/dev/null 2>&1 ; then
       if ! terraform validate -check-variables=true ; then
         echo

--- a/terraform_validate.sh
+++ b/terraform_validate.sh
@@ -1,30 +1,64 @@
 #!/usr/bin/env bash
-set -e
 
-declare -a paths
-index=0
-error=0
+set -euo pipefail
 
-for file_with_path in "$@"; do
-  file_with_path="${file_with_path// /__REPLACED__SPACE__}"
+# global vars
+declare -A dirs_to_test
+ERROR=0
 
-  paths[index]=$(dirname "$file_with_path")
-  (( "index+=1" ))
-done
+# main code entrypoint
+main() {
+  get_uniq_dirs "$@"
+  process_dirs
+  exit "$ERROR"
+}
 
-for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
-  path_uniq="${path_uniq//__REPLACED__SPACE__/ }"
+# reduce the command line args to a list of valid, uniq dirs
+get_uniq_dirs() {
+  local file
+  local abs_file
+  local abs_dir
+  for file in "$@" ; do
+    # Check that file exists
+    [[ -e $file ]] || continue
 
-  if [[ -n "$(find . -maxdepth 1 -name '*.tf' -print -quit)" ]] ; then
-    if ! terraform validate $path_uniq; then
-      error=1
-      echo
-      echo "Failed path: $path_uniq"
-      echo "================================"
+    # get absolute path
+    abs_file="$(realpath "$file")"
+
+    # test it's a dir
+    if [[ -d $abs_file ]] ; then
+      dirs_to_test["$abs_file"]=1
+      continue
     fi
-  fi
-done
 
-if [[ "${error}" -ne 0 ]] ; then
-  exit 1
-fi
+    # treat as a file
+    abs_dir="$(dirname "$abs_file")"
+    dirs_to_test["$abs_dir"]=1
+  done
+}
+  
+# validate one directory
+test_dir() {
+  local dir="$1" ; shift
+  (
+    cd "$dir"
+    if stat -t -- *.tf >/dev/null 2>&1 ; then
+      if ! terraform validate -check-variables=true ; then
+        echo
+        echo "Failed path: $dir"
+        echo "================================"
+        return 1
+      fi
+    fi
+  )
+}
+
+# process each directory
+process_dirs() {
+  local dir
+  for dir in "${!dirs_to_test[@]}"; do
+    test_dir "$dir" || ERROR=1
+  done
+}
+
+main "$@"

--- a/terraform_validate.sh
+++ b/terraform_validate.sh
@@ -2,24 +2,18 @@
 
 set -euo pipefail
 
-# global vars
-declare -A dirs_to_test
-ERROR=0
+[[ ${BASH_VERSINFO[0]} -ge 4 ]] || (
+  printf "\nError: Bash 4 or greater required\n\n" >&2
+  exit 1
+)
 
 # main code entrypoint
 main() {
-  preflight_check
   get_uniq_dirs "$@"
   process_dirs
   exit "$ERROR"
 }
 
-preflight_check() {
-  [[ ${BASH_VERSINFO[0]} -ge 4 ]] || (
-    printf "\nError: Bash 4 or greater required\n\n" >&2
-    exit 1
-  )
-}
 
 # reduce the command line args to a list of valid, uniq dirs
 get_uniq_dirs() {
@@ -68,5 +62,9 @@ process_dirs() {
     test_dir "$dir" || ERROR=1
   done
 }
+
+# global vars
+declare -A dirs_to_test
+ERROR=0
 
 main "$@"


### PR DESCRIPTION
I've tweaked the `terraform_validate_with_variables.sh` script to be a little more robust and use more idiomatic bash code which should handle files with spaces in their name more elegantly.

A similar approach could be applied to `terraform_validate_no_variables.sh`. In fact, both scripts could probably be merged into one, with a command-line option to choose whether to test with or without variables.