### PR TITLE
fix: trigger terraform-docs on changes in lock files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -12,7 +12,7 @@
   require_serial: true
   entry: terraform_docs.sh
   language: script
-  files: (\.tf)$
+  files: (\.tf|\.terraform\.lock\.hcl)$
   exclude: \.terraform\/.*$
 
 - id: terraform_docs_without_aggregate_type_defaults


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [x] This PR enhances existing functionality.

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123":
-->

The recent versions of `terraform-docs` extract provider version from terraform lock files. Starting from version 0.15.0, this behaviour can also be controlled by `--lockfile` command line flag. Since the new behaviour is active by default, add lock files to the pattern that triggers pre-commit hook, so that README files are updated on any changes in lock files.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Tested locally by overriding file pattern in `.pre-commit-config.yaml` inside the client project.