### PR TITLE
Move terraform-docs args after md command

### DIFF
--- a/terraform_docs.sh
+++ b/terraform_docs.sh
@@ -76,7 +76,7 @@ terraform_docs() {
     fi
 
   if [[ "$terraform_docs_awk_file" == "0" ]]; then
-    terraform-docs $args md ./ > "$tmp_file"
+    terraform-docs md $args ./ > "$tmp_file"
   else
     # Can't append extension for mktemp, so renaming instead
     tmp_file_docs=$(mktemp "${TMPDIR:-/tmp}/terraform-docs-XXXXXXXXXX")
@@ -84,7 +84,7 @@ terraform_docs() {
     tmp_file_docs_tf="$tmp_file_docs.tf"
 
     awk -f "$terraform_docs_awk_file" ./*.tf > "$tmp_file_docs_tf"
-    terraform-docs $args md "$tmp_file_docs_tf" > "$tmp_file"
+    terraform-docs md $args "$tmp_file_docs_tf" > "$tmp_file"
     rm -f "$tmp_file_docs_tf"
   fi
 


### PR DESCRIPTION
## Move terraform-docs args after `markdown` command
With the actual behavior of the `terraform_docs.sh` script, we can't pass command options. We can only pass global options like `--with-aggregate-type-defaults`, `--no-sort`, etc. By moving args after `markdown` command, we can pass global and commands options at once.
 
~## terraform-docs without escape hook~
~I don't since which version of terraform-docs, but it try to escape all values with underscore. Everything is  discussed in the following issue https://github.com/segmentio/terraform-docs/issues/111 and PR https://github.com/segmentio/terraform-docs/pull/117.~

So with this PR I add the `--no-escape` option to resolve doc generation issue https://github.com/terraform-aws-modules/terraform-aws-eks/pull/668

~_**I can remove this hook if you think we don't need to defined it here**_~