### PR TITLE
feat: Updated Docker image from Ubuntu to Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -162,10 +162,10 @@ COPY --from=builder /usr/local/lib/python3.9/site-packages/ /usr/local/lib/pytho
 COPY --from=builder /root/ /root/
 
 # Install hooks extra deps
-RUN if [ "$(grep -o 'terraform-docs SKIPPED' /usr/bin/tools_versions_info)" = "" ]; then \
+RUN if [ "$(grep -o '^terraform-docs SKIPPED$' /usr/bin/tools_versions_info)" = "" ]; then \
         apk add --no-cache perl \
     ; fi && \
-    if [ "$(grep -o 'infracost SKIPPED' /usr/bin/tools_versions_info)" = "" ]; then \
+    if [ "$(grep -o '^infracost SKIPPED$' /usr/bin/tools_versions_info)" = "" ]; then \
         apk add --no-cache jq \
     ; fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -162,10 +162,10 @@ COPY --from=builder /usr/local/lib/python3.9/site-packages/ /usr/local/lib/pytho
 COPY --from=builder /root/ /root/
 
 # Install hooks extra deps
-RUN if [ "$(grep terraform-docs /usr/bin/tools_versions_info | grep -o SKIPPED)" = "" ]; then \
+RUN if [ "$(grep -o 'terraform-docs SKIPPED' /usr/bin/tools_versions_info)" = "" ]; then \
         apk add --no-cache perl \
     ; fi && \
-    if [ "$(grep infracost /usr/bin/tools_versions_info | grep -o SKIPPED || echo)" = "" ]; then \
+    if [ "$(grep -o 'infracost SKIPPED' /usr/bin/tools_versions_info)" = "" ]; then \
         apk add --no-cache jq \
     ; fi
 


### PR DESCRIPTION
Decreased image size and build time:

| All hooks  | Ubuntu | Alpine | Decreased by |
| ---------- | ------ | ------ | ------------ |
| Build time | 2m 50s | 1m 47s | 63s, 37%     |
| Image size | 625MB  | 568MB  | 67MB, 10%    |

| Without hooks | Ubuntu | Alpine | Decreased by |
| ------------- | ------ | ------ | ------------ |
| Build time    | 1m 45s | 0m 41s | 64s, 61%     |
| Image size    | 259MB  | 164MB  | 85MB, 37%    |

Co-authored-by: Balazs Hamorszky <balihb@gmail.com>

<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [x] This PR enhances existing functionality.

### Description of your changes

Something was updated in the Docker image based on Debian/Ubuntu and now it does not meet deps.
The quick fix was not found, so I decided to migrate the image to alpine, hopefully, @balihb found all needed deps earlier. 


Fixes #277
Closes #239 as outdated duplicate 

### How has this code been tested

```bash
git clone git@github.com:antonbabenko/pre-commit-terraform.git
cd pre-commit-terraform
git checkout docker_to_alpine
# Install the latest versions of all the tools
docker build -t pre-commit --build-arg INSTALL_ALL=true .
```
