### PR TITLE
fix: analyse all folders with tflint and don't stop on first execution

### DIFF
--- a/terraform_tflint.sh
+++ b/terraform_tflint.sh
@@ -58,20 +58,24 @@ tflint_() {
 
     ((index += 1))
   done
-
+  set +e
+  tflint_final_exit_code=0
   for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
     path_uniq="${path_uniq//__REPLACED__SPACE__/ }"
-    pushd "$path_uniq" > /dev/null
 
     # Print checked PATH **only** if TFLint have any messages
     # shellcheck disable=SC2091 # Suppress error output
-    $(tflint "${ARGS[@]}" 2>&1) 2> /dev/null || {
+    $(tflint "${ARGS[@]}" $path_uniq 2>&1) 2> /dev/null || {
       echo >&2 -e "\033[1;33m\nTFLint in $path_uniq/:\033[0m"
-      tflint "${ARGS[@]}"
+      tflint "${ARGS[@]}" $path_uniq
     }
-
-    popd > /dev/null
+    local exit_code=$?
+    if [ $exit_code != 0 ]; then
+      tflint_final_exit_code=$exit_code
+    fi
   done
+  set -e
+  exit $tflint_final_exit_code
 }
 
 # global arrays


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

In a monorepo tflint is currently stopping after analysing the first module. This is because of the `set -e` that causes the script to exit. This change disables it temporarily for executing `tflint`, catches the exit codes from the `tflint` executions and then uses the exit code for the function. It also removes the `pushd`/`popd` since it is not necessary because tflint can just receive the path as an argument.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123":
-->

<!-- Fixes # -->

### How has this code been tested

Create a mono repo with two or more modules in different folders, with code that makes tflint report something. Notice that before this change, it just analyses one of the modules. With this change it will keep analysing the modules and report the output for all of them.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
