### PR TITLE
feat: Add terraform_validate support to init modules and providers if needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,22 +534,21 @@ Example:
         - --init-args=-lockfile=readonly
     ```
 
-4. It may happen that Terraform working directory (`.terraform`) already exists but not in the best condition (eg, not initialized modules, wrong version of Terraform, etc.). To solve this problem, you can find and delete all `.terraform` directories in your repository:
+4. `terraform_validate` hook identifies automatically, if all needed modules are initialized and will reinitialize them if needed before running the `terraform validate` command. If you want to force a module initialization on every run, pass the following argument to its `terraform init`:
 
-    ```bash
-    echo "
-    function rm_terraform {
-        find . -name ".terraform*" -print0 | xargs -0 rm -r
-    }
-    " >>~/.bashrc
-
-    # Reload shell and use `rm_terraform` command in the repo root
+    ```yaml
+    - id: terraform_validate
+      args:
+        - --init-args=-get=true
     ```
 
-   `terraform_validate` hook will try to reinitialize them before running the `terraform validate` command.
+5. Pass the following argument, if you want `terraform_validate` hook to also upgrade all specified providers:
 
-    **Warning:** If you use Terraform workspaces, DO NOT use this workaround ([details](https://github.com/antonbabenko/pre-commit-terraform/issues/203#issuecomment-918791847)). Wait to [`force-init`](https://github.com/antonbabenko/pre-commit-terraform/issues/224) option implementation.
-
+    ```yaml
+    - id: terraform_validate
+      args:
+        - --init-args=-upgrade
+    ```
 
 ## Authors
 

--- a/README.md
+++ b/README.md
@@ -542,7 +542,7 @@ Example:
         - --init-args=-get=true
     ```
 
-5. Pass the following argument, if you want `terraform_validate` hook to also upgrade all specified providers:
+5. Pass the following argument, if you want `terraform_validate` hook to also upgrade all specified providers and (if `-get=true` is specified) to (re-)install latest versions of module(s) allowed within configured constraints:
 
     ```yaml
     - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -543,13 +543,17 @@ Example:
         - --init-args=-get=true
     ```
 
-5. Pass the following argument, if you want `terraform_validate` hook to also upgrade all specified providers and (if `-get=true` is specified) to (re-)install latest versions of module(s) allowed within configured constraints:
+5. If you want `terraform_validate` hook upgrade all specified providers and install the latest versions of modules allowed within configured constraints, set:
 
     ```yaml
+```suggestion
     - id: terraform_validate
       args:
         - --init-args=-upgrade
+        - --init-args=-get=true
     ```
+
+    For all possible `terraform init` args, check [official docs](https://www.terraform.io/docs/cli/commands/init.html).
 
 ### terrascan
 

--- a/terraform_validate.sh
+++ b/terraform_validate.sh
@@ -90,19 +90,20 @@ terraform_validate_() {
 
       pushd "$(realpath "$path_uniq")" > /dev/null
 
-      if [[ ! -d .terraform ]]; then
-        set +e
-        init_output=$(terraform init -backend=false "${INIT_ARGS[@]}" 2>&1)
-        init_code=$?
-        set -e
+      local init_get
+      terraform providers > /dev/null 2>&1 && init_get="false" || init_get="true"
 
-        if [[ $init_code != 0 ]]; then
-          error=1
-          echo "Init before validation failed: $path_uniq"
-          echo "$init_output"
-          popd > /dev/null
-          continue
-        fi
+      set +e
+      init_output=$(terraform init -backend=false -get=$init_get "${INIT_ARGS[@]}" 2>&1)
+      init_code=$?
+      set -e
+
+      if [[ $init_code != 0 ]]; then
+        error=1
+        echo "Init before validation failed: $path_uniq"
+        echo "$init_output"
+        popd > /dev/null
+        continue
       fi
 
       set +e


### PR DESCRIPTION
Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [x] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes
This PR adds logic to `terraform_validate` to detect if module initialization is needed and run it. It's also possible now to force an initialization and/or provider upgrade by just adding the documented `init-args` to the hook call.

The new logic works as follows:
`terraform providers` is called on every run and used to detect if all needed modules are initialized correctly. If it succeeds it will pass `-get=false` to the `terraform init` call, which prevents modules to be re-downloaded. On the other hand, if `terraform providers` fails, this means modules or providers are not initialized and `-get=true`will be passed to `terraform init` - a full initialization will happen.

Since `terraform init` will be called every time, the already existing `--init-args` feature will give us to additional benefits:
- `--init-args=-get=true` will result in a forced initialization on every run
- `--init-args=-upgrade` will allow to upgrade providers in addition to the modules if needed

<!-- Fixes # -->
Fixes #224 

### How has this code been tested
1. You need to have terraform code which references modules and providers.
2. Delete `.terraform` folder if present
3. Change a module version in your code to some other existing version and stage the commit
4. run `pre-commit run terraform_validate` and you see that it will initialize the `.terraform` folder newly and validate your code.
5. Every re-run of `pre-commit run terraform_validate` will be faster, as long as no module version changes happen
6. Again change a module version in your code to some other existing version and stage the commit
7. run `pre-commit run terraform_validate` and you see that it will reinitialize for the new module

Repeat the above steps with changing provider version and setting the `--init-args=-upgrade` argument. You will notice that only providers or both are initialized if needed.
