### PR TITLE
feat: Add support for relative path for tflint

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,12 +323,12 @@ Example:
         - --args=--enable-rule=terraform_documented_variables
     ```
 
-2. When you have multiple directories and want to run `tflint` in all of them and share a single config file, it is impractical to hard-code the path to `.tflint.hcl` file. The solution is to use the `__GIT_WORKING_DIR__` placeholder which will be replaced by `terraform_tflint` hooks with Git working directory (repo root) at run time. For example:
+2. When you have multiple directories and want to run `tflint` in all of them and share a single config file, it is impractical to hard-code the path to `.tflint.hcl` file. The solution is to use relative path to file which will be replaced by `terraform_tflint` hooks with Git working directory (repo root) at run time. For example:
 
     ```yaml
     - id: terraform_tflint
       args:
-        - --args=--config=__GIT_WORKING_DIR__/.tflint.hcl
+        - --args=--config=.tflint.hcl
     ```
 
 


### PR DESCRIPTION

<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [x] This PR adds new functionality.
- [x] This PR enhances existing functionality.

### Description of your changes

tflint: Add relative path support.

Add common functions that will be moved to separately file in the future.
For DRY reason

Relates: #252, #255, #259, #262

### How has this code been tested

Run `pre-commit run -a` for each configuration. Results should be the same.

```yaml
repos:
- repo: git://github.com/antonbabenko/pre-commit-terraform
  rev: 0f7aa9e92024ed3656954306c327ea563ce0e868
  hooks:
  - id: terraform_tflint
    args:
      - '--args=--config=.tflint.hcl'
```
```yaml
repos:
- repo: git://github.com/antonbabenko/pre-commit-terraform
  rev: 0f7aa9e92024ed3656954306c327ea563ce0e868
  hooks:
  - id: terraform_tflint
    args:
      - '--args=--config=__GIT_WORKING_DIR__/.tflint.hcl'
```