### PR TITLE
chore: Updated messages shown in terraform_tflint hook

### DIFF
--- a/terraform_tflint.sh
+++ b/terraform_tflint.sh
@@ -66,7 +66,7 @@ tflint_() {
     # Print checked PATH **only** if TFLint have any messages
     # shellcheck disable=SC2091 # Suppress error output
     $(tflint "${ARGS[@]}" 2>&1) 2> /dev/null || {
-      echo >&2 -e "\033[1;31m\nERROR in $path_uniq/:\033[0m"
+      echo >&2 -e "\033[1;33m\nTFLint in $path_uniq/:\033[0m"
       tflint "${ARGS[@]}"
     }
 


### PR DESCRIPTION
Those messages do not relate to code errors but can have deprecation
notice about the TFLint configuration.

We don't want to just skip them. But it also doesn't error messages.
So let's show it as a warning.

See details in 
https://github.com/antonbabenko/pre-commit-terraform/issues/273
