### PR TITLE
fix: typo in arg name for terraform-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ Unlike most other hooks, this hook triggers once if there are any changed files 
     - id: terraform_docs
       args:
         - --hook-config=--path-to-file=README.md        # Valid UNIX path. I.e. ../TFDOC.md or docs/README.md etc.
-        - --hook-config=--add-to-exiting-file=true      # Boolean. true or false
+        - --hook-config=--add-to-existing-file=true     # Boolean. true or false
         - --hook-config=--create-file-if-not-exist=true # Boolean. true or false
     ```
 

--- a/terraform_docs.sh
+++ b/terraform_docs.sh
@@ -132,7 +132,7 @@ terraform_docs() {
       --path-to-file)
         text_file=$value
         ;;
-      --add-to-existing-file)
+      --add-to-existing-file|--add-to-exiting-file) # Typo left for compatibility. Will removed in 2.0.0.
         add_to_existing=$value
         ;;
       --create-file-if-not-exist)

--- a/terraform_docs.sh
+++ b/terraform_docs.sh
@@ -119,7 +119,7 @@ terraform_docs() {
   # Get hook settings
   #
   local text_file="README.md"
-  local add_to_exiting=false
+  local add_to_existing=false
   local create_if_not_exist=false
 
   configs=($hook_config)
@@ -132,8 +132,8 @@ terraform_docs() {
       --path-to-file)
         text_file=$value
         ;;
-      --add-to-exiting-file)
-        add_to_exiting=$value
+      --add-to-existing-file)
+        add_to_existing=$value
         ;;
       --create-file-if-not-exist)
         create_if_not_exist=$value
@@ -171,10 +171,10 @@ terraform_docs() {
     [[ ! -f "$text_file" ]] && popd > /dev/null && continue
 
     #
-    # If `--add-to-exiting-file=true` set, check is in file exist "hook markers",
+    # If `--add-to-existing-file=true` set, check is in file exist "hook markers",
     # and if not - append "hook markers" to the end of file.
     #
-    if $add_to_exiting; then
+    if $add_to_existing; then
       HAVE_MARKER=$(grep -o '<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->' "$text_file" || exit 0)
 
       if [ ! "$HAVE_MARKER" ]; then

--- a/terraform_docs.sh
+++ b/terraform_docs.sh
@@ -132,7 +132,7 @@ terraform_docs() {
       --path-to-file)
         text_file=$value
         ;;
-      --add-to-existing-file|--add-to-exiting-file) # Typo left for compatibility. Will removed in 2.0.0.
+      --add-to-existing-file|--add-to-exiting-file) # Typo left for compatibility. Will be removed in 2.0.0.
         add_to_existing=$value
         ;;
       --create-file-if-not-exist)

--- a/terraform_docs.sh
+++ b/terraform_docs.sh
@@ -132,7 +132,7 @@ terraform_docs() {
       --path-to-file)
         text_file=$value
         ;;
-      --add-to-existing-file|--add-to-exiting-file) # Typo left for compatibility. Will be removed in 2.0.0.
+      --add-to-existing-file)
         add_to_existing=$value
         ;;
       --create-file-if-not-exist)


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123":
-->

As someone who often does not copy commands/args but types them out, I encountered an issue when trying to add the argument `--add-to-existing-file` for `terraform_docs`, as it has a typo in the name currently. This PR updates `exiting` to `existing` in all places.

This, however, is a breaking change for people that are using this argument with its current name. In order to make it non-breaking, we can check for `--add-to-exiting-file|--add-to-existing-file)` in the `case` block maybe?

<!-- Fixes # -->

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Tested using this:

```yaml
repos:
  - repo: git://github.com/mj3c/pre-commit-terraform
    rev: master
    hooks:
      - id: terraform_docs
        args:
          - --hook-config=--add-to-existing-file=true
```
