### PR TITLE
fix: Fix and pin versions in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM ubuntu:18.04
 
 ARG PRE_COMMIT_VERSION="2.11.1"
 ARG TERRAFORM_VERSION="0.15.0"
-ARG TFSEC_VERSION="latest" 
-ARG TERRAFORM_DOCS_VERSION="latest"
-ARG TFLINT_VERSION="latest"
+ARG TFSEC_VERSION="v0.39.21" 
+ARG TERRAFORM_DOCS_VERSION="v0.12.0"
+ARG TFLINT_VERSION="v0.27.0"
 ARG CHECKOV_VERSION="1.0.838"
 
 # Install general dependencies
@@ -15,9 +15,9 @@ RUN apt update && \
 RUN add-apt-repository ppa:deadsnakes/ppa && \
     apt install -y python3.7 python3-pip && \
     pip3 install pre-commit==${PRE_COMMIT_VERSION} && \
-    curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/${TERRAFORM_DOCS_VERSION} | grep -o -E "https://.+?-linux-amd64.tar.gz")" > terraform-docs.tgz && tar xzf terraform-docs.tgz && chmod +x terraform-docs && mv terraform-docs /usr/bin/ && \
-    curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/${TFLINT_VERSION} | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && mv tflint /usr/bin/ && \
-    curl -L "$(curl -s https://api.github.com/repos/tfsec/tfsec/releases/${TFSEC_VERSION} | grep -o -E "https://.+?tfsec-linux-amd64")" > tfsec && chmod +x tfsec && mv tfsec /usr/bin/ && \
+    curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases | grep -o -E "https://.+?${TERRAFORM_DOCS_VERSION}-linux-amd64.tar.gz")" > terraform-docs.tgz && tar xzf terraform-docs.tgz && chmod +x terraform-docs && mv terraform-docs /usr/bin/ && \
+    curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases | grep -o -E "https://.+?/${TFLINT_VERSION}/tflint_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && mv tflint /usr/bin/ && \
+    curl -L "$(curl -s https://api.github.com/repos/tfsec/tfsec/releases | grep -o -E "https://.+?/${TFSEC_VERSION}/tfsec-linux-amd64")" > tfsec && chmod +x tfsec && mv tfsec /usr/bin/ && \
     python3.7 -m pip install -U checkov==${CHECKOV_VERSION}
 
 # Install terraform because pre-commit needs it

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,15 @@
 FROM ubuntu:18.04
 
 ARG PRE_COMMIT_VERSION="2.11.1"
-ARG GOLANG_VERSION="1.16"
-ARG TERRAFORM_VERSION="0.14.8"
-ARG TFSEC_VERSION="v0.39.6"
+ARG TERRAFORM_VERSION="0.15.0"
+ARG TFSEC_VERSION="latest" 
 ARG TERRAFORM_DOCS_VERSION="latest"
 ARG TFLINT_VERSION="latest"
-ARG TFSEC_VERSION="v0.39.6"
 ARG CHECKOV_VERSION="1.0.838"
 
 # Install general dependencies
 RUN apt update && \
     apt install -y curl git gawk unzip software-properties-common
-
-# Install golang
-RUN curl -L https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz > go${GOLANG_VERSION}.linux-amd64.tar.gz && \
-    tar xzf go${GOLANG_VERSION}.linux-amd64.tar.gz && \
-    rm -f go${GOLANG_VERSION}.linux-amd64.tar.gz
-ENV GOPATH /go
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
 # Install tools
 RUN add-apt-repository ppa:deadsnakes/ppa && \
@@ -27,8 +17,8 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
     pip3 install pre-commit==${PRE_COMMIT_VERSION} && \
     curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/${TERRAFORM_DOCS_VERSION} | grep -o -E "https://.+?-linux-amd64.tar.gz")" > terraform-docs.tgz && tar xzf terraform-docs.tgz && chmod +x terraform-docs && mv terraform-docs /usr/bin/ && \
     curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/${TFLINT_VERSION} | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && mv tflint /usr/bin/ && \
+    curl -L "$(curl -s https://api.github.com/repos/tfsec/tfsec/releases/${TFSEC_VERSION} | grep -o -E "https://.+?tfsec-linux-amd64")" > tfsec && chmod +x tfsec && mv tfsec /usr/bin/ && \
     python3.7 -m pip install -U checkov==${CHECKOV_VERSION}
-RUN env GO111MODULE=on go get -u github.com/tfsec/tfsec/cmd/tfsec@${TFSEC_VERSION}
 
 # Install terraform because pre-commit needs it
 RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
@@ -36,7 +26,6 @@ RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
     apt-get update && apt-get install terraform=${TERRAFORM_VERSION}
 
 # Checking all binaries are in the PATH
-RUN go version
 RUN terraform --help
 RUN pre-commit --help
 RUN terraform-docs --help

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ sudo apt install -y python3.7 python3-pip
 pip3 install pre-commit
 curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64.tar.gz")" > terraform-docs.tgz && tar xzf terraform-docs.tgz && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
 curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
-env GO111MODULE=on go get -u github.com/tfsec/tfsec/cmd/tfsec
+curl -L "$(curl -s https://api.github.com/repos/tfsec/tfsec/releases/latest | grep -o -E "https://.+?tfsec-linux-amd64")" > tfsec && chmod +x tfsec && mv tfsec /usr/bin/
 python3.7 -m pip install -U checkov
 ```
 


### PR DESCRIPTION
- use curl to obtain `tfsec` and use `latest` version as well and hence remove go as I got an error at
```sh
env GO111MODULE=on go get -u github.com/tfsec/tfsec/cmd/tfsec@${TFSEC_VERSION}
```
- use latest terraform version `0.15.0` by default
- reduce the docker image size by ~50%