### PR TITLE
feat: Add support for specify terraform-docs config file

### DIFF
--- a/terraform_docs.sh
+++ b/terraform_docs.sh
@@ -4,6 +4,8 @@ set -eo pipefail
 main() {
   initialize_
   parse_cmdline_ "$@"
+  # Support for setting relative PATH to .terraform-docs.yml config.
+  ARGS=${ARGS/--config=/--config=$(pwd)\/}
   terraform_docs_ "${ARGS[*]}" "${FILES[@]}"
 }
 


### PR DESCRIPTION
Before it was able only via absolute PATH, which is unusable

<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [x] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

Fixes #225 
