### PR TITLE
feat: Improved speed of `pre-commit run -a` for multiple hooks

### DIFF
--- a/hooks/terraform_tfsec.sh
+++ b/hooks/terraform_tfsec.sh
@@ -43,4 +43,22 @@ function per_dir_hook_unique_part {
   return $exit_code
 }
 
+#######################################################################
+# Unique part of `common::per_dir_hook`. The function is executed one time
+# in the root git repo
+# Arguments:
+#   args (string with array) arguments that configure wrapped tool behavior
+#######################################################################
+function run_hook_on_whole_repo {
+  local -r args="$1"
+
+  # pass the arguments to hook
+  # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
+  tfsec "$(pwd)" ${args[@]}
+
+  # return exit code to common::per_dir_hook
+  local exit_code=$?
+  return $exit_code
+}
+
 [ "${BASH_SOURCE[0]}" != "$0" ] || main "$@"

--- a/hooks/terragrunt_fmt.sh
+++ b/hooks/terragrunt_fmt.sh
@@ -40,4 +40,22 @@ function per_dir_hook_unique_part {
   return $exit_code
 }
 
+#######################################################################
+# Unique part of `common::per_dir_hook`. The function is executed one time
+# in the root git repo
+# Arguments:
+#   args (string with array) arguments that configure wrapped tool behavior
+#######################################################################
+function run_hook_on_whole_repo {
+  local -r args="$1"
+
+  # pass the arguments to hook
+  # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
+  terragrunt hclfmt "$(pwd)" ${args[@]}
+
+  # return exit code to common::per_dir_hook
+  local exit_code=$?
+  return $exit_code
+}
+
 [ "${BASH_SOURCE[0]}" != "$0" ] || main "$@"

--- a/hooks/terragrunt_validate.sh
+++ b/hooks/terragrunt_validate.sh
@@ -40,4 +40,22 @@ function per_dir_hook_unique_part {
   return $exit_code
 }
 
+#######################################################################
+# Unique part of `common::per_dir_hook`. The function is executed one time
+# in the root git repo
+# Arguments:
+#   args (string with array) arguments that configure wrapped tool behavior
+#######################################################################
+function run_hook_on_whole_repo {
+  local -r args="$1"
+
+  # pass the arguments to hook
+  # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
+  terragrunt run-all validate ${args[@]}
+
+  # return exit code to common::per_dir_hook
+  local exit_code=$?
+  return $exit_code
+}
+
 [ "${BASH_SOURCE[0]}" != "$0" ] || main "$@"


### PR DESCRIPTION
…m_tfsec`, `terragrunt_fmt` and `terragrunt_validate`

<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [x] This PR enhances existing functionality.

### Description of your changes

Speedup hooks execution on `pre-commit run --all`

Closes #309

### How can we test changes

```yaml
repos:
- repo: https://github.com/antonbabenko/pre-commit-terraform
  rev: 7ebbe57df62dce6d50cfe11a12566850d96a9613
  hooks:
    - id: terraform_tfsec
      #args:
      #  - >
      #    --args=--config-file=.tfsec.json
    - id: terragrunt_fmt
    - id: terragrunt_validate
```