### PR TITLE
fix: Fixed 1.54.0 where `terraform_docs` was broken

### DIFF
--- a/terraform_docs.sh
+++ b/terraform_docs.sh
@@ -6,7 +6,7 @@ main() {
   parse_cmdline_ "$@"
   # Support for setting relative PATH to .terraform-docs.yml config.
   ARGS=${ARGS[*]/--config=/--config=$(pwd)\/}
-  terraform_docs_ "${HOOK_CONFIG[*]}" "$ARGS" "${FILES[*]}"
+  terraform_docs_ "${HOOK_CONFIG[*]}" "$ARGS" "${FILES[@]}"
 }
 
 initialize_() {


### PR DESCRIPTION


Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

Bug introduced in #260 (https://github.com/antonbabenko/pre-commit-terraform/pull/260#discussion_r735942054)
Fixes #271

@yermulnik 
## How has this code been tested

Run `pre-commit run -a` in https://github.com/terraform-aws-modules/terraform-aws-s3-bucket

with this config:

```yaml
  - repo: git://github.com/antonbabenko/pre-commit-terraform
    rev: d7bd36dc2327132e7ed1d74f0b972411f7f043c5
    hooks:
      # - id: terraform_fmt
      # - id: terraform_validate
      - id: terraform_docs
```