### PR TITLE
fix: Allow passing multiple args to terraform-docs

### DIFF
--- a/terraform_docs.sh
+++ b/terraform_docs.sh
@@ -95,7 +95,8 @@ terraform_docs() {
     fi
 
     if [[ "$terraform_docs_awk_file" == "0" ]]; then
-      terraform-docs md "$args" ./ > "$tmp_file"
+      # shellcheck disable=SC2086
+      terraform-docs md $args ./ > "$tmp_file"
     else
       # Can't append extension for mktemp, so renaming instead
       tmp_file_docs=$(mktemp "${TMPDIR:-/tmp}/terraform-docs-XXXXXXXXXX")
@@ -103,7 +104,8 @@ terraform_docs() {
       tmp_file_docs_tf="$tmp_file_docs.tf"
 
       awk -f "$terraform_docs_awk_file" ./*.tf > "$tmp_file_docs_tf"
-      terraform-docs md "$args" "$tmp_file_docs_tf" > "$tmp_file"
+      # shellcheck disable=SC2086
+      terraform-docs md $args "$tmp_file_docs_tf" > "$tmp_file"
       rm -f "$tmp_file_docs_tf"
     fi
 


### PR DESCRIPTION
The `args` variable was mistakenly double-quoted in one of the recent commits, which made it impossible to pass multiple arguments to `terraform-docs`.
With this change it is possible to configure the hook like this:

```yaml
    hooks:
      - id: terraform_docs
        args:
          - '--args=document --indent 3'
```