### PR TITLE
terraform_tflint: Fix files array assignation

### DIFF
--- a/terraform_tflint.sh
+++ b/terraform_tflint.sh
@@ -7,7 +7,7 @@ main() {
   eval "set -- $argv"
 
   declare args
-  declare files
+  declare -a files
 
   for argv; do
     case $argv in
@@ -18,13 +18,13 @@ main() {
         ;;
       (--)
         shift
-        files="$@"
+        files=("$@")
         break
         ;;
     esac
   done
 
-  tflint_ "$args" "$files"
+  tflint_ "$args" "${files[@]}"
 }
 
 tflint_() {


### PR DESCRIPTION
Files were concatenated into a single space-separated string

How `args` are passed to the `tflint` function might have to be improved too.

Here's `shellcheck` output:

```bash
$ shellcheck terraform_tflint.sh                                                                                                                                       [12:11:58]

In terraform_tflint.sh line 36:
    let "index+=1"
    ^-----------^ SC2219: Instead of 'let expr', prefer (( expr )) .


In terraform_tflint.sh line 43:
    tflint $args
           ^---^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
    tflint "$args"


In terraform_tflint.sh line 534:
[[ $BASH_SOURCE != "$0" ]] || main "$@"
   ^----------^ SC2128: Expanding an array without an index only gives the first element.

For more information:
  https://www.shellcheck.net/wiki/SC2128 -- Expanding an array without an ind...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
  https://www.shellcheck.net/wiki/SC2219 -- Instead of 'let expr', prefer (( ...
```