### PR TITLE
feat: Make checkov more flexible

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -95,9 +95,9 @@
 - id: checkov
   name: Checkov
   description: Runs checkov on Terraform templates.
-  entry: hooks/checkov -d .
-  language: python
-  pass_filenames: false
+  entry: hooks/checkov.sh
+  language: script
+  pass_filenames: true
   always_run: false
   files: \.tf$
   exclude: \.terraform\/.*$

--- a/README.md
+++ b/README.md
@@ -238,10 +238,12 @@ For [checkov](https://github.com/bridgecrewio/checkov) you need to specify each 
 ```yaml
 - id: checkov
   args: [
-    "-d", ".",
+    "-d", "./mod1",
     "--skip-check", "CKV2_AWS_8",
   ]
 ```
+
+By default, `checkov` will scan the entire repository's terraform files. You can use the `--scan-change-directories` or `--scan-change-files` arguments, to restrict the scan to changed directories or terraform files (if both of these are provided, the directory command will take precedence). Any other arguments provided will be passed through to checkov.
 
 ### infracost_breakdown
 

--- a/hooks/checkov.sh
+++ b/hooks/checkov.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+#######################################################################
+# Wrapper function for hook. Determines run mode based on bool set by
+# argparse, and triggers that run mode.
+# Globals:
+#   None
+# Arguments:
+#   None
+# Returns:
+#   0 if successful, non-zero on error
+#######################################################################
+function main {
+  parse_arguments "$@"
+  # shellcheck disable=SC2153 # False positive
+  if [[ ${CHANGE_DIRECTORY_SCAN} == true ]]; then
+    # directories containing changed .tf files only
+    directory_runner
+  elif [[ ${CHANGE_FILE_SCAN} == true ]]; then
+    # changed .tf files only
+    file_runner
+  else
+    # whole repository
+    checkov "${ARGS[@]}" -d .
+  fi
+}
+
+#######################################################################
+# Parses arguments provided to the hook to filter out changed files and
+# args for the hook, set run mode (if present) and remove run mode toggles
+# from the args as they're not valid for checkov. Enables backwards
+# compatibility for those using checkov with no args, or without --args
+# Globals:
+#   None
+# Arguments:
+#   None
+# Returns:
+#   0 if successful, non-zero on error
+#   Creates global arrays ARGS, FILES, may create a run mode global
+#######################################################################
+function parse_arguments {
+  declare -a -g ARGS=()
+  declare -a -g FILES=()
+
+  argv=("$@")
+  pattern='^.*\.tf$'
+
+  for item in "${argv[@]}"; do
+    if [[ $item =~ $pattern ]]; then
+      FILES+=("$item")
+    else
+      case $item in
+        --scan-change-directories)
+          CHANGE_DIRECTORY_SCAN=true
+          ;;
+        --scan-change-files)
+          CHANGE_FILE_SCAN=true
+          ;;
+        # -f filtered out to avoid duplicating
+        -f | --file)
+          :
+          ;;
+        *)
+          ARGS+=("$item")
+          ;;
+      esac
+    fi
+  done
+}
+
+#######################################################################
+# Identifies directories containing files that have changed in them, builds
+# a command string from them, and then runs checkov against those dirs
+# with args provided to hook.
+# Globals:
+#   FILES
+#   ARGS
+# Arguments:
+#   None
+# Returns:
+#   0 if successful, non-zero on error
+#######################################################################
+function directory_runner {
+  declare -a directories=()
+  declare -a directory_command=()
+
+  for file_with_path in "${FILES[@]}"; do
+    directory=$(dirname "$file_with_path")
+    directories+=("$directory")
+  done
+
+  for dir in $(echo "${directories[*]}" | tr ' ' '\n' | sort -u); do
+    directory_command+=("-d")
+    directory_command+=("$dir")
+  done
+
+  checkov "${ARGS[@]}" "${directory_command[@]}"
+}
+
+#######################################################################
+# Builds a command string from the files provided, and runs checkov against
+# those files with args provided to hook. This is the fastest run mode.
+# Globals:
+#   FILES
+#   ARGS
+# Arguments:
+#   None
+# Returns:
+#   0 if successful, non-zero on error
+#######################################################################
+function file_runner {
+  declare -a file_command=()
+
+  for file in "${FILES[@]}"; do
+    file_command+=("-f")
+    file_command+=("$file")
+  done
+
+  checkov "${ARGS[@]}" "${file_command[@]}"
+}
+
+[ "${BASH_SOURCE[0]}" != "$0" ] || main "$@"


### PR DESCRIPTION
Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [X] This PR enhances existing functionality.

### Description of your changes

Currently, the checkov hook is hard-coded to run against the entire directory - no override is possible.

This change allows the hook to run in any of three modes - whole directory (the default), against all directories which contain a changed file, and against only changed files.

It should be noted that:

- There is a PR in place for similar but different functionality; the disparity between the two approaches I thought was sufficient to justify a separate PR as the code and logic is very different. I will post a link to this PR in that PR's discussion to raise the question as to which route should be followed.
- Common scripts were not used deliberately; this is for two reasons. 1. Using the `common::parse_cmdline` function would've forced the introduction of a breaking change (having to preface all arguments with `--args`) and 2. Using the `common::per_dir_hook` function would have removed the ability to pass multiple arguments to checkov, as the code block at line 70 assumes that only $1 is an argument and the rest are files.

### How can we test changes

- Use a dummy IaC repo with multiple modules and known security issues
- Use `pre-commit try-repo $path/to/clone` to confirm the default behaviour is still scanning the entire repository
- Use manual script runs of `checkov.sh` from within that dummy directory to confirm that when passed `--scan-change-directories` (and file names), the tool only scans directories that contain a change file, and while passed `--scan-change-files`, the tool only scans files, as well as any other changes and logic deemed necessary.