### PR TITLE
Fixed exit code for terraform 0.11 branch in terraform_docs

### DIFF
--- a/terraform_docs.sh
+++ b/terraform_docs.sh
@@ -26,7 +26,7 @@ main() {
   done
 
   local hack_terraform_docs
-  hack_terraform_docs=$(terraform version | head -1 | grep -c 0.12)
+  hack_terraform_docs=$(terraform version | head -1 | grep -c 0.12) || true
 
   if [[ ! $(command -v terraform-docs) ]]; then
     echo "ERROR: terraform-docs is required by terraform_docs pre-commit hook but is not installed or in the system's PATH."


### PR DESCRIPTION
Without this fix `terraform_docs` hook was always exiting with code 1 when using Terraform 0.11:
```
Terraform docs...........................................................Failed
- hook id: terraform_docs
- duration: 0.55s
- exit code: 1
```