### PR TITLE
fix: Fixed args expand in terraform_docs

### DIFF
--- a/terraform_docs.sh
+++ b/terraform_docs.sh
@@ -6,7 +6,7 @@ main() {
   parse_cmdline_ "$@"
   # Support for setting relative PATH to .terraform-docs.yml config.
   ARGS=${ARGS[*]/--config=/--config=$(pwd)\/}
-  terraform_docs_ "${HOOK_CONFIG[*]}" "$ARGS" "${FILES[@]}"
+  terraform_docs_ "${HOOK_CONFIG[*]}" "$ARGS" "${FILES[*]}"
 }
 
 initialize_() {


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123":
-->

 Fixes #225

### How has this code been tested

```bash
mkdir -p /tmp/fix-GH-225/precommit
cd /tmp/fix-GH-225/
git init

touch vars.tf
echo "formatter: markdown" > precommit/.terraform-docs.yml
echo "
repos:
  - repo: https://github.com/antonbabenko/pre-commit-terraform
    rev: b37b70b266e2acbd0ac9521d0b2ba7b5efa0d10f
    hooks:
      - id: terraform_docs
        args:
          - --args=--sort-by required
          - --args=--config=precommit/.terraform-docs.yml
" > precommit/.pre-commit-config.yaml

git add -A
pre-commit run -c precommit/.pre-commit-config.yaml -a -v
```