### PR TITLE
update rev in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Step into the repository you want to have the pre-commit hooks installed and run
 ```bash
 cat <<EOF > .pre-commit-config.yaml
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.18.0
+  rev: v1.19.0
   hooks:
     - id: terraform_fmt
     - id: terraform_docs


### PR DESCRIPTION
Updating the rev in the README.

In order for `terraform_tflint` to work, the rev must be at least `v1.19.0`.