### PR TITLE
feat: Adding getopt flag and feature: --env-passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,7 +303,7 @@ All notable changes to this project will be documented in this file.
 
 - fix: Change terraform_validate hook functionality for subdirectories with terraform files ([#100](https://github.com/antonbabenko/pre-commit-terraform/issues/100))
 
-### 
+###
 
 configuration for the appropriate working directory.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -331,7 +331,7 @@ All notable changes to this project will be documented in this file.
 
 - fix: Change terraform_validate hook functionality for subdirectories with terraform files ([#100](https://github.com/antonbabenko/pre-commit-terraform/issues/100))
 
-###
+### 
 
 configuration for the appropriate working directory.
 

--- a/hooks/infracost_breakdown.sh
+++ b/hooks/infracost_breakdown.sh
@@ -13,6 +13,7 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 function main {
   common::initialize "$SCRIPT_DIR"
   common::parse_cmdline "$@"
+  common::passthrough_env_vars
   # shellcheck disable=SC2153 # False positive
   infracost_breakdown_ "${HOOK_CONFIG[*]}" "${ARGS[*]}"
 }

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -13,6 +13,7 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 function main {
   common::initialize "$SCRIPT_DIR"
   common::parse_cmdline "$@"
+  common::passthrough_env_vars
   # Support for setting relative PATH to .terraform-docs.yml config.
   # shellcheck disable=SC2178 # It's the simplest syntax for that case
   ARGS=${ARGS[*]/--config=/--config=$(pwd)\/}

--- a/hooks/terraform_fmt.sh
+++ b/hooks/terraform_fmt.sh
@@ -13,6 +13,7 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 function main {
   common::initialize "$SCRIPT_DIR"
   common::parse_cmdline "$@"
+  common::passthrough_env_vars
   # shellcheck disable=SC2153 # False positive
   terraform_fmt_ "${ARGS[*]}" "${FILES[@]}"
 }

--- a/hooks/terraform_providers_lock.sh
+++ b/hooks/terraform_providers_lock.sh
@@ -13,6 +13,7 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 function main {
   common::initialize "$SCRIPT_DIR"
   common::parse_cmdline "$@"
+  common::passthrough_env_vars
   # shellcheck disable=SC2153 # False positive
   common::per_dir_hook "${ARGS[*]}" "$HOOK_ID" "${FILES[@]}"
 }

--- a/hooks/terraform_tflint.sh
+++ b/hooks/terraform_tflint.sh
@@ -13,6 +13,7 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 function main {
   common::initialize "$SCRIPT_DIR"
   common::parse_cmdline "$@"
+  common::passthrough_env_vars
   # Support for setting PATH to repo root.
   # shellcheck disable=SC2178 # It's the simplest syntax for that case
   ARGS=${ARGS[*]/__GIT_WORKING_DIR__/$(pwd)\/}

--- a/hooks/terraform_tfsec.sh
+++ b/hooks/terraform_tfsec.sh
@@ -12,6 +12,7 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 function main {
   common::initialize "$SCRIPT_DIR"
   common::parse_cmdline "$@"
+  common::passthrough_env_vars
   # Support for setting PATH to repo root.
   # shellcheck disable=SC2178 # It's the simplest syntax for that case
   ARGS=${ARGS[*]/__GIT_WORKING_DIR__/$(pwd)\/}

--- a/hooks/terragrunt_fmt.sh
+++ b/hooks/terragrunt_fmt.sh
@@ -12,6 +12,8 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 function main {
   common::initialize "$SCRIPT_DIR"
   common::parse_cmdline "$@"
+  common::passthrough_env_vars
+
   # shellcheck disable=SC2153 # False positive
   common::per_dir_hook "${ARGS[*]}" "$HOOK_ID" "${FILES[@]}"
 }

--- a/hooks/terragrunt_validate.sh
+++ b/hooks/terragrunt_validate.sh
@@ -12,6 +12,7 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 function main {
   common::initialize "$SCRIPT_DIR"
   common::parse_cmdline "$@"
+  common::passthrough_env_vars
   # shellcheck disable=SC2153 # False positive
   common::per_dir_hook "${ARGS[*]}" "$HOOK_ID" "${FILES[@]}"
 }

--- a/hooks/terrascan.sh
+++ b/hooks/terrascan.sh
@@ -12,6 +12,7 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 function main {
   common::initialize "$SCRIPT_DIR"
   common::parse_cmdline "$@"
+  common::passthrough_env_vars
   # shellcheck disable=SC2153 # False positive
   common::per_dir_hook "${ARGS[*]}" "$HOOK_ID" "${FILES[@]}"
 }


### PR DESCRIPTION
<!-- Thank you for helping to improve pre-commit-terraform! -->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug. 
- [X] This PR adds new functionality.
- [X] This PR enhances existing functionality.

### Description of your changes

Context: I need to pass in the location of an alternate `tflint` config in CI.
The location is based on an environment variable in my CI environment, so
hard-coding the value as an argument isn't tenable.

This PR adds the `__ENV_*__` placeholder, and the argument `--env-passthrough`.
The idea is to replace the `__ENV_FOO__` placeholder with the value of
environment variable `${FOO}`.

Example config leveraging the changes in this PR:

```
repos:
  - repo: https://github.com/antonbabenko/pre-commit-terraform
    rev: v1.65.0
    hooks:
      - id: terraform_tflint
        args:
          - "--env-passthrough=FOO"
          - "--args=--config=__ENV_FOO__/.tflint.hcl"
```

_Note: hooks which do not use the common argument parser in `_common.sh` were not modified to use this functionality_
<!-- Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours
does, you can uncomment the below line to indicate which issue your PR fixes,
for example "Fixes #123": -->

<!-- Fixes # -->

### How can we test changes

- From AWS Codebuild:
`pre-commit try-repo https://andrew-glenn/pc-sandbox env-debug`

For transparency, here's the `.pre-commit-hooks.yaml` config in my sandbox repo
https://github.com/andrew-glenn/pc-sandbox/blob/abcdad5b40aee08484185451912b8ad191f80138/.pre-commit-hooks.yaml

as well as the script that echo's args passed to it:

https://github.com/andrew-glenn/pc-sandbox/blob/abcdad5b40aee08484185451912b8ad191f80138/env.sh#L1-L19

- Others:

Modify your local `.pre-commit-config` file to add my sandbox repo, replacing
`FOO` with an environment variable name of your choice.

```
repos:
  - repo: https://github.com/andrew-glenn/pc-sandbox
    rev: abcdad5b40aee08484185451912b8ad191f80138
    hooks:
      - id: env-debug
        args:
          - "--env-passthrough=FOO"
          - "--args=--config=__ENV_FOO__"
```

Example output:
```
===============================================================================
[INFO] Initializing environment for https://github.com/andrew-glenn/pc-sandbox.
env debug................................................................Passed
- hook id: env-debug
- duration: 0.01s

--foo=/codebuild/output/src982431412/src
```
<!-- Before reviewers can be confident in the correctness of this pull request,
it needs to tested and shown to be correct. Briefly describe the testing that
has already been done or which is planned for this change. -->

