### PR TITLE
Fix terraform_docs_awk complex type error

### DIFF
--- a/terraform_docs.sh
+++ b/terraform_docs.sh
@@ -153,7 +153,7 @@ terraform_docs_awk() {
         if (blockDefCnt > 0) {
           blockDefCnt = 0
         }
-        if ($blockDefCnt !~ /string$/) {
+        if ($blockDefCnt !~ /(string|number|bool)$/) {
           print $0
         }
       }

--- a/terraform_docs.sh
+++ b/terraform_docs.sh
@@ -153,7 +153,9 @@ terraform_docs_awk() {
         if (blockDefCnt > 0) {
           blockDefCnt = 0
         }
-        print $0
+        if ($blockDefCnt !~ /string$/) {
+          print $0
+        }
       }
     }
   }


### PR DESCRIPTION
But it's looks like crutch, should be added multiline support
for  'type'

Related: https://github.com/antonbabenko/pre-commit-terraform/issues/65