### PR TITLE
fix: terrafrom_tflint ERROR output for files located in repo root

### DIFF
--- a/terraform_tflint.sh
+++ b/terraform_tflint.sh
@@ -61,19 +61,12 @@ tflint_() {
 
   for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
     path_uniq="${path_uniq//__REPLACED__SPACE__/ }"
-
     pushd "$path_uniq" > /dev/null
-    TFLINT_MSG=$(
-      tflint "${ARGS[@]}" 2>&1 ||
-        echo >&2 -e "\033[1;31m\nERROR in ./$path_uniq/:\033[0m" &&
-        tflint "${ARGS[@]}" # Print TFLint error with PATH
-    )
 
-    # Print checked PATH if TFLint have any messages
-    if [ ! -z "$TFLINT_MSG" ]; then
-      echo -e "\n./$path_uniq/:"
-      echo "$TFLINT_MSG"
-    fi
+    # Print checked PATH **only** if TFLint have any messages
+    # shellcheck disable=SC2091 # Suppress error output
+    $(tflint "${ARGS[@]}" 2>&1) ||
+      echo >&2 -e "\033[1;31m\nERROR in $path_uniq/:\033[0m" && tflint "${ARGS[@]}"
 
     popd > /dev/null
   done


### PR DESCRIPTION
If use constructions like:

```bash
HAVE_ERR="$(tflint "${ARGS[@]}" 2>&1)"
if [ ! -z "$HAVE_ERR" ]; then
  echo >&2 -e "\033[1;31m\nERROR in $path_uniq/:\033[0m"
  tflint "${ARGS[@]}"
fi
```

some errors will not be printed.

So this one-liner fits our requirements in the best way.

Fixes #240

<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.


