### PR TITLE
fix: Make hooks bash 3.2 compatible

### DIFF
--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -27,7 +27,7 @@ function common::initialize {
 function common::parse_cmdline {
   # common global arrays.
   # Populated via `common::parse_cmdline` and can be used inside hooks' functions
-  declare -g -a ARGS=() HOOK_CONFIG=() FILES=()
+  ARGS=() HOOK_CONFIG=() FILES=()
 
   local argv
   argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

In new versions, macOS use `zsh` by default and include bash 3.2 for compatibility reasons.
That OS will never upgrade bash to 4+, during license issues.
[theverge.com/2019/6/4/18651872/apple-macos-catalina-zsh-bash-shell-replacement-features](https://www.theverge.com/2019/6/4/18651872/apple-macos-catalina-zsh-bash-shell-replacement-features)

So looks like we need to maintain compatibility with bash 3.2 🙄
**Or require bash 4.2+ as deps.**

Fixes #337

### How can we test changes

Run on macOS:

```yaml
repos:
- repo: https://github.com/antonbabenko/pre-commit-terraform
  rev: 48bc03ca3f0f2f782d2f430069868019a6892062
  hooks:
    - id: terraform_fmt
```
