### PR TITLE
chore: Refactor all hooks

### DIFF
--- a/infracost_breakdown.sh
+++ b/infracost_breakdown.sh
@@ -44,6 +44,7 @@ function common::parse_cmdline {
   # common global arrays.
   # Populated via `common::parse_cmdline` and can be used inside hooks' functions
   declare -g -a ARGS=() FILES=() HOOK_CONFIG=()
+  declare -g -r HOOK_CONFIG_SEPARATOR='%%SEPARATOR%%'
 
   local argv
   argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
@@ -58,7 +59,7 @@ function common::parse_cmdline {
         ;;
       -h | --hook-config)
         shift
-        HOOK_CONFIG+=("$1;")
+        HOOK_CONFIG+=("${1}${HOOK_CONFIG_SEPARATOR}")
         shift
         ;;
       --)
@@ -76,7 +77,7 @@ function infracost_breakdown_ {
   read -r -a args <<< "$2"
 
   # Get hook settings
-  IFS=";" read -r -a checks <<< "$hook_config"
+  IFS="$HOOK_CONFIG_SEPARATOR" read -r -a checks <<< "$hook_config"
 
   if [ "$PRE_COMMIT_COLOR" = "never" ]; then
     args+=("--no-color")

--- a/infracost_breakdown.sh
+++ b/infracost_breakdown.sh
@@ -179,4 +179,4 @@ function infracost_breakdown_ {
   fi
 }
 
-[[ ${BASH_SOURCE[0]} != "$0" ]] || main "$@"
+[ "${BASH_SOURCE[0]}" != "$0" ] || main "$@"

--- a/infracost_breakdown.sh
+++ b/infracost_breakdown.sh
@@ -8,15 +8,14 @@ function main {
 }
 
 function common::colorify {
-  # Colors. Provided as first string to first arg of function.
   # shellcheck disable=SC2034
-  local -r red="$(tput setaf 1)"
+  local -r red="\e[0m\e[31m"
   # shellcheck disable=SC2034
-  local -r green="$(tput setaf 2)"
+  local -r green="\e[0m\e[32m"
   # shellcheck disable=SC2034
-  local -r yellow="$(tput setaf 3)"
+  local -r yellow="\e[0m\e[33m"
   # Color reset
-  local -r RESET="$(tput sgr0)"
+  local -r RESET="\e[0m"
 
   # Params start #
   local COLOR="${!1}"

--- a/infracost_breakdown.sh
+++ b/infracost_breakdown.sh
@@ -40,12 +40,11 @@ function common::initialize {
   . "$SCRIPT_DIR/lib_getopt"
 }
 
-# common global arrays.
-# Populated in `parse_cmdline` and can used in hooks functions
-declare -a ARGS=()
-declare -a HOOK_CONFIG=()
-declare -a FILES=()
 function common::parse_cmdline {
+  # common global arrays.
+  # Populated via `common::parse_cmdline` and can be used inside hooks' functions
+  declare -g -a ARGS=() FILES=() HOOK_CONFIG=()
+
   local argv
   argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
   eval "set -- $argv"

--- a/infracost_breakdown.sh
+++ b/infracost_breakdown.sh
@@ -44,7 +44,6 @@ function common::parse_cmdline {
   # common global arrays.
   # Populated via `common::parse_cmdline` and can be used inside hooks' functions
   declare -g -a ARGS=() FILES=() HOOK_CONFIG=()
-  declare -g -r HOOK_CONFIG_SEPARATOR='%%SEPARATOR%%'
 
   local argv
   argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
@@ -59,7 +58,7 @@ function common::parse_cmdline {
         ;;
       -h | --hook-config)
         shift
-        HOOK_CONFIG+=("${1}${HOOK_CONFIG_SEPARATOR}")
+        HOOK_CONFIG+=("$1;")
         shift
         ;;
       --)
@@ -77,7 +76,7 @@ function infracost_breakdown_ {
   read -r -a args <<< "$2"
 
   # Get hook settings
-  IFS="$HOOK_CONFIG_SEPARATOR" read -r -a checks <<< "$hook_config"
+  IFS=";" read -r -a checks <<< "$hook_config"
 
   if [ "$PRE_COMMIT_COLOR" = "never" ]; then
     args+=("--no-color")

--- a/terraform_docs.sh
+++ b/terraform_docs.sh
@@ -370,4 +370,4 @@ EOF
 
 }
 
-[[ ${BASH_SOURCE[0]} != "$0" ]] || main "$@"
+[ "${BASH_SOURCE[0]}" != "$0" ] || main "$@"

--- a/terraform_docs.sh
+++ b/terraform_docs.sh
@@ -23,7 +23,6 @@ function common::parse_cmdline {
   # common global arrays.
   # Populated via `common::parse_cmdline` and can be used inside hooks' functions
   declare -g -a ARGS=() FILES=() HOOK_CONFIG=()
-  declare -g -r HOOK_CONFIG_SEPARATOR='%%SEPARATOR%%'
 
   local argv
   argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
@@ -38,7 +37,7 @@ function common::parse_cmdline {
         ;;
       -h | --hook-config)
         shift
-        HOOK_CONFIG+=("${1}${HOOK_CONFIG_SEPARATOR}")
+        HOOK_CONFIG+=("$1;")
         shift
         ;;
       --)
@@ -57,7 +56,7 @@ function terraform_docs_ {
   local -a -r files=("$@")
 
   # Get hook settings
-  IFS="$HOOK_CONFIG_SEPARATOR" read -r -a configs <<< "$hook_config"
+  IFS=";" read -r -a configs <<< "$hook_config"
 
   local hack_terraform_docs
   hack_terraform_docs=$(terraform version | sed -n 1p | grep -c 0.12) || true

--- a/terraform_docs.sh
+++ b/terraform_docs.sh
@@ -140,11 +140,11 @@ function terraform_docs {
     esac
   done
 
-  local path_uniq
-  for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
-    path_uniq="${path_uniq//__REPLACED__SPACE__/ }"
+  local dir_path
+  for dir_path in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
+    dir_path="${dir_path//__REPLACED__SPACE__/ }"
 
-    pushd "$path_uniq" > /dev/null
+    pushd "$dir_path" > /dev/null
 
     #
     # Create file if it not exist and `--create-if-not-exist=true` provided

--- a/terraform_docs.sh
+++ b/terraform_docs.sh
@@ -23,6 +23,7 @@ function common::parse_cmdline {
   # common global arrays.
   # Populated via `common::parse_cmdline` and can be used inside hooks' functions
   declare -g -a ARGS=() FILES=() HOOK_CONFIG=()
+  declare -g -r HOOK_CONFIG_SEPARATOR='%%SEPARATOR%%'
 
   local argv
   argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
@@ -37,7 +38,7 @@ function common::parse_cmdline {
         ;;
       -h | --hook-config)
         shift
-        HOOK_CONFIG+=("$1;")
+        HOOK_CONFIG+=("${1}${HOOK_CONFIG_SEPARATOR}")
         shift
         ;;
       --)
@@ -56,7 +57,7 @@ function terraform_docs_ {
   local -a -r files=("$@")
 
   # Get hook settings
-  IFS=";" read -r -a configs <<< "$hook_config"
+  IFS="$HOOK_CONFIG_SEPARATOR" read -r -a configs <<< "$hook_config"
 
   local hack_terraform_docs
   hack_terraform_docs=$(terraform version | sed -n 1p | grep -c 0.12) || true

--- a/terraform_docs.sh
+++ b/terraform_docs.sh
@@ -19,12 +19,11 @@ function common::initialize {
   . "$SCRIPT_DIR/lib_getopt"
 }
 
-# common global arrays.
-# Populated in `parse_cmdline` and can used in hooks functions
-declare -a ARGS=()
-declare -a HOOK_CONFIG=()
-declare -a FILES=()
 function common::parse_cmdline {
+  # common global arrays.
+  # Populated via `common::parse_cmdline` and can be used inside hooks' functions
+  declare -g -a ARGS=() FILES=() HOOK_CONFIG=()
+
   local argv
   argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
   eval "set -- $argv"

--- a/terraform_docs.sh
+++ b/terraform_docs.sh
@@ -144,7 +144,7 @@ function terraform_docs {
   for dir_path in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
     dir_path="${dir_path//__REPLACED__SPACE__/ }"
 
-    pushd "$dir_path" > /dev/null
+    pushd "$dir_path" > /dev/null || continue
 
     #
     # Create file if it not exist and `--create-if-not-exist=true` provided

--- a/terraform_fmt.sh
+++ b/terraform_fmt.sh
@@ -21,6 +21,7 @@ function common::parse_cmdline {
   # common global arrays.
   # Populated via `common::parse_cmdline` and can be used inside hooks' functions
   declare -g -a ARGS=() FILES=() HOOK_CONFIG=()
+  declare -g -r HOOK_CONFIG_SEPARATOR='%%SEPARATOR%%'
 
   local argv
   argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
@@ -35,7 +36,7 @@ function common::parse_cmdline {
         ;;
       -h | --hook-config)
         shift
-        HOOK_CONFIG+=("$1;")
+        HOOK_CONFIG+=("${1}${HOOK_CONFIG_SEPARATOR}")
         shift
         ;;
       --)

--- a/terraform_fmt.sh
+++ b/terraform_fmt.sh
@@ -17,12 +17,11 @@ function common::initialize {
   . "$SCRIPT_DIR/lib_getopt"
 }
 
-# common global arrays.
-# Populated in `parse_cmdline` and can used in hooks functions
-declare -a ARGS=()
-declare -a HOOK_CONFIG=()
-declare -a FILES=()
 function common::parse_cmdline {
+  # common global arrays.
+  # Populated via `common::parse_cmdline` and can be used inside hooks' functions
+  declare -g -a ARGS=() FILES=() HOOK_CONFIG=()
+
   local argv
   argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
   eval "set -- $argv"
@@ -67,9 +66,9 @@ function terraform_fmt_ {
     ((index += 1))
   done
 
-  # allow hook to continue if exit_code is greater than 0
   # preserve errexit status
   shopt -qo errexit && ERREXIT_IS_SET=true
+  # allow hook to continue if exit_code is greater than 0
   set +e
   local final_exit_code=0
 
@@ -112,8 +111,8 @@ function per_dir_hook_unique_part {
   local -r args="$1"
   local -r dir_path="$2"
 
-  # pass the arguments to terrascan
-  # shellcheck disable=SC2068 # terrascan fails when quoting is used ("$arg" vs $arg)
+  # pass the arguments to hook
+  # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
   terraform fmt ${args[@]}
 
   # return exit code to common::per_dir_hook

--- a/terraform_fmt.sh
+++ b/terraform_fmt.sh
@@ -1,33 +1,30 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-main() {
-  initialize_
-  parse_cmdline_ "$@"
-  terraform_fmt_
+function main {
+  common::initialize
+  common::parse_cmdline "$@"
+  terraform_fmt_ "${ARGS[*]}" "${FILES[@]}"
 }
 
-initialize_() {
+function common::initialize {
+  local SCRIPT_DIR
   # get directory containing this script
-  local dir
-  local source
-  source="${BASH_SOURCE[0]}"
-  while [[ -L $source ]]; do # resolve $source until the file is no longer a symlink
-    dir="$(cd -P "$(dirname "$source")" > /dev/null && pwd)"
-    source="$(readlink "$source")"
-    # if $source was a relative symlink, we need to resolve it relative to the path where the symlink file was located
-    [[ $source != /* ]] && source="$dir/$source"
-  done
-  _SCRIPT_DIR="$(dirname "$source")"
+  SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
   # source getopt function
   # shellcheck source=lib_getopt
-  . "$_SCRIPT_DIR/lib_getopt"
+  . "$SCRIPT_DIR/lib_getopt"
 }
 
-parse_cmdline_() {
-  declare argv
-  argv=$(getopt -o a: --long args: -- "$@") || return
+# common global arrays.
+# Populated in `parse_cmdline` and can used in hooks functions
+declare -a ARGS=()
+declare -a HOOK_CONFIG=()
+declare -a FILES=()
+function common::parse_cmdline {
+  local argv
+  argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
   eval "set -- $argv"
 
   for argv; do
@@ -35,6 +32,11 @@ parse_cmdline_() {
       -a | --args)
         shift
         ARGS+=("$1")
+        shift
+        ;;
+      -h | --hook-config)
+        shift
+        HOOK_CONFIG+=("$1;")
         shift
         ;;
       --)
@@ -46,44 +48,77 @@ parse_cmdline_() {
   done
 }
 
-terraform_fmt_() {
-
-  declare -a paths
-  declare -a tfvars_files
-
-  index=0
-
-  for file_with_path in "${FILES[@]}"; do
+function terraform_fmt_ {
+  local -r args="$1"
+  shift 1
+  local -a -r files=("$@")
+  # consume modified files passed from pre-commit so that
+  # hook runs against only those relevant directories
+  local index=0
+  for file_with_path in "${files[@]}"; do
     file_with_path="${file_with_path// /__REPLACED__SPACE__}"
 
-    paths[index]=$(dirname "$file_with_path")
-
+    dir_paths[index]=$(dirname "$file_with_path")
+    # TODO Unique part
     if [[ "$file_with_path" == *".tfvars" ]]; then
       tfvars_files+=("$file_with_path")
     fi
-
+    #? End for unique part
     ((index += 1))
   done
 
-  for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
-    path_uniq="${path_uniq//__REPLACED__SPACE__/ }"
+  # allow hook to continue if exit_code is greater than 0
+  # preserve errexit status
+  shopt -qo errexit && ERREXIT_IS_SET=true
+  set +e
+  local final_exit_code=0
 
-    (
-      cd "$path_uniq"
-      terraform fmt "${ARGS[@]}"
-    )
+  # run hook for each path
+  for dir_path in $(echo "${dir_paths[*]}" | tr ' ' '\n' | sort -u); do
+    dir_path="${dir_path//__REPLACED__SPACE__/ }"
+    pushd "$dir_path" > /dev/null
+
+    per_dir_hook_unique_part "$args" "$dir_path"
+
+    local exit_code=$?
+    if [ "$exit_code" != 0 ]; then
+      final_exit_code=$exit_code
+    fi
+
+    popd > /dev/null
   done
 
+  # TODO: Unique part
   # terraform.tfvars are excluded by `terraform fmt`
   for tfvars_file in "${tfvars_files[@]}"; do
     tfvars_file="${tfvars_file//__REPLACED__SPACE__/ }"
 
     terraform fmt "${ARGS[@]}" "$tfvars_file"
+    local exit_code=$?
+    if [ "$exit_code" != 0 ]; then
+      final_exit_code=$exit_code
+    fi
   done
+  #? End for unique part
+  # restore errexit if it was set before the "for" loop
+  [[ $ERREXIT_IS_SET ]] && set -e
+  # return the hook final exit_code
+  exit $final_exit_code
+
 }
 
-# global arrays
-declare -a ARGS=()
-declare -a FILES=()
+function per_dir_hook_unique_part {
+  # common logic located in common::per_dir_hook
+  local -r args="$1"
+  local -r dir_path="$2"
+
+  # pass the arguments to terrascan
+  # shellcheck disable=SC2068 # terrascan fails when quoting is used ("$arg" vs $arg)
+  terraform fmt ${args[@]}
+
+  # return exit code to common::per_dir_hook
+  local exit_code=$?
+  return $exit_code
+}
 
 [[ ${BASH_SOURCE[0]} != "$0" ]] || main "$@"

--- a/terraform_fmt.sh
+++ b/terraform_fmt.sh
@@ -75,7 +75,7 @@ function terraform_fmt_ {
   # run hook for each path
   for dir_path in $(echo "${dir_paths[*]}" | tr ' ' '\n' | sort -u); do
     dir_path="${dir_path//__REPLACED__SPACE__/ }"
-    pushd "$dir_path" > /dev/null
+    pushd "$dir_path" > /dev/null || continue
 
     per_dir_hook_unique_part "$args" "$dir_path"
 

--- a/terraform_fmt.sh
+++ b/terraform_fmt.sh
@@ -80,7 +80,7 @@ function terraform_fmt_ {
     per_dir_hook_unique_part "$args" "$dir_path"
 
     local exit_code=$?
-    if [ "$exit_code" != 0 ]; then
+    if [ $exit_code -ne 0 ]; then
       final_exit_code=$exit_code
     fi
 
@@ -94,7 +94,7 @@ function terraform_fmt_ {
 
     terraform fmt "${ARGS[@]}" "$tfvars_file"
     local exit_code=$?
-    if [ "$exit_code" != 0 ]; then
+    if [ $exit_code -ne 0 ]; then
       final_exit_code=$exit_code
     fi
   done
@@ -120,4 +120,4 @@ function per_dir_hook_unique_part {
   return $exit_code
 }
 
-[[ ${BASH_SOURCE[0]} != "$0" ]] || main "$@"
+[ "${BASH_SOURCE[0]}" != "$0" ] || main "$@"

--- a/terraform_fmt.sh
+++ b/terraform_fmt.sh
@@ -21,7 +21,6 @@ function common::parse_cmdline {
   # common global arrays.
   # Populated via `common::parse_cmdline` and can be used inside hooks' functions
   declare -g -a ARGS=() FILES=() HOOK_CONFIG=()
-  declare -g -r HOOK_CONFIG_SEPARATOR='%%SEPARATOR%%'
 
   local argv
   argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
@@ -36,7 +35,7 @@ function common::parse_cmdline {
         ;;
       -h | --hook-config)
         shift
-        HOOK_CONFIG+=("${1}${HOOK_CONFIG_SEPARATOR}")
+        HOOK_CONFIG+=("$1;")
         shift
         ;;
       --)

--- a/terraform_providers_lock.sh
+++ b/terraform_providers_lock.sh
@@ -45,7 +45,6 @@ function common::parse_cmdline {
   # common global arrays.
   # Populated via `common::parse_cmdline` and can be used inside hooks' functions
   declare -g -a ARGS=() FILES=() HOOK_CONFIG=()
-  declare -g -r HOOK_CONFIG_SEPARATOR='%%SEPARATOR%%'
 
   local argv
   argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
@@ -60,7 +59,7 @@ function common::parse_cmdline {
         ;;
       -h | --hook-config)
         shift
-        HOOK_CONFIG+=("${1}${HOOK_CONFIG_SEPARATOR}")
+        HOOK_CONFIG+=("$1;")
         shift
         ;;
       --)

--- a/terraform_providers_lock.sh
+++ b/terraform_providers_lock.sh
@@ -101,7 +101,7 @@ function common::per_dir_hook {
     per_dir_hook_unique_part "$args" "$dir_path"
 
     local exit_code=$?
-    if [ "$exit_code" != 0 ]; then
+    if [ $exit_code -ne 0 ]; then
       final_exit_code=$exit_code
     fi
 
@@ -119,11 +119,11 @@ function per_dir_hook_unique_part {
   local -r args="$1"
   local -r dir_path="$2"
 
-  if [[ ! -d ".terraform" ]]; then
+  if [ ! -d ".terraform" ]; then
     init_output=$(terraform init -backend=false 2>&1)
     init_code=$?
 
-    if [[ $init_code != 0 ]]; then
+    if [ $init_code -ne 0 ]; then
       common::colorify "red" "Init before validation failed: $dir_path"
       common::colorify "red" "$init_output"
       exit $init_code
@@ -139,4 +139,4 @@ function per_dir_hook_unique_part {
   return $exit_code
 }
 
-[[ ${BASH_SOURCE[0]} != "$0" ]] || main "$@"
+[ "${BASH_SOURCE[0]}" != "$0" ] || main "$@"

--- a/terraform_providers_lock.sh
+++ b/terraform_providers_lock.sh
@@ -96,7 +96,7 @@ function common::per_dir_hook {
   # run hook for each path
   for dir_path in $(echo "${dir_paths[*]}" | tr ' ' '\n' | sort -u); do
     dir_path="${dir_path//__REPLACED__SPACE__/ }"
-    pushd "$dir_path" > /dev/null
+    pushd "$dir_path" > /dev/null || continue
 
     per_dir_hook_unique_part "$args" "$dir_path"
 

--- a/terraform_providers_lock.sh
+++ b/terraform_providers_lock.sh
@@ -45,6 +45,7 @@ function common::parse_cmdline {
   # common global arrays.
   # Populated via `common::parse_cmdline` and can be used inside hooks' functions
   declare -g -a ARGS=() FILES=() HOOK_CONFIG=()
+  declare -g -r HOOK_CONFIG_SEPARATOR='%%SEPARATOR%%'
 
   local argv
   argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
@@ -59,7 +60,7 @@ function common::parse_cmdline {
         ;;
       -h | --hook-config)
         shift
-        HOOK_CONFIG+=("$1;")
+        HOOK_CONFIG+=("${1}${HOOK_CONFIG_SEPARATOR}")
         shift
         ;;
       --)

--- a/terraform_providers_lock.sh
+++ b/terraform_providers_lock.sh
@@ -9,15 +9,14 @@ function main {
 }
 
 function common::colorify {
-  # Colors. Provided as first string to first arg of function.
   # shellcheck disable=SC2034
-  local -r red="$(tput setaf 1)"
+  local -r red="\e[0m\e[31m"
   # shellcheck disable=SC2034
-  local -r green="$(tput setaf 2)"
+  local -r green="\e[0m\e[32m"
   # shellcheck disable=SC2034
-  local -r yellow="$(tput setaf 3)"
+  local -r yellow="\e[0m\e[33m"
   # Color reset
-  local -r RESET="$(tput sgr0)"
+  local -r RESET="\e[0m"
 
   # Params start #
   local COLOR="${!1}"

--- a/terraform_tflint.sh
+++ b/terraform_tflint.sh
@@ -103,7 +103,7 @@ function common::per_dir_hook {
     per_dir_hook_unique_part "$args" "$dir_path"
 
     local exit_code=$?
-    if [ "$exit_code" != 0 ]; then
+    if [ $exit_code -ne 0 ]; then
       final_exit_code=$exit_code
     fi
 
@@ -135,4 +135,4 @@ function per_dir_hook_unique_part {
   return $exit_code
 }
 
-[[ ${BASH_SOURCE[0]} != "$0" ]] || main "$@"
+[ "${BASH_SOURCE[0]}" != "$0" ] || main "$@"

--- a/terraform_tflint.sh
+++ b/terraform_tflint.sh
@@ -11,15 +11,14 @@ function main {
 }
 
 function common::colorify {
-  # Colors. Provided as first string to first arg of function.
   # shellcheck disable=SC2034
-  local -r red="$(tput setaf 1)"
+  local -r red="\e[0m\e[31m"
   # shellcheck disable=SC2034
-  local -r green="$(tput setaf 2)"
+  local -r green="\e[0m\e[32m"
   # shellcheck disable=SC2034
-  local -r yellow="$(tput setaf 3)"
+  local -r yellow="\e[0m\e[33m"
   # Color reset
-  local -r RESET="$(tput sgr0)"
+  local -r RESET="\e[0m"
 
   # Params start #
   local COLOR="${!1}"

--- a/terraform_tflint.sh
+++ b/terraform_tflint.sh
@@ -43,12 +43,11 @@ function common::initialize {
   . "$SCRIPT_DIR/lib_getopt"
 }
 
-# common global arrays.
-# Populated in `parse_cmdline` and can used in hooks functions
-declare -a ARGS=()
-declare -a HOOK_CONFIG=()
-declare -a FILES=()
 function common::parse_cmdline {
+  # common global arrays.
+  # Populated via `common::parse_cmdline` and can be used inside hooks' functions
+  declare -g -a ARGS=() FILES=() HOOK_CONFIG=()
+
   local argv
   argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
   eval "set -- $argv"
@@ -90,9 +89,9 @@ function common::per_dir_hook {
     ((index += 1))
   done
 
-  # allow hook to continue if exit_code is greater than 0
   # preserve errexit status
   shopt -qo errexit && ERREXIT_IS_SET=true
+  # allow hook to continue if exit_code is greater than 0
   set +e
   local final_exit_code=0
 

--- a/terraform_tflint.sh
+++ b/terraform_tflint.sh
@@ -47,7 +47,6 @@ function common::parse_cmdline {
   # common global arrays.
   # Populated via `common::parse_cmdline` and can be used inside hooks' functions
   declare -g -a ARGS=() FILES=() HOOK_CONFIG=()
-  declare -g -r HOOK_CONFIG_SEPARATOR='%%SEPARATOR%%'
 
   local argv
   argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
@@ -62,7 +61,7 @@ function common::parse_cmdline {
         ;;
       -h | --hook-config)
         shift
-        HOOK_CONFIG+=("${1}${HOOK_CONFIG_SEPARATOR}")
+        HOOK_CONFIG+=("$1;")
         shift
         ;;
       --)

--- a/terraform_tflint.sh
+++ b/terraform_tflint.sh
@@ -47,6 +47,7 @@ function common::parse_cmdline {
   # common global arrays.
   # Populated via `common::parse_cmdline` and can be used inside hooks' functions
   declare -g -a ARGS=() FILES=() HOOK_CONFIG=()
+  declare -g -r HOOK_CONFIG_SEPARATOR='%%SEPARATOR%%'
 
   local argv
   argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
@@ -61,7 +62,7 @@ function common::parse_cmdline {
         ;;
       -h | --hook-config)
         shift
-        HOOK_CONFIG+=("$1;")
+        HOOK_CONFIG+=("${1}${HOOK_CONFIG_SEPARATOR}")
         shift
         ;;
       --)

--- a/terraform_tflint.sh
+++ b/terraform_tflint.sh
@@ -98,7 +98,7 @@ function common::per_dir_hook {
   # run hook for each path
   for dir_path in $(echo "${dir_paths[*]}" | tr ' ' '\n' | sort -u); do
     dir_path="${dir_path//__REPLACED__SPACE__/ }"
-    pushd "$dir_path" > /dev/null
+    pushd "$dir_path" > /dev/null || continue
 
     per_dir_hook_unique_part "$args" "$dir_path"
 

--- a/terraform_tflint.sh
+++ b/terraform_tflint.sh
@@ -2,41 +2,44 @@
 
 set -eo pipefail
 
-main() {
-  initialize_
-  parse_cmdline_ "$@"
-  tflint_
+function main {
+  common::initialize
+  common::parse_cmdline "$@"
+  # Support for setting PATH to repo root.
+  ARGS=${ARGS[*]/__GIT_WORKING_DIR__/$(pwd)\/}
+  common::per_dir_hook "$ARGS" "${FILES[@]}"
 }
 
-initialize_() {
+function common::initialize {
+  local SCRIPT_DIR
   # get directory containing this script
-  local dir
-  local source
-  source="${BASH_SOURCE[0]}"
-  while [[ -L $source ]]; do # resolve $source until the file is no longer a symlink
-    dir="$(cd -P "$(dirname "$source")" > /dev/null && pwd)"
-    source="$(readlink "$source")"
-    # if $source was a relative symlink, we need to resolve it relative to the path where the symlink file was located
-    [[ $source != /* ]] && source="$dir/$source"
-  done
-  _SCRIPT_DIR="$(dirname "$source")"
+  SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
   # source getopt function
   # shellcheck source=lib_getopt
-  . "$_SCRIPT_DIR/lib_getopt"
+  . "$SCRIPT_DIR/lib_getopt"
 }
 
-parse_cmdline_() {
-  declare argv
-  argv=$(getopt -o a: --long args: -- "$@") || return
+# common global arrays.
+# Populated in `parse_cmdline` and can used in hooks functions
+declare -a ARGS=()
+declare -a HOOK_CONFIG=()
+declare -a FILES=()
+function common::parse_cmdline {
+  local argv
+  argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
   eval "set -- $argv"
 
   for argv; do
     case $argv in
       -a | --args)
         shift
-        expanded_arg="${1//__GIT_WORKING_DIR__/$PWD}"
-        ARGS+=("$expanded_arg")
+        ARGS+=("$1")
+        shift
+        ;;
+      -h | --hook-config)
+        shift
+        HOOK_CONFIG+=("$1;")
         shift
         ;;
       --)
@@ -46,43 +49,66 @@ parse_cmdline_() {
         ;;
     esac
   done
-
 }
 
-tflint_() {
+function common::per_dir_hook {
+  local -r args="$1"
+  shift 1
+  local -a -r files=("$@")
+
+  # consume modified files passed from pre-commit so that
+  # hook runs against only those relevant directories
   local index=0
-  for file_with_path in "${FILES[@]}"; do
+  for file_with_path in "${files[@]}"; do
     file_with_path="${file_with_path// /__REPLACED__SPACE__}"
 
-    paths[index]=$(dirname "$file_with_path")
+    dir_paths[index]=$(dirname "$file_with_path")
 
     ((index += 1))
   done
+
+  # allow hook to continue if exit_code is greater than 0
+  # preserve errexit status
+  shopt -qo errexit && ERREXIT_IS_SET=true
   set +e
-  tflint_final_exit_code=0
-  for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
+  local final_exit_code=0
+
+  # run hook for each path
+  for path_uniq in $(echo "${dir_paths[*]}" | tr ' ' '\n' | sort -u); do
     path_uniq="${path_uniq//__REPLACED__SPACE__/ }"
     pushd "$path_uniq" > /dev/null
 
-    # Print checked PATH **only** if TFLint have any messages
-    # shellcheck disable=SC2091 # Suppress error output
-    $(tflint "${ARGS[@]}" 2>&1) 2> /dev/null || {
-      echo >&2 -e "\033[1;33m\nTFLint in $path_uniq/:\033[0m"
-      tflint "${ARGS[@]}"
-    }
+    per_dir_hook_unique_part "$args"
+
     local exit_code=$?
-    if [ $exit_code != 0 ]; then
-      tflint_final_exit_code=$exit_code
+    if [ "$exit_code" != 0 ]; then
+      final_exit_code=$exit_code
     fi
 
     popd > /dev/null
   done
-  set -e
-  exit $tflint_final_exit_code
+
+  # restore errexit if it was set before the "for" loop
+  [[ $ERREXIT_IS_SET ]] && set -e
+  # return the hook final exit_code
+  exit $final_exit_code
 }
 
-# global arrays
-declare -a ARGS
-declare -a FILES
+function per_dir_hook_unique_part {
+  # common logic located in common::per_dir_hook
+  local -r args="$1"
+
+  # Print checked PATH **only** if TFLint have any messages
+  # shellcheck disable=SC2091,SC2068 # Suppress error output
+  $(tflint ${args[@]} 2>&1) 2> /dev/null || {
+    echo >&2 -e "\033[1;33m\nTFLint in $path_uniq/:\033[0m"
+    # shellcheck disable=SC2068 # tflint fails when quoting is used ("$arg" vs $arg)
+    tflint ${args[@]}
+  }
+
+  # return exit code to common::per_dir_hook
+  local exit_code=$?
+  return $exit_code
+}
 
 [[ ${BASH_SOURCE[0]} != "$0" ]] || main "$@"

--- a/terraform_tfsec.sh
+++ b/terraform_tfsec.sh
@@ -19,12 +19,11 @@ function common::initialize {
   . "$SCRIPT_DIR/lib_getopt"
 }
 
-# common global arrays.
-# Populated in `parse_cmdline` and can used in hooks functions
-declare -a ARGS=()
-declare -a HOOK_CONFIG=()
-declare -a FILES=()
 function common::parse_cmdline {
+  # common global arrays.
+  # Populated via `common::parse_cmdline` and can be used inside hooks' functions
+  declare -g -a ARGS=() FILES=() HOOK_CONFIG=()
+
   local argv
   argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
   eval "set -- $argv"
@@ -66,9 +65,9 @@ function common::per_dir_hook {
     ((index += 1))
   done
 
-  # allow hook to continue if exit_code is greater than 0
   # preserve errexit status
   shopt -qo errexit && ERREXIT_IS_SET=true
+  # allow hook to continue if exit_code is greater than 0
   set +e
   local final_exit_code=0
 

--- a/terraform_tfsec.sh
+++ b/terraform_tfsec.sh
@@ -1,74 +1,110 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-main() {
-  initialize_
-  parse_cmdline_ "$@"
-
-  # propagate $FILES to custom function
-  tfsec_ "$ARGS" "${FILES[*]}"
+function main {
+  common::initialize
+  common::parse_cmdline "$@"
+  # Support for setting PATH to repo root.
+  ARGS=${ARGS[*]/__GIT_WORKING_DIR__/$(pwd)\/}
+  common::per_dir_hook "$ARGS" "${FILES[@]}"
 }
 
-tfsec_() {
-  # consume modified files passed from pre-commit so that
-  # tfsec runs against only those relevant directories
-  for file_with_path in ${FILES[*]}; do
-    file_with_path="${file_with_path// /__REPLACED__SPACE__}"
-    paths[index]=$(dirname "$file_with_path")
-
-    let "index+=1"
-  done
-
-  for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
-    path_uniq="${path_uniq//__REPLACED__SPACE__/ }"
-    pushd "$path_uniq" > /dev/null
-    tfsec $ARGS
-    popd > /dev/null
-  done
-}
-
-initialize_() {
+function common::initialize {
+  local SCRIPT_DIR
   # get directory containing this script
-  local dir
-  local source
-  source="${BASH_SOURCE[0]}"
-  while [[ -L $source ]]; do # resolve $source until the file is no longer a symlink
-    dir="$(cd -P "$(dirname "$source")" > /dev/null && pwd)"
-    source="$(readlink "$source")"
-    # if $source was a relative symlink, we need to resolve it relative to the path where the symlink file was located
-    [[ $source != /* ]] && source="$dir/$source"
-  done
-  _SCRIPT_DIR="$(dirname "$source")"
+  SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
   # source getopt function
   # shellcheck source=lib_getopt
-  . "$_SCRIPT_DIR/lib_getopt"
+  . "$SCRIPT_DIR/lib_getopt"
 }
 
-parse_cmdline_() {
-  declare argv
-  argv=$(getopt -o a: --long args: -- "$@") || return
+# common global arrays.
+# Populated in `parse_cmdline` and can used in hooks functions
+declare -a ARGS=()
+declare -a HOOK_CONFIG=()
+declare -a FILES=()
+function common::parse_cmdline {
+  local argv
+  argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
   eval "set -- $argv"
 
   for argv; do
     case $argv in
       -a | --args)
         shift
-        expanded_arg="${1//__GIT_WORKING_DIR__/$PWD}"
-        ARGS+=("$expanded_arg")
+        ARGS+=("$1")
+        shift
+        ;;
+      -h | --hook-config)
+        shift
+        HOOK_CONFIG+=("$1;")
         shift
         ;;
       --)
         shift
-        FILES+=("$@")
+        FILES=("$@")
         break
         ;;
     esac
   done
 }
 
-# global arrays
-declare -a ARGS=()
-declare -a FILES=()
+function common::per_dir_hook {
+  local -r args="$1"
+  shift 1
+  local -a -r files=("$@")
+
+  # consume modified files passed from pre-commit so that
+  # hook runs against only those relevant directories
+  local index=0
+  for file_with_path in "${files[@]}"; do
+    file_with_path="${file_with_path// /__REPLACED__SPACE__}"
+
+    dir_paths[index]=$(dirname "$file_with_path")
+
+    ((index += 1))
+  done
+
+  # allow hook to continue if exit_code is greater than 0
+  # preserve errexit status
+  shopt -qo errexit && ERREXIT_IS_SET=true
+  set +e
+  local final_exit_code=0
+
+  # run hook for each path
+  for dir_path in $(echo "${dir_paths[*]}" | tr ' ' '\n' | sort -u); do
+    dir_path="${dir_path//__REPLACED__SPACE__/ }"
+    pushd "$dir_path" > /dev/null
+
+    per_dir_hook_unique_part "$args" "$dir_path"
+
+    local exit_code=$?
+    if [ "$exit_code" != 0 ]; then
+      final_exit_code=$exit_code
+    fi
+
+    popd > /dev/null
+  done
+
+  # restore errexit if it was set before the "for" loop
+  [[ $ERREXIT_IS_SET ]] && set -e
+  # return the hook final exit_code
+  exit $final_exit_code
+}
+
+function per_dir_hook_unique_part {
+  # common logic located in common::per_dir_hook
+  local -r args="$1"
+  local -r dir_path="$2"
+
+  # pass the arguments to hook
+  # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
+  tfsec ${args[@]}
+
+  # return exit code to common::per_dir_hook
+  local exit_code=$?
+  return $exit_code
+}
 
 [[ ${BASH_SOURCE[0]} != "$0" ]] || main "$@"

--- a/terraform_tfsec.sh
+++ b/terraform_tfsec.sh
@@ -79,7 +79,7 @@ function common::per_dir_hook {
     per_dir_hook_unique_part "$args" "$dir_path"
 
     local exit_code=$?
-    if [ "$exit_code" != 0 ]; then
+    if [ $exit_code -ne 0 ]; then
       final_exit_code=$exit_code
     fi
 
@@ -106,4 +106,4 @@ function per_dir_hook_unique_part {
   return $exit_code
 }
 
-[[ ${BASH_SOURCE[0]} != "$0" ]] || main "$@"
+[ "${BASH_SOURCE[0]}" != "$0" ] || main "$@"

--- a/terraform_tfsec.sh
+++ b/terraform_tfsec.sh
@@ -23,6 +23,7 @@ function common::parse_cmdline {
   # common global arrays.
   # Populated via `common::parse_cmdline` and can be used inside hooks' functions
   declare -g -a ARGS=() FILES=() HOOK_CONFIG=()
+  declare -g -r HOOK_CONFIG_SEPARATOR='%%SEPARATOR%%'
 
   local argv
   argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
@@ -37,7 +38,7 @@ function common::parse_cmdline {
         ;;
       -h | --hook-config)
         shift
-        HOOK_CONFIG+=("$1;")
+        HOOK_CONFIG+=("${1}${HOOK_CONFIG_SEPARATOR}")
         shift
         ;;
       --)

--- a/terraform_tfsec.sh
+++ b/terraform_tfsec.sh
@@ -74,7 +74,7 @@ function common::per_dir_hook {
   # run hook for each path
   for dir_path in $(echo "${dir_paths[*]}" | tr ' ' '\n' | sort -u); do
     dir_path="${dir_path//__REPLACED__SPACE__/ }"
-    pushd "$dir_path" > /dev/null
+    pushd "$dir_path" > /dev/null || continue
 
     per_dir_hook_unique_part "$args" "$dir_path"
 

--- a/terraform_tfsec.sh
+++ b/terraform_tfsec.sh
@@ -23,7 +23,6 @@ function common::parse_cmdline {
   # common global arrays.
   # Populated via `common::parse_cmdline` and can be used inside hooks' functions
   declare -g -a ARGS=() FILES=() HOOK_CONFIG=()
-  declare -g -r HOOK_CONFIG_SEPARATOR='%%SEPARATOR%%'
 
   local argv
   argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
@@ -38,7 +37,7 @@ function common::parse_cmdline {
         ;;
       -h | --hook-config)
         shift
-        HOOK_CONFIG+=("${1}${HOOK_CONFIG_SEPARATOR}")
+        HOOK_CONFIG+=("$1;")
         shift
         ;;
       --)

--- a/terraform_validate.sh
+++ b/terraform_validate.sh
@@ -4,31 +4,23 @@ set -eo pipefail
 # `terraform validate` requires this env variable to be set
 export AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-east-1}
 
-main() {
-  initialize_
+function main {
+  common::initialize
   parse_cmdline_ "$@"
   terraform_validate_
 }
 
-initialize_() {
+function common::initialize {
+  local SCRIPT_DIR
   # get directory containing this script
-  local dir
-  local source
-  source="${BASH_SOURCE[0]}"
-  while [[ -L $source ]]; do # resolve $source until the file is no longer a symlink
-    dir="$(cd -P "$(dirname "$source")" > /dev/null && pwd)"
-    source="$(readlink "$source")"
-    # if $source was a relative symlink, we need to resolve it relative to the path where the symlink file was located
-    [[ $source != /* ]] && source="$dir/$source"
-  done
-  _SCRIPT_DIR="$(dirname "$source")"
+  SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
   # source getopt function
   # shellcheck source=lib_getopt
-  . "$_SCRIPT_DIR/lib_getopt"
+  . "$SCRIPT_DIR/lib_getopt"
 }
 
-parse_cmdline_() {
+function parse_cmdline_ {
   declare argv
   argv=$(getopt -o e:i:a: --long envs:,init-args:,args: -- "$@") || return
   eval "set -- $argv"
@@ -59,7 +51,7 @@ parse_cmdline_() {
   done
 }
 
-terraform_validate_() {
+function terraform_validate_ {
 
   # Setup environment variables
   local var var_name var_value

--- a/terraform_validate.sh
+++ b/terraform_validate.sh
@@ -74,23 +74,23 @@ function terraform_validate_ {
     ((index += 1))
   done
 
-  local path_uniq
-  for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
-    path_uniq="${path_uniq//__REPLACED__SPACE__/ }"
+  local dir_path
+  for dir_path in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
+    dir_path="${dir_path//__REPLACED__SPACE__/ }"
 
-    if [[ -n "$(find "$path_uniq" -maxdepth 1 -name '*.tf' -print -quit)" ]]; then
+    if [[ -n "$(find "$dir_path" -maxdepth 1 -name '*.tf' -print -quit)" ]]; then
 
-      pushd "$(realpath "$path_uniq")" > /dev/null
+      pushd "$(realpath "$dir_path")" > /dev/null
 
-      if [[ ! -d .terraform ]]; then
+      if [ ! -d .terraform ]; then
         set +e
         init_output=$(terraform init -backend=false "${INIT_ARGS[@]}" 2>&1)
         init_code=$?
         set -e
 
-        if [[ $init_code != 0 ]]; then
+        if [ $init_code -ne 0 ]; then
           error=1
-          echo "Init before validation failed: $path_uniq"
+          echo "Init before validation failed: $dir_path"
           echo "$init_output"
           popd > /dev/null
           continue
@@ -102,9 +102,9 @@ function terraform_validate_ {
       validate_code=$?
       set -e
 
-      if [[ $validate_code != 0 ]]; then
+      if [ $validate_code -ne 0 ]; then
         error=1
-        echo "Validation failed: $path_uniq"
+        echo "Validation failed: $dir_path"
         echo "$validate_output"
         echo
       fi
@@ -113,7 +113,7 @@ function terraform_validate_ {
     fi
   done
 
-  if [[ $error -ne 0 ]]; then
+  if [ $error -ne 0 ]; then
     exit 1
   fi
 }
@@ -124,4 +124,4 @@ declare -a INIT_ARGS
 declare -a ENVS
 declare -a FILES
 
-[[ ${BASH_SOURCE[0]} != "$0" ]] || main "$@"
+[ "${BASH_SOURCE[0]}" != "$0" ] || main "$@"

--- a/terragrunt_fmt.sh
+++ b/terragrunt_fmt.sh
@@ -21,6 +21,7 @@ function common::parse_cmdline {
   # common global arrays.
   # Populated via `common::parse_cmdline` and can be used inside hooks' functions
   declare -g -a ARGS=() FILES=() HOOK_CONFIG=()
+  declare -g -r HOOK_CONFIG_SEPARATOR='%%SEPARATOR%%'
 
   local argv
   argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
@@ -35,7 +36,7 @@ function common::parse_cmdline {
         ;;
       -h | --hook-config)
         shift
-        HOOK_CONFIG+=("$1;")
+        HOOK_CONFIG+=("${1}${HOOK_CONFIG_SEPARATOR}")
         shift
         ;;
       --)

--- a/terragrunt_fmt.sh
+++ b/terragrunt_fmt.sh
@@ -1,23 +1,108 @@
 #!/usr/bin/env bash
+set -eo pipefail
 
-set -e
+function main {
+  common::initialize
+  common::parse_cmdline "$@"
+  common::per_dir_hook "${ARGS[*]}" "${FILES[@]}"
+}
 
-declare -a paths
+function common::initialize {
+  local SCRIPT_DIR
+  # get directory containing this script
+  SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
-index=0
+  # source getopt function
+  # shellcheck source=lib_getopt
+  . "$SCRIPT_DIR/lib_getopt"
+}
 
-for file_with_path in "$@"; do
-  file_with_path="${file_with_path// /__REPLACED__SPACE__}"
+# common global arrays.
+# Populated in `parse_cmdline` and can used in hooks functions
+declare -a ARGS=()
+declare -a HOOK_CONFIG=()
+declare -a FILES=()
+function common::parse_cmdline {
+  local argv
+  argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
+  eval "set -- $argv"
 
-  paths[index]=$(dirname "$file_with_path")
+  for argv; do
+    case $argv in
+      -a | --args)
+        shift
+        ARGS+=("$1")
+        shift
+        ;;
+      -h | --hook-config)
+        shift
+        HOOK_CONFIG+=("$1;")
+        shift
+        ;;
+      --)
+        shift
+        FILES=("$@")
+        break
+        ;;
+    esac
+  done
+}
 
-  let "index+=1"
-done
+function common::per_dir_hook {
+  local -r args="$1"
+  shift 1
+  local -a -r files=("$@")
 
-for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
-  path_uniq="${path_uniq//__REPLACED__SPACE__/ }"
+  # consume modified files passed from pre-commit so that
+  # hook runs against only those relevant directories
+  local index=0
+  for file_with_path in "${files[@]}"; do
+    file_with_path="${file_with_path// /__REPLACED__SPACE__}"
 
-  pushd "$path_uniq" > /dev/null
-  terragrunt hclfmt
-  popd > /dev/null
-done
+    dir_paths[index]=$(dirname "$file_with_path")
+
+    ((index += 1))
+  done
+
+  # allow hook to continue if exit_code is greater than 0
+  # preserve errexit status
+  shopt -qo errexit && ERREXIT_IS_SET=true
+  set +e
+  local final_exit_code=0
+
+  # run hook for each path
+  for dir_path in $(echo "${dir_paths[*]}" | tr ' ' '\n' | sort -u); do
+    dir_path="${dir_path//__REPLACED__SPACE__/ }"
+    pushd "$dir_path" > /dev/null
+
+    per_dir_hook_unique_part "$args" "$dir_path"
+
+    local exit_code=$?
+    if [ "$exit_code" != 0 ]; then
+      final_exit_code=$exit_code
+    fi
+
+    popd > /dev/null
+  done
+
+  # restore errexit if it was set before the "for" loop
+  [[ $ERREXIT_IS_SET ]] && set -e
+  # return the hook final exit_code
+  exit $final_exit_code
+}
+
+function per_dir_hook_unique_part {
+  # common logic located in common::per_dir_hook
+  local -r args="$1"
+  local -r dir_path="$2"
+
+  # pass the arguments to hook
+  # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
+  terragrunt hclfmt ${args[@]}
+
+  # return exit code to common::per_dir_hook
+  local exit_code=$?
+  return $exit_code
+}
+
+[[ ${BASH_SOURCE[0]} != "$0" ]] || main "$@"

--- a/terragrunt_fmt.sh
+++ b/terragrunt_fmt.sh
@@ -72,7 +72,7 @@ function common::per_dir_hook {
   # run hook for each path
   for dir_path in $(echo "${dir_paths[*]}" | tr ' ' '\n' | sort -u); do
     dir_path="${dir_path//__REPLACED__SPACE__/ }"
-    pushd "$dir_path" > /dev/null
+    pushd "$dir_path" > /dev/null || continue
 
     per_dir_hook_unique_part "$args" "$dir_path"
 

--- a/terragrunt_fmt.sh
+++ b/terragrunt_fmt.sh
@@ -17,12 +17,11 @@ function common::initialize {
   . "$SCRIPT_DIR/lib_getopt"
 }
 
-# common global arrays.
-# Populated in `parse_cmdline` and can used in hooks functions
-declare -a ARGS=()
-declare -a HOOK_CONFIG=()
-declare -a FILES=()
 function common::parse_cmdline {
+  # common global arrays.
+  # Populated via `common::parse_cmdline` and can be used inside hooks' functions
+  declare -g -a ARGS=() FILES=() HOOK_CONFIG=()
+
   local argv
   argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
   eval "set -- $argv"
@@ -64,9 +63,9 @@ function common::per_dir_hook {
     ((index += 1))
   done
 
-  # allow hook to continue if exit_code is greater than 0
   # preserve errexit status
   shopt -qo errexit && ERREXIT_IS_SET=true
+  # allow hook to continue if exit_code is greater than 0
   set +e
   local final_exit_code=0
 

--- a/terragrunt_fmt.sh
+++ b/terragrunt_fmt.sh
@@ -77,7 +77,7 @@ function common::per_dir_hook {
     per_dir_hook_unique_part "$args" "$dir_path"
 
     local exit_code=$?
-    if [ "$exit_code" != 0 ]; then
+    if [ $exit_code -ne 0 ]; then
       final_exit_code=$exit_code
     fi
 
@@ -104,4 +104,4 @@ function per_dir_hook_unique_part {
   return $exit_code
 }
 
-[[ ${BASH_SOURCE[0]} != "$0" ]] || main "$@"
+[ "${BASH_SOURCE[0]}" != "$0" ] || main "$@"

--- a/terragrunt_fmt.sh
+++ b/terragrunt_fmt.sh
@@ -21,7 +21,6 @@ function common::parse_cmdline {
   # common global arrays.
   # Populated via `common::parse_cmdline` and can be used inside hooks' functions
   declare -g -a ARGS=() FILES=() HOOK_CONFIG=()
-  declare -g -r HOOK_CONFIG_SEPARATOR='%%SEPARATOR%%'
 
   local argv
   argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
@@ -36,7 +35,7 @@ function common::parse_cmdline {
         ;;
       -h | --hook-config)
         shift
-        HOOK_CONFIG+=("${1}${HOOK_CONFIG_SEPARATOR}")
+        HOOK_CONFIG+=("$1;")
         shift
         ;;
       --)

--- a/terragrunt_validate.sh
+++ b/terragrunt_validate.sh
@@ -21,6 +21,7 @@ function common::parse_cmdline {
   # common global arrays.
   # Populated via `common::parse_cmdline` and can be used inside hooks' functions
   declare -g -a ARGS=() FILES=() HOOK_CONFIG=()
+  declare -g -r HOOK_CONFIG_SEPARATOR='%%SEPARATOR%%'
 
   local argv
   argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
@@ -35,7 +36,7 @@ function common::parse_cmdline {
         ;;
       -h | --hook-config)
         shift
-        HOOK_CONFIG+=("$1;")
+        HOOK_CONFIG+=("${1}${HOOK_CONFIG_SEPARATOR}")
         shift
         ;;
       --)

--- a/terragrunt_validate.sh
+++ b/terragrunt_validate.sh
@@ -72,7 +72,7 @@ function common::per_dir_hook {
   # run hook for each path
   for dir_path in $(echo "${dir_paths[*]}" | tr ' ' '\n' | sort -u); do
     dir_path="${dir_path//__REPLACED__SPACE__/ }"
-    pushd "$dir_path" > /dev/null
+    pushd "$dir_path" > /dev/null || continue
 
     per_dir_hook_unique_part "$args" "$dir_path"
 

--- a/terragrunt_validate.sh
+++ b/terragrunt_validate.sh
@@ -17,12 +17,11 @@ function common::initialize {
   . "$SCRIPT_DIR/lib_getopt"
 }
 
-# common global arrays.
-# Populated in `parse_cmdline` and can used in hooks functions
-declare -a ARGS=()
-declare -a HOOK_CONFIG=()
-declare -a FILES=()
 function common::parse_cmdline {
+  # common global arrays.
+  # Populated via `common::parse_cmdline` and can be used inside hooks' functions
+  declare -g -a ARGS=() FILES=() HOOK_CONFIG=()
+
   local argv
   argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
   eval "set -- $argv"
@@ -64,9 +63,9 @@ function common::per_dir_hook {
     ((index += 1))
   done
 
-  # allow hook to continue if exit_code is greater than 0
   # preserve errexit status
   shopt -qo errexit && ERREXIT_IS_SET=true
+  # allow hook to continue if exit_code is greater than 0
   set +e
   local final_exit_code=0
 

--- a/terragrunt_validate.sh
+++ b/terragrunt_validate.sh
@@ -77,7 +77,7 @@ function common::per_dir_hook {
     per_dir_hook_unique_part "$args" "$dir_path"
 
     local exit_code=$?
-    if [ "$exit_code" != 0 ]; then
+    if [ $exit_code -ne 0 ]; then
       final_exit_code=$exit_code
     fi
 
@@ -104,4 +104,4 @@ function per_dir_hook_unique_part {
   return $exit_code
 }
 
-[[ ${BASH_SOURCE[0]} != "$0" ]] || main "$@"
+[ "${BASH_SOURCE[0]}" != "$0" ] || main "$@"

--- a/terragrunt_validate.sh
+++ b/terragrunt_validate.sh
@@ -21,7 +21,6 @@ function common::parse_cmdline {
   # common global arrays.
   # Populated via `common::parse_cmdline` and can be used inside hooks' functions
   declare -g -a ARGS=() FILES=() HOOK_CONFIG=()
-  declare -g -r HOOK_CONFIG_SEPARATOR='%%SEPARATOR%%'
 
   local argv
   argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
@@ -36,7 +35,7 @@ function common::parse_cmdline {
         ;;
       -h | --hook-config)
         shift
-        HOOK_CONFIG+=("${1}${HOOK_CONFIG_SEPARATOR}")
+        HOOK_CONFIG+=("$1;")
         shift
         ;;
       --)

--- a/terragrunt_validate.sh
+++ b/terragrunt_validate.sh
@@ -1,23 +1,108 @@
 #!/usr/bin/env bash
+set -eo pipefail
 
-set -e
+function main {
+  common::initialize
+  common::parse_cmdline "$@"
+  common::per_dir_hook "${ARGS[*]}" "${FILES[@]}"
+}
 
-declare -a paths
+function common::initialize {
+  local SCRIPT_DIR
+  # get directory containing this script
+  SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
-index=0
+  # source getopt function
+  # shellcheck source=lib_getopt
+  . "$SCRIPT_DIR/lib_getopt"
+}
 
-for file_with_path in "$@"; do
-  file_with_path="${file_with_path// /__REPLACED__SPACE__}"
+# common global arrays.
+# Populated in `parse_cmdline` and can used in hooks functions
+declare -a ARGS=()
+declare -a HOOK_CONFIG=()
+declare -a FILES=()
+function common::parse_cmdline {
+  local argv
+  argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
+  eval "set -- $argv"
 
-  paths[index]=$(dirname "$file_with_path")
+  for argv; do
+    case $argv in
+      -a | --args)
+        shift
+        ARGS+=("$1")
+        shift
+        ;;
+      -h | --hook-config)
+        shift
+        HOOK_CONFIG+=("$1;")
+        shift
+        ;;
+      --)
+        shift
+        FILES=("$@")
+        break
+        ;;
+    esac
+  done
+}
 
-  let "index+=1"
-done
+function common::per_dir_hook {
+  local -r args="$1"
+  shift 1
+  local -a -r files=("$@")
 
-for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
-  path_uniq="${path_uniq//__REPLACED__SPACE__/ }"
+  # consume modified files passed from pre-commit so that
+  # hook runs against only those relevant directories
+  local index=0
+  for file_with_path in "${files[@]}"; do
+    file_with_path="${file_with_path// /__REPLACED__SPACE__}"
 
-  pushd "$path_uniq" > /dev/null
-  terragrunt validate
-  popd > /dev/null
-done
+    dir_paths[index]=$(dirname "$file_with_path")
+
+    ((index += 1))
+  done
+
+  # allow hook to continue if exit_code is greater than 0
+  # preserve errexit status
+  shopt -qo errexit && ERREXIT_IS_SET=true
+  set +e
+  local final_exit_code=0
+
+  # run hook for each path
+  for dir_path in $(echo "${dir_paths[*]}" | tr ' ' '\n' | sort -u); do
+    dir_path="${dir_path//__REPLACED__SPACE__/ }"
+    pushd "$dir_path" > /dev/null
+
+    per_dir_hook_unique_part "$args" "$dir_path"
+
+    local exit_code=$?
+    if [ "$exit_code" != 0 ]; then
+      final_exit_code=$exit_code
+    fi
+
+    popd > /dev/null
+  done
+
+  # restore errexit if it was set before the "for" loop
+  [[ $ERREXIT_IS_SET ]] && set -e
+  # return the hook final exit_code
+  exit $final_exit_code
+}
+
+function per_dir_hook_unique_part {
+  # common logic located in common::per_dir_hook
+  local -r args="$1"
+  local -r dir_path="$2"
+
+  # pass the arguments to hook
+  # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
+  terragrunt validate ${args[@]}
+
+  # return exit code to common::per_dir_hook
+  local exit_code=$?
+  return $exit_code
+}
+
+[[ ${BASH_SOURCE[0]} != "$0" ]] || main "$@"

--- a/terrascan.sh
+++ b/terrascan.sh
@@ -1,75 +1,30 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-main() {
-  initialize_
-  parse_cmdline_ "$@"
-  terrascan_ "${ARGS[*]}" "${FILES[@]}"
+function main {
+  common::initialize
+  common::parse_cmdline "$@"
+  common::per_dir_hook "${ARGS[*]}" "${FILES[@]}"
 }
 
-terrascan_() {
-  local -r args="${1}"
-  shift 1
-  local -a -r files=("$@")
-
-  # consume modified files passed from pre-commit so that
-  # terrascan runs against only those relevant directories
-  for file_with_path in "${files[@]}"; do
-    file_with_path="${file_with_path// /__REPLACED__SPACE__}"
-    paths[index]=$(dirname "$file_with_path")
-    index=$((index + 1))
-  done
-
-  # allow terrascan to continue if exit_code is greater than 0
-  # preserve errexit status
-  shopt -qo errexit && ERREXIT_IS_SET=true
-  set +e
-  terrascan_final_exit_code=0
-
-  # for each path run terrascan
-  for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
-    path_uniq="${path_uniq//__REPLACED__SPACE__/ }"
-    pushd "$path_uniq" > /dev/null
-
-    # pass the arguments to terrascan
-    # shellcheck disable=SC2086 # terrascan fails when quoting is used ("$arg" vs $arg)
-    terrascan scan -i terraform $args
-
-    local exit_code=$?
-    if [ $exit_code != 0 ]; then
-      terrascan_final_exit_code=$exit_code
-    fi
-
-    popd > /dev/null
-  done
-
-  # restore errexit if it was set before the "for" loop
-  [[ $ERREXIT_IS_SET ]] && set -e
-  # return the terrascan final exit_code
-  exit $terrascan_final_exit_code
-}
-
-initialize_() {
+function common::initialize {
+  local SCRIPT_DIR
   # get directory containing this script
-  local dir
-  local source
-  source="${BASH_SOURCE[0]}"
-  while [[ -L $source ]]; do # resolve $source until the file is no longer a symlink
-    dir="$(cd -P "$(dirname "$source")" > /dev/null && pwd)"
-    source="$(readlink "$source")"
-    # if $source was a relative symlink, we need to resolve it relative to the path where the symlink file was located
-    [[ $source != /* ]] && source="$dir/$source"
-  done
-  _SCRIPT_DIR="$(dirname "$source")"
+  SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
   # source getopt function
   # shellcheck source=lib_getopt
-  . "$_SCRIPT_DIR/lib_getopt"
+  . "$SCRIPT_DIR/lib_getopt"
 }
 
-parse_cmdline_() {
-  declare argv
-  argv=$(getopt -o a: --long args: -- "$@") || return
+# common global arrays.
+# Populated in `parse_cmdline` and can used in hooks functions
+declare -a ARGS=()
+declare -a HOOK_CONFIG=()
+declare -a FILES=()
+function common::parse_cmdline {
+  local argv
+  argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
   eval "set -- $argv"
 
   for argv; do
@@ -79,17 +34,74 @@ parse_cmdline_() {
         ARGS+=("$1")
         shift
         ;;
+      -h | --hook-config)
+        shift
+        HOOK_CONFIG+=("$1;")
+        shift
+        ;;
       --)
         shift
-        FILES+=("$@")
+        FILES=("$@")
         break
         ;;
     esac
   done
 }
 
-# global arrays
-declare -a ARGS=()
-declare -a FILES=()
+function common::per_dir_hook {
+  local -r args="$1"
+  shift 1
+  local -a -r files=("$@")
+
+  # consume modified files passed from pre-commit so that
+  # hook runs against only those relevant directories
+  local index=0
+  for file_with_path in "${files[@]}"; do
+    file_with_path="${file_with_path// /__REPLACED__SPACE__}"
+
+    dir_paths[index]=$(dirname "$file_with_path")
+
+    ((index += 1))
+  done
+
+  # allow hook to continue if exit_code is greater than 0
+  # preserve errexit status
+  shopt -qo errexit && ERREXIT_IS_SET=true
+  set +e
+  local final_exit_code=0
+
+  # run hook for each path
+  for path_uniq in $(echo "${dir_paths[*]}" | tr ' ' '\n' | sort -u); do
+    path_uniq="${path_uniq//__REPLACED__SPACE__/ }"
+    pushd "$path_uniq" > /dev/null
+
+    per_dir_hook_unique_part "$args"
+
+    local exit_code=$?
+    if [ "$exit_code" != 0 ]; then
+      final_exit_code=$exit_code
+    fi
+
+    popd > /dev/null
+  done
+
+  # restore errexit if it was set before the "for" loop
+  [[ $ERREXIT_IS_SET ]] && set -e
+  # return the hook final exit_code
+  exit $final_exit_code
+}
+
+function per_dir_hook_unique_part {
+  # common logic located in common::per_dir_hook
+  local -r args="$1"
+
+  # pass the arguments to hook
+  # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
+  terrascan scan -i terraform ${args[@]}
+
+  # return exit code to common::per_dir_hook
+  local exit_code=$?
+  return $exit_code
+}
 
 [[ ${BASH_SOURCE[0]} != "$0" ]] || main "$@"

--- a/terrascan.sh
+++ b/terrascan.sh
@@ -21,6 +21,7 @@ function common::parse_cmdline {
   # common global arrays.
   # Populated via `common::parse_cmdline` and can be used inside hooks' functions
   declare -g -a ARGS=() FILES=() HOOK_CONFIG=()
+  declare -g -r HOOK_CONFIG_SEPARATOR='%%SEPARATOR%%'
 
   local argv
   argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
@@ -35,7 +36,7 @@ function common::parse_cmdline {
         ;;
       -h | --hook-config)
         shift
-        HOOK_CONFIG+=("$1;")
+        HOOK_CONFIG+=("${1}${HOOK_CONFIG_SEPARATOR}")
         shift
         ;;
       --)

--- a/terrascan.sh
+++ b/terrascan.sh
@@ -17,12 +17,11 @@ function common::initialize {
   . "$SCRIPT_DIR/lib_getopt"
 }
 
-# common global arrays.
-# Populated in `parse_cmdline` and can used in hooks functions
-declare -a ARGS=()
-declare -a HOOK_CONFIG=()
-declare -a FILES=()
 function common::parse_cmdline {
+  # common global arrays.
+  # Populated via `common::parse_cmdline` and can be used inside hooks' functions
+  declare -g -a ARGS=() FILES=() HOOK_CONFIG=()
+
   local argv
   argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
   eval "set -- $argv"

--- a/terrascan.sh
+++ b/terrascan.sh
@@ -72,7 +72,7 @@ function common::per_dir_hook {
   # run hook for each path
   for dir_path in $(echo "${dir_paths[*]}" | tr ' ' '\n' | sort -u); do
     dir_path="${dir_path//__REPLACED__SPACE__/ }"
-    pushd "$dir_path" > /dev/null
+    pushd "$dir_path" > /dev/null || continue
 
     per_dir_hook_unique_part "$args" "$dir_path"
 

--- a/terrascan.sh
+++ b/terrascan.sh
@@ -71,11 +71,11 @@ function common::per_dir_hook {
   local final_exit_code=0
 
   # run hook for each path
-  for path_uniq in $(echo "${dir_paths[*]}" | tr ' ' '\n' | sort -u); do
-    path_uniq="${path_uniq//__REPLACED__SPACE__/ }"
-    pushd "$path_uniq" > /dev/null
+  for dir_path in $(echo "${dir_paths[*]}" | tr ' ' '\n' | sort -u); do
+    dir_path="${dir_path//__REPLACED__SPACE__/ }"
+    pushd "$dir_path" > /dev/null
 
-    per_dir_hook_unique_part "$args"
+    per_dir_hook_unique_part "$args" "$dir_path"
 
     local exit_code=$?
     if [ "$exit_code" != 0 ]; then
@@ -94,6 +94,7 @@ function common::per_dir_hook {
 function per_dir_hook_unique_part {
   # common logic located in common::per_dir_hook
   local -r args="$1"
+  local -r dir_path="$2"
 
   # pass the arguments to hook
   # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")

--- a/terrascan.sh
+++ b/terrascan.sh
@@ -77,7 +77,7 @@ function common::per_dir_hook {
     per_dir_hook_unique_part "$args" "$dir_path"
 
     local exit_code=$?
-    if [ "$exit_code" != 0 ]; then
+    if [ $exit_code -ne 0 ]; then
       final_exit_code=$exit_code
     fi
 
@@ -104,4 +104,4 @@ function per_dir_hook_unique_part {
   return $exit_code
 }
 
-[[ ${BASH_SOURCE[0]} != "$0" ]] || main "$@"
+[ "${BASH_SOURCE[0]}" != "$0" ] || main "$@"

--- a/terrascan.sh
+++ b/terrascan.sh
@@ -64,9 +64,9 @@ function common::per_dir_hook {
     ((index += 1))
   done
 
-  # allow hook to continue if exit_code is greater than 0
   # preserve errexit status
   shopt -qo errexit && ERREXIT_IS_SET=true
+  # allow hook to continue if exit_code is greater than 0
   set +e
   local final_exit_code=0
 

--- a/terrascan.sh
+++ b/terrascan.sh
@@ -21,7 +21,6 @@ function common::parse_cmdline {
   # common global arrays.
   # Populated via `common::parse_cmdline` and can be used inside hooks' functions
   declare -g -a ARGS=() FILES=() HOOK_CONFIG=()
-  declare -g -r HOOK_CONFIG_SEPARATOR='%%SEPARATOR%%'
 
   local argv
   argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return
@@ -36,7 +35,7 @@ function common::parse_cmdline {
         ;;
       -h | --hook-config)
         shift
-        HOOK_CONFIG+=("${1}${HOOK_CONFIG_SEPARATOR}")
+        HOOK_CONFIG+=("$1;")
         shift
         ;;
       --)


### PR DESCRIPTION
Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [x] This PR enhances existing functionality.

### Description of your changes

Make hooks the as same as possible 
The next big thing will be to move the `common::` functions to separate file, and import them to all hooks.
Then, most of the hooks will look like this:

```bash
#!/usr/bin/env bash

. common.sh

function main {
  common::initialize
  common::parse_cmdline "$@"
  common::per_dir_hook "${ARGS[*]}" "${FILES[@]}"
}


function per_dir_hook_unique_part {
  # common logic located in common::per_dir_hook
  local -r args="$1"
  local -r dir_path="$2"

  # pass the arguments to hook
  # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
  terrascan scan -i terraform ${args[@]}

  # return exit code to common::per_dir_hook
  local exit_code=$?
  return $exit_code
}

[[ ${BASH_SOURCE[0]} != "$0" ]] || main "$@"
```


### How has this code been tested


```yaml
repos:
- repo: https://github.com/antonbabenko/pre-commit-terraform
  rev: a243f3f314de907b5c964d7adcb9e9fa128b7ac9
  hooks:
# all hooks
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

---

Merge will affect:
* https://github.com/antonbabenko/pre-commit-terraform/pull/155 (introduce small, but breaking changes)
* https://github.com/antonbabenko/pre-commit-terraform/pull/194 (already have big conflicts)
