### PR TITLE
Fix to follow HTTP redirection when downloading latest terraform-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ brew install pre-commit gawk terraform-docs tflint tfsec coreutils
 ```bash
 sudo apt install python3-pip gawk &&\
 pip3 install pre-commit
-curl -L "$(curl -s https://api.github.com/repos/segmentio/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64")" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
+curl -L "$(curl -sL https://api.github.com/repos/segmentio/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64")" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
 curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
 env GO111MODULE=on go get -u github.com/liamg/tfsec/cmd/tfsec
 ```


### PR DESCRIPTION
The curl command to download the latest version of `terraform-docs` is failing due to a HTTP/301 redirection.
Adding `-L` will follow the redirection.