### PR TITLE
tflint: iterate over files

### DIFF
--- a/terraform_tflint.sh
+++ b/terraform_tflint.sh
@@ -28,7 +28,7 @@ main() {
 }
 
 tflint_() {
-  for file_with_path in "$@"; do
+  for file_with_path in $files; do
     file_with_path="${file_with_path// /__REPLACED__SPACE__}"
 
     paths[index]=$(dirname "$file_with_path")


### PR DESCRIPTION
It will avoid this bug:
```
/Users/robinho/.cache/pre-commit/repoxfm3uiv2/terraform_tflint.sh: line 42: pushd: modules/prometheus/lb.tf modules/prometheus/ec2.tf modules/prometheus/variables.tf modules/prometheus: No such file or directory
```