### PR TITLE
fix: Speedup `terrascan` hook up to x3 times in big repos

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -108,3 +108,4 @@
   description: Runs terrascan on Terraform templates.
   language: script
   entry: terrascan.sh
+  require_serial: true


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [x] This PR enhances existing functionality.

### Description of your changes

During https://github.com/antonbabenko/pre-commit-terraform/pull/305#pullrequestreview-837797221 found that tag v1.62.1 with `require_serial: true` took 9s when without taking took 20s.

The root cause is same to previous `require_serial: true`  fixes - `pre-commit` run hook multiply times in the same folder/

So, let's not wait to PR merge, and implement this fix now.
