### PR TITLE
feat: add terragrunt validate hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -58,6 +58,14 @@
   files: (\.hcl)$
   exclude: \.terraform\/.*$
 
+- id: terragrunt_validate
+  name: Terragrunt validate
+  description: Validates all Terragrunt configuration files.
+  entry: terragrunt_validate.sh
+  language: script
+  files: (\.hcl)$
+  exclude: \.terraform\/.*$
+
 - id: terraform_tfsec
   name: Terraform validate with tfsec
   description: Static analysis of Terraform templates to spot potential security issues.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ There are several [pre-commit](https://pre-commit.com/) hooks to keep Terraform 
 | `terraform_docs_replace`                         | Runs `terraform-docs` and pipes the output directly to README.md                                                           |
 | `terraform_tflint`                               | Validates all Terraform configuration files with [TFLint](https://github.com/terraform-linters/tflint).                              |
 | `terragrunt_fmt`                                 | Rewrites all [Terragrunt](https://github.com/gruntwork-io/terragrunt) configuration files (`*.hcl`) to a canonical format. |
+| `terragrunt_validate`                            | Validates all [Terragrunt](https://github.com/gruntwork-io/terragrunt) configuration files (`*.hcl`)                       |
 | `terraform_tfsec`                                | [TFSec](https://github.com/liamg/tfsec) static analysis of terraform templates to spot potential security issues.     |
 
 Check the [source file](https://github.com/antonbabenko/pre-commit-terraform/blob/master/.pre-commit-hooks.yaml) to know arguments used for each hook.

--- a/terragrunt_validate.sh
+++ b/terragrunt_validate.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+
+declare -a paths
+
+index=0
+
+for file_with_path in "$@"; do
+  file_with_path="${file_with_path// /__REPLACED__SPACE__}"
+
+  paths[index]=$(dirname "$file_with_path")
+
+  let "index+=1"
+done
+
+for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
+  path_uniq="${path_uniq//__REPLACED__SPACE__/ }"
+
+  pushd "$path_uniq" > /dev/null
+  terragrunt validate
+  popd > /dev/null
+done


### PR DESCRIPTION
Simple hook to execute terragrunt validate

Suggest having the `disable_init` in the [remote_state block](https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#remote_state) to avoid having to init backend for terragrunt validate.

```hcl
remote_state {
  backend      = "gcs"
  disable_init = tobool(get_env("TERRAGRUNT_DISABLE_INIT", "false"))

  config = {
    bucket = "terraform-states"
    prefix = "terragrunt/${path_relative_to_include()}"
  }
}
```
