### PR TITLE
fix: Restore current working directory behavior

### DIFF
--- a/terraform_tflint.sh
+++ b/terraform_tflint.sh
@@ -62,17 +62,20 @@ tflint_() {
   tflint_final_exit_code=0
   for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
     path_uniq="${path_uniq//__REPLACED__SPACE__/ }"
+    pushd "$path_uniq" > /dev/null
 
     # Print checked PATH **only** if TFLint have any messages
     # shellcheck disable=SC2091 # Suppress error output
-    $(tflint "${ARGS[@]}" $path_uniq 2>&1) 2> /dev/null || {
+    $(tflint "${ARGS[@]}" 2>&1) 2> /dev/null || {
       echo >&2 -e "\033[1;33m\nTFLint in $path_uniq/:\033[0m"
-      tflint "${ARGS[@]}" $path_uniq
+      tflint "${ARGS[@]}"
     }
     local exit_code=$?
     if [ $exit_code != 0 ]; then
       tflint_final_exit_code=$exit_code
     fi
+
+    popd > /dev/null
   done
   set -e
   exit $tflint_final_exit_code


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123":
-->

This has been removed in #289, but it breaks `tflint` for features like the `--modules` flag which require the directory to be initialized. `tflint` looks for the `.terraform` directory in the current working directory.

<!-- Fixes # -->

### How has this code been tested

Run on a repository with `--modules` argument, both in a valid and an invalid state, previous behavior is restored.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
