### PR TITLE
docs: Added checkov install

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ##### MacOS
 
 ```bash
-brew install pre-commit gawk terraform-docs tflint tfsec coreutils
+brew install pre-commit gawk terraform-docs tflint tfsec coreutils checkov
 ```
 
 ##### Ubuntu

--- a/README.md
+++ b/README.md
@@ -19,14 +19,18 @@
 brew install pre-commit gawk terraform-docs tflint tfsec coreutils checkov
 ```
 
-##### Ubuntu
+##### Ubuntu 18.04
 
 ```bash
-sudo apt install python3-pip gawk unzip &&\
+sudo apt update
+sudo apt install -y gawk unzip software-properties-common
+sudo add-apt-repository ppa:deadsnakes/ppa
+sudo apt install -y python3.7 python3-pip
 pip3 install pre-commit
 curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64.tar.gz")" > terraform-docs.tgz && tar xzf terraform-docs.tgz && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
 curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
 env GO111MODULE=on go get -u github.com/tfsec/tfsec/cmd/tfsec
+python3.7 -m pip install -U checkovpython3.7 -m pip install -U checkov
 ```
 
 ### 2. Install the pre-commit hook globally


### PR DESCRIPTION
- Adds `checkov` to the install section as it was missing. 
- Are you generally interested in having a `Dockerfile` in the repo with the install instruction, so we can verify them in the future?