### PR TITLE
fix: Correct deprecated parameter to terraform-docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: git://github.com/pre-commit/pre-commit-hooks
-  rev: v3.2.0
+  rev: v3.3.0
   hooks:
     - id: check-yaml
     - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ if they are present in `README.md`.
     ```yaml
     hooks:
       - id: terraform_docs_replace
-        args: ['--with-aggregate-type-defaults', '--sort-by-required', '--dest=TEST.md']
+        args: ['--sort-by-required', '--dest=TEST.md']
     ```
 
 1. It is possible to pass additional arguments to shell scripts when using `terraform_docs` and `terraform_docs_without_aggregate_type_defaults`. Send pull-request with the new hook if there is something missing.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ There are several [pre-commit](https://pre-commit.com/) hooks to keep Terraform 
 | `terraform_validate`                             | Validates all Terraform configuration files.                                                                               |
 | `terraform_docs`                                 | Inserts input and output documentation into `README.md`. Recommended.                                                      |
 | `terraform_docs_without_aggregate_type_defaults` | Inserts input and output documentation into `README.md` without aggregate type defaults.                                   |
-| `terraform_docs_replace`                         | Runs `terraform-docs` and pipes the output directly to README.md                                                           |
+| `terraform_docs_replace`                         | Runs `terraform-docs` and pipes the output directly to README.md (requires terraform-docs v0.10.0 or later)                                                           |
 | `terraform_tflint`                               | Validates all Terraform configuration files with [TFLint](https://github.com/terraform-linters/tflint).                              |
 | `terragrunt_fmt`                                 | Rewrites all [Terragrunt](https://github.com/gruntwork-io/terragrunt) configuration files (`*.hcl`) to a canonical format. |
 | `terragrunt_validate`                            | Validates all [Terragrunt](https://github.com/gruntwork-io/terragrunt) configuration files (`*.hcl`)                       |
@@ -91,13 +91,13 @@ Check the [source file](https://github.com/antonbabenko/pre-commit-terraform/blo
 ```
 if they are present in `README.md`.
 
-1. `terraform_docs_replace` replaces the entire README.md rather than doing string replacement between markers. Put your additional documentation at the top of your `main.tf` for it to be pulled in. The optional `--dest` argument lets you change the name of the file that gets created/modified.
+1. `terraform_docs_replace` replaces the entire README.md rather than doing string replacement between markers. Put your additional documentation at the top of your `main.tf` for it to be pulled in. The optional `--dest` argument lets you change the name of the file that gets created/modified. This hook requires terraform-docs v0.10.0 or later.
 
     1. Example:
     ```yaml
     hooks:
       - id: terraform_docs_replace
-        args: ['--with-aggregate-type-defaults', '--sort-inputs-by-required', '--dest=TEST.md']
+        args: ['--with-aggregate-type-defaults', '--sort-by-required', '--dest=TEST.md']
     ```
 
 1. It is possible to pass additional arguments to shell scripts when using `terraform_docs` and `terraform_docs_without_aggregate_type_defaults`. Send pull-request with the new hook if there is something missing.

--- a/pre_commit_hooks/terraform_docs_replace.py
+++ b/pre_commit_hooks/terraform_docs_replace.py
@@ -15,6 +15,10 @@ def main(argv=None):
     )
     parser.add_argument(
         '--sort-inputs-by-required', dest='sort', action='store_true',
+        help='[deprecated] use --sort-by-required instead',
+    )
+    parser.add_argument(
+        '--sort-by-required', dest='sort', action='store_true',
     )
     parser.add_argument(
         '--with-aggregate-type-defaults', dest='aggregate', action='store_true',
@@ -35,7 +39,7 @@ def main(argv=None):
             procArgs = []
             procArgs.append('terraform-docs')
             if args.sort:
-                procArgs.append('--sort-inputs-by-required')
+                procArgs.append('--sort-by-required')
             if args.aggregate:
                 procArgs.append('--with-aggregate-type-defaults')
             procArgs.append('md')

--- a/pre_commit_hooks/terraform_docs_replace.py
+++ b/pre_commit_hooks/terraform_docs_replace.py
@@ -22,6 +22,7 @@ def main(argv=None):
     )
     parser.add_argument(
         '--with-aggregate-type-defaults', dest='aggregate', action='store_true',
+        help='[deprecated]',
     )
     parser.add_argument('filenames', nargs='*', help='Filenames to check.')
     args = parser.parse_args(argv)
@@ -40,8 +41,6 @@ def main(argv=None):
             procArgs.append('terraform-docs')
             if args.sort:
                 procArgs.append('--sort-by-required')
-            if args.aggregate:
-                procArgs.append('--with-aggregate-type-defaults')
             procArgs.append('md')
             procArgs.append("./{dir}".format(dir=dir))
             procArgs.append("| sed -e '$ d' -e 'N;/^\\n$/D;P;D'")


### PR DESCRIPTION
The --sort-inputs-by-required was removed here: https://github.com/terraform-docs/terraform-docs/commit/b6a6ad1bbf77e99fa920dee784b9936170b35477#diff-2fb3c316208521762f7701f5a16834dc239636c3b6c8ec403d02688e5f7da53eL23 after being marked for deprecation in favor of the --sort-by-required flag instead. and noted for deprecation here: https://github.com/terraform-docs/terraform-docs/releases/tag/v0.8.0

This PR switches to the new supported flag which has been available for 6 months now. 

Caveat: Existing terraform-docs users using 0.9.1 or older will need to upgrade. If relevant messaging is necessary, that can be added. 