### PR TITLE
fix: remove sed postprocessing from the terraform_docs_replace hook to fix compatibility with terraform-docs 0.11.0+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
+- fix: Removes sed post-processing from the `terraform_docs_replace` hook which was causing the last line to be missing when using `terraform-docs` 0.11.0+. Note: for older versions this change will result in an extra newline at the end of the file (making the pre-commit hook and `terraform-docs` output identical).
 
 
 <a name="v1.46.0"></a>
@@ -123,7 +124,7 @@ All notable changes to this project will be documented in this file.
 
 - fix: Change terraform_validate hook functionality for subdirectories with terraform files ([#100](https://github.com/antonbabenko/pre-commit-terraform/issues/100))
 
-### 
+###
 
 configuration for the appropriate working directory.
 

--- a/pre_commit_hooks/terraform_docs_replace.py
+++ b/pre_commit_hooks/terraform_docs_replace.py
@@ -29,7 +29,7 @@ def main(argv=None):
 
     dirs = []
     for filename in args.filenames:
-        if (os.path.realpath(filename) not in dirs and \
+        if (os.path.realpath(filename) not in dirs and
                 (filename.endswith(".tf") or filename.endswith(".tfvars"))):
             dirs.append(os.path.dirname(filename))
 
@@ -43,9 +43,8 @@ def main(argv=None):
                 procArgs.append('--sort-by-required')
             procArgs.append('md')
             procArgs.append("./{dir}".format(dir=dir))
-            procArgs.append("| sed -e '$ d' -e 'N;/^\\n$/D;P;D'")
             procArgs.append('>')
-            procArgs.append("./{dir}/{dest}".format(dir=dir,dest=args.dest))
+            procArgs.append("./{dir}/{dest}".format(dir=dir, dest=args.dest))
             subprocess.check_call(" ".join(procArgs), shell=True)
         except subprocess.CalledProcessError as e:
             print(e)


### PR DESCRIPTION
Since updating to terraform-docs 0.11.0+ (also affects 0.11.1 and 0.11.2) all my README.md's are now missing the last line!

After a little bit of digging I've noticed that, since version 0.11.0, `terraform-docs` no longer adds an extra empty newline at the end. This PR amends the sed pattern to produce the same output in <0.11.0 as in 0.11.0+:

0.10.0:
```
$ terraform-docs --sort-by-required md ./ | gsed -e '$ d' -e 'N;/^\n$/D;P;D' | tail -n 3
|------|-------------|
| ids | List of IDs of the created instances |
| private\_ips | The private IP addresses assigned to the instances |

$ terraform-docs --sort-by-required md ./ | gsed -e '${/^$/d;}' -e 'N;/^\n$/D;P;D' | tail -n 3
|------|-------------|
| ids | List of IDs of the created instances |
| private\_ips | The private IP addresses assigned to the instances |
```

0.11.0:
```
$ terraform-docs --sort-by-required md ./ | gsed -e '$ d' -e 'N;/^\n$/D;P;D' | tail -n 3
| Name | Description |
|------|-------------|
| ids | List of IDs of the created instances |

$ terraform-docs --sort-by-required md ./ | gsed -e '${/^$/d;}' -e 'N;/^\n$/D;P;D' | tail -n 3
|------|-------------|
| ids | List of IDs of the created instances |
| private\_ips | The private IP addresses assigned to the instances |
```
