### PR TITLE
fix: Print out the full path in tflint when run through pre-commit

### DIFF
--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -138,7 +138,7 @@ function common::per_dir_hook {
   # run hook for each path
   for dir_path in $(echo "${dir_paths[*]}" | tr ' ' '\n' | sort -u); do
     dir_path="${dir_path//__REPLACED__SPACE__/ }"
-    pushd "$dir_path" > /dev/null || continue
+    [ -f "$dir_path" ] || continue
 
     per_dir_hook_unique_part "$args" "$dir_path"
 
@@ -147,7 +147,6 @@ function common::per_dir_hook {
       final_exit_code=$exit_code
     fi
 
-    popd > /dev/null
   done
 
   # restore errexit if it was set before the "for" loop

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -138,7 +138,7 @@ function common::per_dir_hook {
   # run hook for each path
   for dir_path in $(echo "${dir_paths[*]}" | tr ' ' '\n' | sort -u); do
     dir_path="${dir_path//__REPLACED__SPACE__/ }"
-    [ -f "$dir_path" ] || continue
+    [ ! -d "$dir_path" ] && continue
 
     per_dir_hook_unique_part "$args" "$dir_path"
 

--- a/hooks/terraform_fmt.sh
+++ b/hooks/terraform_fmt.sh
@@ -58,7 +58,7 @@ function terraform_fmt_ {
   # run hook for each path
   for dir_path in $(echo "${dir_paths[*]}" | tr ' ' '\n' | sort -u); do
     dir_path="${dir_path//__REPLACED__SPACE__/ }"
-    pushd "$dir_path" > /dev/null || continue
+    [ ! -d "$dir_path" ] && continue
 
     per_dir_hook_unique_part "$args" "$dir_path"
 
@@ -67,7 +67,6 @@ function terraform_fmt_ {
       final_exit_code=$exit_code
     fi
 
-    popd > /dev/null
   done
 
   # TODO: Unique part

--- a/hooks/terraform_fmt.sh
+++ b/hooks/terraform_fmt.sh
@@ -105,7 +105,7 @@ function per_dir_hook_unique_part {
 
   # pass the arguments to hook
   # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
-  terraform fmt ${args[@]}
+  terraform fmt ${args[@]} "$dir_path"
 
   # return exit code to common::per_dir_hook
   local exit_code=$?

--- a/hooks/terraform_providers_lock.sh
+++ b/hooks/terraform_providers_lock.sh
@@ -44,7 +44,7 @@ function per_dir_hook_unique_part {
 
   # pass the arguments to hook
   # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
-  terraform providers lock ${args[@]}
+  terraform providers lock ${args[@]} "$dir_path"
 
   # return exit code to common::per_dir_hook
   local exit_code=$?

--- a/hooks/terraform_tflint.sh
+++ b/hooks/terraform_tflint.sh
@@ -36,11 +36,11 @@ function per_dir_hook_unique_part {
 
   # Print checked PATH **only** if TFLint have any messages
   # shellcheck disable=SC2091,SC2068 # Suppress error output
-  $(tflint ${args[@]} 2>&1) 2> /dev/null || {
+  $(tflint ${args[@]} "$dir_path" 2>&1) 2> /dev/null || {
     common::colorify "yellow" "TFLint in $dir_path/:"
 
     # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
-    tflint ${args[@]}
+    tflint ${args[@]} "$dir_path"
   }
 
   # return exit code to common::per_dir_hook

--- a/hooks/terraform_tfsec.sh
+++ b/hooks/terraform_tfsec.sh
@@ -36,7 +36,7 @@ function per_dir_hook_unique_part {
 
   # pass the arguments to hook
   # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
-  tfsec ${args[@]}
+  tfsec ${args[@]} "$dir_path"
 
   # return exit code to common::per_dir_hook
   local exit_code=$?

--- a/hooks/terragrunt_fmt.sh
+++ b/hooks/terragrunt_fmt.sh
@@ -33,7 +33,7 @@ function per_dir_hook_unique_part {
 
   # pass the arguments to hook
   # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
-  terragrunt hclfmt ${args[@]}
+  terragrunt hclfmt ${args[@]} "$dir_path"
 
   # return exit code to common::per_dir_hook
   local exit_code=$?

--- a/hooks/terragrunt_validate.sh
+++ b/hooks/terragrunt_validate.sh
@@ -33,7 +33,7 @@ function per_dir_hook_unique_part {
 
   # pass the arguments to hook
   # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
-  terragrunt validate ${args[@]}
+  terragrunt validate ${args[@]} "$dir_path"
 
   # return exit code to common::per_dir_hook
   local exit_code=$?

--- a/hooks/terrascan.sh
+++ b/hooks/terrascan.sh
@@ -33,7 +33,7 @@ function per_dir_hook_unique_part {
 
   # pass the arguments to hook
   # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
-  terrascan scan -i terraform ${args[@]}
+  terrascan scan -i terraform ${args[@]} "$dir_path"
 
   # return exit code to common::per_dir_hook
   local exit_code=$?


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123":
-->
This PR aims to fix the issue here: https://github.com/antonbabenko/pre-commit-terraform/issues/54

The issue for tflint is resolved by running the pre-commit at the repo level and the full path is then displayed on an error. 

### How can we test changes

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

```yaml
repos:
- repo: https://github.com/thomaslast/pre-commit-terraform
  rev: afde258978090e4d2382fd90bb230347d0b349ac
```

✅ Work as expected 
☑️ - Able to check only passed, not fail scenario
✖️ - work, but not print full path
❌ - failed to start
Not checked

✅ `checkov` (python, not affected hook)
✅ `infracost_breakdown`
✅ `terraform_docs_replace` (deprecated, python, not affected hook)
✖️ `terraform_docs_without_aggregate_type_defaults`
✖️  `terraform_docs`
✅  `terraform_fmt`
❌ `terraform_providers_lock`
❌   `terraform_tflint`
✅  `terraform_tfsec`
☑️  `terraform_validate`
✖️  `terragrunt_fmt`
☑️  `terragrunt_validate`
❌  `terrascan`