### PR TITLE
fix: Change terraform_validate hook functionality for subdirectories with terraform files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -35,7 +35,7 @@
   exclude: \.terraform\/.*$
 
 - id: terraform_validate
-  name: Terraform validate without variables
+  name: Terraform validate
   description: Validates all Terraform configuration files.
   entry: terraform_validate.sh
   language: script

--- a/terraform_validate.sh
+++ b/terraform_validate.sh
@@ -15,13 +15,17 @@ done
 for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
   path_uniq="${path_uniq//__REPLACED__SPACE__/ }"
 
+  current_path="$(pwd)"
+
   if [[ -n "$(find . -maxdepth 1 -name '*.tf' -print -quit)" ]]; then
+    cd "$path_uniq"
     if ! terraform validate $path_uniq; then
       error=1
       echo
       echo "Failed path: $path_uniq"
       echo "================================"
     fi
+    cd "$current_path"
   fi
 done
 

--- a/terraform_validate.sh
+++ b/terraform_validate.sh
@@ -19,7 +19,7 @@ for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
 
   if [[ -n "$(find . -maxdepth 1 -name '*.tf' -print -quit)" ]]; then
     cd "$path_uniq"
-    if ! terraform validate $path_uniq; then
+    if ! terraform validate; then
       error=1
       echo
       echo "Failed path: $path_uniq"

--- a/terraform_validate.sh
+++ b/terraform_validate.sh
@@ -17,11 +17,11 @@ for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
 
   if [[ -n "$(find $path_uniq -maxdepth 1 -name '*.tf' -print -quit)" ]]; then
 
-    current_path=$(realpath "$path_uniq")
+    starting_path=$(realpath "$path_uniq")
     terraform_path="$path_uniq"
 
     # Find the relevant .terraform directory (indicating a 'terraform init'),
-    # but fall through to the current directory..
+    # but fall through to the current directory.
     while [[ "$terraform_path" != "." ]]; do
       if [[ -d "$terraform_path/.terraform" ]]; then
         break
@@ -30,22 +30,18 @@ for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
       fi
     done
 
-    check_path="${uniq_path#"$terraform_path"}"
+    validate_path="${path_uniq#"$terraform_path"}"
 
-    #
     # Change to the directory that has been initialized, run validation, then
     # change back to the starting directory.
-    #
     cd "$(realpath "$terraform_path")"
-
-    if ! terraform validate $check_path; then
+    if ! terraform validate $validate_path; then
       error=1
       echo
       echo "Failed path: $path_uniq"
       echo "================================"
     fi
-
-    cd "$current_path"
+    cd "$starting_path"
   fi
 done
 


### PR DESCRIPTION
This is a fix toward allowing the `terraform_validate` hook to correctly process a repository that has Terraform files in subdirectories per #59 and #87. This is achieved by working down a path to search for a `.terraform` subdirectory that indicates that a `terraform init` has been run in that directory. It then `cd`s to that path, runs `terraform validate` against the new path (taking account the `cd`), and `cd`s back to the original directory.

I ran `pre-commit run --all-files` using my fork locally in the following repos from my org to test:
https://github.com/cisagov/skeleton-tf-module/tree/improvements/upstream_updates
https://github.com/cisagov/cyhy_amis

I also pushed the change to the first repo to ensure our GitHub Actions tasks ran successfully. You can see testing from the Actions log for that repository including success after switching to my fork:
https://github.com/cisagov/skeleton-tf-module/actions