### PR TITLE
Fix Terraform Validate failing because AWS_DEFAULT_REGION isn't set

### DIFF
--- a/terraform_validate.sh
+++ b/terraform_validate.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
+export AWS_DEFAULT_REGION=us-east-1
+
 main() {
   initialize_
   parse_cmdline_ "$@"


### PR DESCRIPTION
`terraform validate` will fail to run if `AWS_DEFAULT_REGION` isn't set, as of 0.13.

Setting it to `us-east-1` shouldn't matter, as Terraform does no provider checks anyway.