### PR TITLE
chore: Fix docker test workflow

### DIFF
--- a/.github/workflows/build-image-test.yaml
+++ b/.github/workflows/build-image-test.yaml
@@ -19,7 +19,7 @@ jobs:
             Dockerfile
 
       - name: Build if Dockerfile changed
-        if: steps.changed-files-specific.outputs.any_changed == "true"
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
         uses: docker/build-push-action@v2
         with:
           context: .

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -27,7 +27,7 @@ function common::initialize {
 function common::parse_cmdline {
   # common global arrays.
   # Populated via `common::parse_cmdline` and can be used inside hooks' functions
-  ARGS=() HOOK_CONFIG=() FILES=()
+  declare -g -a ARGS=() HOOK_CONFIG=() FILES=()
 
   local argv
   argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -27,7 +27,7 @@ function common::initialize {
 function common::parse_cmdline {
   # common global arrays.
   # Populated via `common::parse_cmdline` and can be used inside hooks' functions
-  declare -g -a ARGS=() HOOK_CONFIG=() FILES=()
+  ARGS=() HOOK_CONFIG=() FILES=()
 
   local argv
   argv=$(getopt -o a:,h: --long args:,hook-config: -- "$@") || return


### PR DESCRIPTION
Invalid workflow file: .github/workflows/build-image-test.yaml#L22
The workflow is not valid. .github/workflows/build-image-test.yaml (Line: 22, Col: 13): Unexpected symbol: '"true"'. Located at position 53 within expression: steps.changed-files-specific.outputs.any_changed == "true"
