### PR TITLE
fix: terragrunt validate for module folders (#191)

### DIFF
--- a/terragrunt_validate.sh
+++ b/terragrunt_validate.sh
@@ -17,7 +17,9 @@ done
 for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
   path_uniq="${path_uniq//__REPLACED__SPACE__/ }"
 
-  pushd "$path_uniq" > /dev/null
-  terragrunt validate
-  popd > /dev/null
+  if [[ -f "$path_uniq/terragrunt.hcl" ]]; then
+    pushd "$path_uniq" > /dev/null
+    terragrunt validate
+    popd > /dev/null
+  fi
 done


### PR DESCRIPTION
Only include folders with a `terragrunt.hcl` file (default for `terragrunt validate`) in the terragrunt_validate pre-commit hook

Fixes #191 