### PR TITLE
fix: Fix regex considering terraform-docs v0.10.0 old

### DIFF
--- a/terraform_docs.sh
+++ b/terraform_docs.sh
@@ -60,7 +60,7 @@ terraform_docs_() {
   fi
 
   local is_old_terraform_docs
-  is_old_terraform_docs=$(terraform-docs version | grep -o "v0.[1-7]" | tail -1) || true
+  is_old_terraform_docs=$(terraform-docs version | grep -o "v0.[1-7]\." | tail -1) || true
 
   if [[ -z "$is_old_terraform_docs" ]]; then # Using terraform-docs 0.8+ (preferred)
 


### PR DESCRIPTION
Got this error using `v1.42.0` on terraform_docs hook:

```sh
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x13fdbe6]
```

Looks like the new `v0.10.0` terraform-docs is going the awk script route instead of "Using terraform-docs 0.8+ (preferred)" route because the regex matches when it shouldn't.