### PR TITLE
Formatter for Terragrunt HCL files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -41,3 +41,11 @@
   language: script
   files: (\.tf|\.tfvars)$
   exclude: \.terraform\/.*$
+
+- id: terragrunt_fmt
+  name: Terragrunt fmt
+  description: Rewrites all Terragrunt configuration files to a canonical format.
+  entry: terragrunt_fmt.sh
+  language: script
+  files: (\.hcl)$
+  exclude: \.terraform\/.*$

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ There are several [pre-commit](http://pre-commit.com/) hooks to keep Terraform c
 * `terraform_docs` - Inserts input and output documentation into `README.md`. Recommended.
 * `terraform_docs_without_aggregate_type_defaults` - Inserts input and output documentation into `README.md` without aggregate type defaults.
 * `terraform_docs_replace` - Runs `terraform-docs` and pipes the output directly to README.md
+* `terragrunt_fmt` - Rewrites all Terragrunt configuration files to a canonical format.
 
 Check the [source file](https://github.com/antonbabenko/pre-commit-terraform/blob/master/.pre-commit-hooks.yaml) to know arguments used for each hook.
 

--- a/terragrunt_fmt.sh
+++ b/terragrunt_fmt.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+
+declare -a paths
+
+index=0
+
+for file_with_path in "$@"; do
+  file_with_path="${file_with_path// /__REPLACED__SPACE__}"
+
+  paths[index]=$(dirname "$file_with_path")
+
+  let "index+=1"
+done
+
+for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
+  path_uniq="${path_uniq//__REPLACED__SPACE__/ }"
+
+  pushd "$path_uniq" > /dev/null
+  terragrunt hclfmt
+  popd > /dev/null
+done


### PR DESCRIPTION
Provides a `terragrunt_fmt` hook for users of Terragrunt.

## Description
Terragrunt has its own formatter for the `.hcl` files that are used throughout a Terragrunt-enabled repository. These files are not formatted by Terraform, and therefore, Terragrunt needs its own formatting hook.

## Motivation and Context
I wanted to also be able to format my Terragrunt configurations.

## How Has This Been Tested?
Ran the following command against a Terragrunt repo using a local copy of this branch:

```shell
$ pre-commit try-repo \
--verbose \
--all-files \
'/local/copy/of/this/pre-commit-terraform' \
terragrunt_fmt
```

Only downside is it takes a bit of time.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.