### PR TITLE
chore: Fix docker test pipeline

### DIFF
--- a/.github/workflows/build-image-test.yaml
+++ b/.github/workflows/build-image-test.yaml
@@ -28,4 +28,4 @@ jobs:
           platforms: linux/amd64
           push: false
           tags: |
-            ghcr.io/${{ github.repository }}:${{ env.IMAGE_TAG }}
+            ghcr.io/${{ github.repository }}:pr-test


### PR DESCRIPTION
Pipeline needs a valid image tag to be able to run
