### PR TITLE
[WIP] Run TFLint from repository root

### DIFF
--- a/terraform_tflint.sh
+++ b/terraform_tflint.sh
@@ -17,7 +17,5 @@ done
 for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
   path_uniq="${path_uniq//__REPLACED__SPACE__/ }"
 
-  pushd "$path_uniq" > /dev/null
-  tflint --deep
-  popd > /dev/null
+  tflint --deep $path_uniq
 done


### PR DESCRIPTION
The current TFLint hook changes directory before running TFLint. This causes TFLint to ignore any `.tflint.hcl` config file that may be present in the repository root.

Is there some reason for changing directories before running TFLint? Thanks

Edit: marked this as WIP, as I noticed that TFLint will error occasionally as it is unable to parse sub-modules properly when not running from the module directory.