### PR TITLE
fix: Correctly handle arrays in terraform_docs.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: git://github.com/pre-commit/pre-commit-hooks
-  rev: v2.5.0
+  rev: v3.2.0
   hooks:
     - id: check-yaml
     - id: end-of-file-fixer
@@ -9,7 +9,7 @@ repos:
     - id: check-merge-conflict
     - id: check-executables-have-shebangs
 - repo: git://github.com/jumanjihouse/pre-commit-hooks
-  rev: 2.0.0
+  rev: 2.1.4
   hooks:
     - id: shfmt
       args: ['-l', '-i', '2', '-ci', '-sr', '-w']


### PR DESCRIPTION
@antonbabenko A serious regression has been introduced in v1.34.0 in the process of factoring out `getopt`. Starting with that version, `terraform_docs` pre-commit hook would only process one terraform module, ignoring any other modules that are part of the commit.

This PR attempts to fix the regression. I have tested it on Ubuntu Focal (GNU bash, version 5.0.17), but I would appreciate if anyone could also test it on Bash 4.x and on MacOS.

Please note that `args` are still passed around in the script as a single argument (just as it was), and I have also successfully verified the correct operation with multiple `--args=` in the pre-commit YAML configuration (fixed earlier in #98).

Side note: other hooks may also be affected in a similar way, but I haven't tested them because we are not using them.