### PR TITLE
chore: Add hadolint check for Dockerfiles

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -72,7 +72,7 @@ sudo apt install -y datamash
 ### Run via Docker
 
 ```bash
-# Build `pre-commit` image
+# Build `pre-commit-terraform` image
 docker build -t pre-commit-terraform --build-arg INSTALL_ALL=true .
 # Build test image
 docker build -t pre-commit-tests tests/

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -73,7 +73,7 @@ sudo apt install -y datamash
 
 ```bash
 # Build `pre-commit` image
-docker build -t pre-commit --build-arg INSTALL_ALL=true .
+docker build -t pre-commit-terraform --build-arg INSTALL_ALL=true .
 # Build test image
 docker build -t pre-commit-tests tests/
 # Run

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -25,19 +25,32 @@ jobs:
     - name: Install shellcheck
       run: |
         sudo apt update && sudo apt install shellcheck
+
+    - name: Install hadolint
+      run: |
+        curl -L "$(curl -s https://api.github.com/repos/hadolint/hadolint/releases/latest | grep -o -E -m 1 "https://.+?/hadolint-Linux-x86_64")" > hadolint \
+        && chmod +x hadolint && sudo mv hadolint /usr/bin/
     # Need to success pre-commit fix push
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
-
+    # Skip terraform_tflint which interferes to commit pre-commit auto-fixes
     - uses: actions/setup-python@v2
       with:
         python-version: '3.9'
     - name: Execute pre-commit
       uses: pre-commit/action@v2.0.0
       env:
-        SKIP: no-commit-to-branch
+        SKIP: no-commit-to-branch,hadolint
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
+        extra_args: --color=always --show-diff-on-failure --files ${{ steps.file_changes.outputs.files }}
+    # Run only skipped checks
+    - name: Execute pre-commit check that have no auto-fixes
+      if: always()
+      uses: pre-commit/action@v2.0.0
+      env:
+        SKIP: check-added-large-files,check-merge-conflict,check-vcs-permalinks,forbid-new-submodules,no-commit-to-branch,end-of-file-fixer,trailing-whitespace,check-yaml,check-merge-conflict,check-executables-have-shebangs,check-case-conflict,mixed-line-ending,detect-aws-credentials,detect-private-key,shfmt,shellcheck
+      with:
         extra_args: --color=always --show-diff-on-failure --files ${{ steps.file_changes.outputs.files }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.0.1
+  rev: v4.1.0
   hooks:
     # Git style
     - id: check-added-large-files
@@ -34,3 +34,18 @@ repos:
     - id: shfmt
       args: ['-l', '-i', '2', '-ci', '-sr', '-w']
     - id: shellcheck
+
+# Dockerfile linter
+- repo: https://github.com/hadolint/hadolint
+  rev: v2.8.0
+  hooks:
+    - id: hadolint
+      args: [
+        '--ignore', 'DL3027', # Do not use apt
+        '--ignore', 'DL3007', # Using latest
+        '--ignore', 'DL4006', # Not related to alpine
+        '--ignore', 'SC1091', # Useless check
+        '--ignore', 'SC2015', # Useless check
+        '--ignore', 'SC3037', # Not related to alpine
+        '--ignore', 'DL3013', # Pin versions in pip
+      ]

--- a/hooks/infracost_breakdown.sh
+++ b/hooks/infracost_breakdown.sh
@@ -73,8 +73,8 @@ function infracost_breakdown_ {
     }; then
       check="${check:1:-1}"
     fi
-    # shellcheck disable=SC2207 # Can't find working `read` command
-    operations=($(echo "$check" | grep -oE '[!<>=]{1,2}'))
+
+    mapfile -t operations < <(echo "$check" | grep -oE '[!<>=]{1,2}')
     # Get the very last operator, that is used in comparison inside `jq` query.
     # From the example below we need to pick the `>` which is in between `add` and `1000`,
     # but not the `!=`, which goes earlier in the `jq` expression

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM pre-commit:latest
+FROM pre-commit-terraform:latest
 
 RUN apt update && \
     apt install -y \

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM pre-commit
+FROM pre-commit:latest
 
 RUN apt update && \
     apt install -y \


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [x] This PR enhances existing functionality.

### Description of your changes

This PR is partly a subset of #319 originally made by @balihb, partly inspired by #319 PR.
It includes:
* [`hadolint`](https://github.com/hadolint/hadolint) check for Dockerfiles
* Fix Dockefiles issues
* Fix `infracost_breakdown` shellcheck issue. (other introduced fix not works)
* Fix performance test docker image, forgotten during refactoring a few months ago.

### How can we test changes

```yaml
repos:
- repo: https://github.com/antonbabenko/pre-commit-terraform
  rev: 7e34de024972344787a1704e5952f812148aa33b
  hooks:
    - id: infracost_breakdown
      args:
        - --args=--path=./environment/qa
        - --hook-config='.totalHourlyCost >= 0.1'
        - --hook-config=".totalHourlyCost|tonumber > 1"
        - -h ".projects[].diff.totalMonthlyCost|tonumber!=10000"
        - -h [.projects[].diff.totalMonthlyCost | select (.!=null) | tonumber] | add > 1000
      verbose: true # Always show costs
```
