### PR TITLE
fix: GH stale action -  remove unsupported setting

### DIFF
--- a/.github/workflows/stale-actions.yaml
+++ b/.github/workflows/stale-actions.yaml
@@ -12,8 +12,8 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         # Staling issues and PR's
         days-before-stale: 30
-        stale-issue-label: lifecycle/stale
-        stale-pr-label: lifecycle/stale
+        stale-issue-label: stale
+        stale-pr-label: stale
         stale-issue-message: |
           This issue has been automatically marked as stale because it has been open 30 days
           with no activity. Remove stale label or comment or this issue will be closed in 10 days
@@ -21,12 +21,11 @@ jobs:
           This PR has been automatically marked as stale because it has been open 30 days
           with no activity. Remove stale label or comment or this PR will be closed in 10 days
         # Not stale if have this labels
-        exempt-issue-labels: kind/bug,lifecycle/active,lifecycle/frozen
-        exempt-pr-labels:    kind/bug,lifecycle/active,lifecycle/frozen
+        exempt-issue-labels: bug,wip,on-hold
+        exempt-pr-labels:    bug,wip,on-hold
         # Close issue operations
         # Label will be automatically removed if the issues are no longer closed nor locked.
         days-before-close: 10
-        close-issue-label: lifecycle/rotten
         delete-branch: true
         close-issue-message: This issue was automatically closed because of stale in 10 days
         close-pr-message: This PR was automatically closed because of stale in 10 days

--- a/.github/workflows/stale-actions.yaml
+++ b/.github/workflows/stale-actions.yaml
@@ -23,8 +23,6 @@ jobs:
         # Not stale if have this labels
         exempt-issue-labels: kind/bug,lifecycle/active,lifecycle/frozen
         exempt-pr-labels:    kind/bug,lifecycle/active,lifecycle/frozen
-        # If unstale
-        labels-to-remove-when-unstale: lifecycle/stale
         # Close issue operations
         # Label will be automatically removed if the issues are no longer closed nor locked.
         days-before-close: 10


### PR DESCRIPTION

<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123":
-->

<!-- Fixes # -->

Fix Warning founded afrer [GH action run](https://github.com/antonbabenko/pre-commit-terraform/runs/3577117856?check_suite_focus=true) by removing unsupported parameter.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Check next run after change merge.

Also, this action have dry-run options as it described in action readme, but for this little fix it will be overkill.

### workaround

It just warning, so workaraund is do nothing