### PR TITLE
fix(terragrunt_validate): Only run terragrunt_validate in valid direc…

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -82,7 +82,7 @@
   description: Validates all Terragrunt configuration files.
   entry: terragrunt_validate.sh
   language: script
-  files: (\.hcl)$
+  files: (/terragrunt\.hcl)$
   exclude: \.terraform\/.*$
 
 - id: terraform_tfsec


### PR DESCRIPTION
…tories (#191)

The command fails if there is no terragrunt.hcl file in the directory.

<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123":
-->

Fixes #191 

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Used this `files` pattern locally in my `.pre-commit-config.yaml` file and verified it no longer fails and still runs in desired directories. Using `(/terragrunt\.hcl)$` instead of `(terragrunt\.hcl)$` so files with a `terragrunt` suffix aren't matched, like `root_terragrunt.hcl`.
