### PR TITLE
feat: Pass custom arguments to terraform init in `terraform_validate` hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,15 @@ Example:
         - --envs=AWS_SECRET_ACCESS_KEY="asecretkey"
     ```
 
-3. It may happen that Terraform working directory (`.terraform`) already exists but not in the best condition (eg, not initialized modules, wrong version of Terraform, etc.). To solve this problem, you can find and delete all `.terraform` directories in your repository:
+3. `terraform_validate` also supports passing custom arguments to its `terraform init`:
+
+    ```yaml
+    - id: terraform_validate
+      args:
+        - --init-args=-lockfile=readonly
+    ```
+
+4. It may happen that Terraform working directory (`.terraform`) already exists but not in the best condition (eg, not initialized modules, wrong version of Terraform, etc.). To solve this problem, you can find and delete all `.terraform` directories in your repository:
 
     ```bash
     echo "

--- a/terraform_validate.sh
+++ b/terraform_validate.sh
@@ -30,7 +30,7 @@ initialize_() {
 
 parse_cmdline_() {
   declare argv
-  argv=$(getopt -o e:a: --long envs:,args: -- "$@") || return
+  argv=$(getopt -o e:i:a: --long envs:,init-args:,args: -- "$@") || return
   eval "set -- $argv"
 
   for argv; do
@@ -38,6 +38,11 @@ parse_cmdline_() {
       -a | --args)
         shift
         ARGS+=("$1")
+        shift
+        ;;
+      -i | --init-args)
+        shift
+        INIT_ARGS+=("$1")
         shift
         ;;
       -e | --envs)
@@ -87,7 +92,7 @@ terraform_validate_() {
 
       if [[ ! -d .terraform ]]; then
         set +e
-        init_output=$(terraform init -backend=false 2>&1)
+        init_output=$(terraform init -backend=false "${INIT_ARGS[@]}" 2>&1)
         init_code=$?
         set -e
 
@@ -123,6 +128,7 @@ terraform_validate_() {
 
 # global arrays
 declare -a ARGS
+declare -a INIT_ARGS
 declare -a ENVS
 declare -a FILES
 


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [x] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123":
-->

This adds support for passing arguments to `terraform init` via `--init-args`.

My use case is passing `-lockfile=readonly`, I do not want this hook to modify the lock file, I leave that to `terraform_providers_lock`.

It avoids the issue describe in this discussion: https://github.com/renovatebot/renovate/discussions/11821

<!-- Fixes # -->

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I have run the pre-commit on a repository. Directory are validated, `init` takes the arguments