### PR TITLE
fix: execute tflint once in no errors

### DIFF
--- a/terraform_tflint.sh
+++ b/terraform_tflint.sh
@@ -65,8 +65,10 @@ tflint_() {
 
     # Print checked PATH **only** if TFLint have any messages
     # shellcheck disable=SC2091 # Suppress error output
-    $(tflint "${ARGS[@]}" 2>&1) ||
-      echo >&2 -e "\033[1;31m\nERROR in $path_uniq/:\033[0m" && tflint "${ARGS[@]}"
+    $(tflint "${ARGS[@]}" 2>&1) || {
+      echo >&2 -e "\033[1;31m\nERROR in $path_uniq/:\033[0m"
+      tflint "${ARGS[@]}"
+    }
 
     popd > /dev/null
   done


### PR DESCRIPTION
The expression `cmd1 || cmd2 && cm3` will run the `cmd3` command
unconditionally (in either case when `cmd1` failed or resulted in
success) hence the `cmd2 && cmd3` should be written as
`{ cmd2 && cmd3; }` (or `{ cmd2; cmd3; }`) so that these commands get
executed only when `cmd1` fails.

Co-authored-by: George L. Yermulnik <yz@yz.kiev.ua>
