### PR TITLE
feat: Allow env vars expansion in `--args` section for all hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ If you are using `pre-commit-terraform` already or want to support its developme
   * [4. Run](#4-run)
 * [Available Hooks](#available-hooks)
 * [Hooks usage notes and examples](#hooks-usage-notes-and-examples)
+  * [All hooks: Usage of environment variables in `--args`](#all-hooks-usage-of-environment-variables-in---args)
   * [checkov (deprecated) and terraform_checkov](#checkov-deprecated-and-terraform_checkov)
   * [infracost_breakdown](#infracost_breakdown)
   * [terraform_docs](#terraform_docs)
@@ -239,6 +240,24 @@ There are several [pre-commit](https://pre-commit.com/) hooks to keep Terraform 
 Check the [source file](https://github.com/antonbabenko/pre-commit-terraform/blob/master/.pre-commit-hooks.yaml) to know arguments used for each hook.
 
 ## Hooks usage notes and examples
+
+### All hooks: Usage of environment variables in `--args`
+
+> All, except deprecated hooks: `checkov`, `terraform_docs_replace`
+
+You can use environment variables for the `--args` section.  
+Note: You _must_ use the `${ENV_VAR}` definition, `$ENV_VAR` will not expand.
+
+Config example:
+
+```yaml
+- id: terraform_tflint
+  args:
+  - --args=--config=${CONFIG_NAME}.${CONFIG_EXT}
+  - --args=--module
+```
+
+If for config above set up `export CONFIG_NAME=.tflint; export CONFIG_EXT=hcl` before `pre-commit run`, args will be expanded to `--config=.tflint.hcl --module`.
 
 ### checkov (deprecated) and terraform_checkov
 

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -70,7 +70,7 @@ function common::parse_and_export_env_vars {
 
     # Repeat until all env vars will be expanded
     while true; do
-      # Check is at least 1 env var exist in $arg
+      # Check if at least 1 env var exists in `$arg`
       # shellcheck disable=SC2016 # '${' should not be expanded
       if [[ "$arg" =~ .*'${'[A-Z_][A-Z0-9_]+?'}'.* ]]; then
         tmp=${arg#*$\{}
@@ -78,7 +78,7 @@ function common::parse_and_export_env_vars {
         env_var_value="${!env_var_name}"
         # shellcheck disable=SC2016 # '${' should not be expanded
         common::colorify "green" 'Found ${'"$env_var_name"'} in:        '"'$arg'"
-        # Replace env var name with it value.
+        # Replace env var name with its value.
         # $arg will be checked in if, $ARGS will be used in next functions.
         # shellcheck disable=SC2016 # '${' should not be expanded
         arg=${arg/'${'$env_var_name'}'/$env_var_value}

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -79,7 +79,7 @@ function common::parse_and_export_env_vars {
         # shellcheck disable=SC2016 # '${' should not be expanded
         common::colorify "green" 'Found ${'"$env_var_name"'} in:        '"'$arg'"
         # Replace env var name with its value.
-        # `$arg` will be checked in `if`, `$ARGS` will be used in the next functions.
+        # `$arg` will be checked in `if` conditional, `$ARGS` will be used in the next functions.
         # shellcheck disable=SC2016 # '${' should not be expanded
         arg=${arg/'${'$env_var_name'}'/$env_var_value}
         ARGS[$i]=$arg

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -62,10 +62,10 @@ function common::parse_cmdline {
 #   ARGS (array) arguments that configure wrapped tool behavior
 #######################################################################
 function common::parse_and_export_env_vars {
-  local arg
+  local arg_idx
 
   for arg_idx in "${!ARGS[@]}"; do
-    arg="${ARGS[$arg_idx]}"
+    local arg="${ARGS[$arg_idx]}"
 
     # Repeat until all env vars will be expanded
     while true; do
@@ -73,9 +73,9 @@ function common::parse_and_export_env_vars {
       # shellcheck disable=SC2016 # '${' should not be expanded
       if [[ "$arg" =~ .*'${'[A-Z_][A-Z0-9_]+?'}'.* ]]; then
         # Get `ENV_VAR` from `.*${ENV_VAR}.*`
-        env_var_name=${arg#*$\{}
+        local env_var_name=${arg#*$\{}
         env_var_name=${env_var_name%%\}*}
-        env_var_value="${!env_var_name}"
+        local env_var_value="${!env_var_name}"
         # shellcheck disable=SC2016 # '${' should not be expanded
         common::colorify "green" 'Found ${'"$env_var_name"'} in:        '"'$arg'"
         # Replace env var name with its value.

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -62,7 +62,6 @@ function common::parse_cmdline {
 #   ARGS (array) arguments that configure wrapped tool behavior
 #######################################################################
 function common::parse_and_export_env_vars {
-  local -r len=${#ARGS[@]}
   local arg
 
   for arg_idx in "${!ARGS[@]}"; do

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -79,7 +79,7 @@ function common::parse_and_export_env_vars {
         # shellcheck disable=SC2016 # '${' should not be expanded
         common::colorify "green" 'Found ${'"$env_var_name"'} in:        '"'$arg'"
         # Replace env var name with its value.
-        # $arg will be checked in if, $ARGS will be used in next functions.
+        # `$arg` will be checked in `if`, `$ARGS` will be used in the next functions.
         # shellcheck disable=SC2016 # '${' should not be expanded
         arg=${arg/'${'$env_var_name'}'/$env_var_value}
         ARGS[$i]=$arg

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -74,7 +74,7 @@ function common::parse_and_export_env_vars {
       # shellcheck disable=SC2016 # '${' should not be expanded
       if [[ "$arg" =~ .*'${'[A-Z_][A-Z0-9_]+?'}'.* ]]; then
         env_var_name=${arg#*$\{}
-        env_var_name=$(cut -d'}' -f1 <<< "$tmp")
+        env_var_name=$(cut -d'}' -f1 <<< "$env_var_name")
         env_var_value="${!env_var_name}"
         # shellcheck disable=SC2016 # '${' should not be expanded
         common::colorify "green" 'Found ${'"$env_var_name"'} in:        '"'$arg'"

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -73,7 +73,7 @@ function common::parse_and_export_env_vars {
       # Check if at least 1 env var exists in `$arg`
       # shellcheck disable=SC2016 # '${' should not be expanded
       if [[ "$arg" =~ .*'${'[A-Z_][A-Z0-9_]+?'}'.* ]]; then
-        tmp=${arg#*$\{}
+        env_var_name=${arg#*$\{}
         env_var_name=$(cut -d'}' -f1 <<< "$tmp")
         env_var_value="${!env_var_name}"
         # shellcheck disable=SC2016 # '${' should not be expanded

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -68,7 +68,9 @@ function common::parse_and_export_env_vars {
   for ((i = 0; i < len; i++)); do
     arg="${ARGS[$i]}"
 
+    # Repeat until all env vars will be expanded
     while true; do
+      # Check is at least 1 env var exist in $arg
       # shellcheck disable=SC2016 # '${' should not be expanded
       if [[ "$arg" =~ .*'${'[A-Z_][A-Z0-9_]+?'}'.* ]]; then
         tmp=${arg#*$\{}
@@ -76,6 +78,8 @@ function common::parse_and_export_env_vars {
         env_var_value="${!env_var_name}"
         # shellcheck disable=SC2016 # '${' should not be expanded
         common::colorify "green" 'Found ${'"$env_var_name"'} in:        '"'$arg'"
+        # Replace env var name with it value.
+        # $arg will be checked in if, $ARGS will be used in next functions.
         # shellcheck disable=SC2016 # '${' should not be expanded
         arg=${arg/'${'$env_var_name'}'/$env_var_value}
         ARGS[$i]=$arg

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -73,8 +73,9 @@ function common::parse_and_export_env_vars {
       # Check if at least 1 env var exists in `$arg`
       # shellcheck disable=SC2016 # '${' should not be expanded
       if [[ "$arg" =~ .*'${'[A-Z_][A-Z0-9_]+?'}'.* ]]; then
+        # Get `ENV_VAR` from `.*${ENV_VAR}.*`
         env_var_name=${arg#*$\{}
-        env_var_name=$(cut -d'}' -f1 <<< "$env_var_name")
+        env_var_name=${env_var_name%%\}*}
         env_var_value="${!env_var_name}"
         # shellcheck disable=SC2016 # '${' should not be expanded
         common::colorify "green" 'Found ${'"$env_var_name"'} in:        '"'$arg'"

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -65,8 +65,8 @@ function common::parse_and_export_env_vars {
   local -r len=${#ARGS[@]}
   local arg
 
-  for ((i = 0; i < len; i++)); do
-    arg="${ARGS[$i]}"
+  for arg_idx in "${!ARGS[@]}"; do
+    arg="${ARGS[$arg_idx]}"
 
     # Repeat until all env vars will be expanded
     while true; do
@@ -83,7 +83,7 @@ function common::parse_and_export_env_vars {
         # `$arg` will be checked in `if` conditional, `$ARGS` will be used in the next functions.
         # shellcheck disable=SC2016 # '${' should not be expanded
         arg=${arg/'${'$env_var_name'}'/$env_var_value}
-        ARGS[$i]=$arg
+        ARGS[$arg_idx]=$arg
         # shellcheck disable=SC2016 # '${' should not be expanded
         common::colorify "green" 'After ${'"$env_var_name"'} expansion: '"'$arg'\n"
         continue

--- a/hooks/infracost_breakdown.sh
+++ b/hooks/infracost_breakdown.sh
@@ -13,6 +13,7 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 function main {
   common::initialize "$SCRIPT_DIR"
   common::parse_cmdline "$@"
+  common::parse_and_export_env_vars
   # shellcheck disable=SC2153 # False positive
   infracost_breakdown_ "${HOOK_CONFIG[*]}" "${ARGS[*]}"
 }

--- a/hooks/terraform_checkov.sh
+++ b/hooks/terraform_checkov.sh
@@ -13,6 +13,7 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 function main {
   common::initialize "$SCRIPT_DIR"
   common::parse_cmdline "$@"
+  common::parse_and_export_env_vars
   # shellcheck disable=SC2153 # False positive
   common::per_dir_hook "${ARGS[*]}" "$HOOK_ID" "${FILES[@]}"
 }

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -13,6 +13,7 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 function main {
   common::initialize "$SCRIPT_DIR"
   common::parse_cmdline "$@"
+  common::parse_and_export_env_vars
   # Support for setting relative PATH to .terraform-docs.yml config.
   # shellcheck disable=SC2178 # It's the simplest syntax for that case
   ARGS=${ARGS[*]/--config=/--config=$(pwd)\/}

--- a/hooks/terraform_fmt.sh
+++ b/hooks/terraform_fmt.sh
@@ -13,6 +13,7 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 function main {
   common::initialize "$SCRIPT_DIR"
   common::parse_cmdline "$@"
+  common::parse_and_export_env_vars
   # shellcheck disable=SC2153 # False positive
   terraform_fmt_ "${ARGS[*]}" "${FILES[@]}"
 }

--- a/hooks/terraform_providers_lock.sh
+++ b/hooks/terraform_providers_lock.sh
@@ -13,6 +13,7 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 function main {
   common::initialize "$SCRIPT_DIR"
   common::parse_cmdline "$@"
+  common::parse_and_export_env_vars
   # shellcheck disable=SC2153 # False positive
   common::per_dir_hook "${ARGS[*]}" "$HOOK_ID" "${FILES[@]}"
 }

--- a/hooks/terraform_tflint.sh
+++ b/hooks/terraform_tflint.sh
@@ -13,6 +13,7 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 function main {
   common::initialize "$SCRIPT_DIR"
   common::parse_cmdline "$@"
+  common::parse_and_export_env_vars
   # Support for setting PATH to repo root.
   # shellcheck disable=SC2178 # It's the simplest syntax for that case
   ARGS=${ARGS[*]/__GIT_WORKING_DIR__/$(pwd)\/}

--- a/hooks/terraform_tfsec.sh
+++ b/hooks/terraform_tfsec.sh
@@ -12,6 +12,7 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 function main {
   common::initialize "$SCRIPT_DIR"
   common::parse_cmdline "$@"
+  common::parse_and_export_env_vars
   # Support for setting PATH to repo root.
   # shellcheck disable=SC2178 # It's the simplest syntax for that case
   ARGS=${ARGS[*]/__GIT_WORKING_DIR__/$(pwd)\/}

--- a/hooks/terraform_validate.sh
+++ b/hooks/terraform_validate.sh
@@ -16,6 +16,7 @@ export AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-east-1}
 function main {
   common::initialize "$SCRIPT_DIR"
   parse_cmdline_ "$@"
+  common::parse_and_export_env_vars
   terraform_validate_
 }
 

--- a/hooks/terragrunt_fmt.sh
+++ b/hooks/terragrunt_fmt.sh
@@ -12,6 +12,7 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 function main {
   common::initialize "$SCRIPT_DIR"
   common::parse_cmdline "$@"
+  common::parse_and_export_env_vars
   # shellcheck disable=SC2153 # False positive
   common::per_dir_hook "${ARGS[*]}" "$HOOK_ID" "${FILES[@]}"
 }

--- a/hooks/terragrunt_validate.sh
+++ b/hooks/terragrunt_validate.sh
@@ -12,6 +12,7 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 function main {
   common::initialize "$SCRIPT_DIR"
   common::parse_cmdline "$@"
+  common::parse_and_export_env_vars
   # shellcheck disable=SC2153 # False positive
   common::per_dir_hook "${ARGS[*]}" "$HOOK_ID" "${FILES[@]}"
 }

--- a/hooks/terrascan.sh
+++ b/hooks/terrascan.sh
@@ -12,6 +12,7 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 function main {
   common::initialize "$SCRIPT_DIR"
   common::parse_cmdline "$@"
+  common::parse_and_export_env_vars
   # shellcheck disable=SC2153 # False positive
   common::per_dir_hook "${ARGS[*]}" "$HOOK_ID" "${FILES[@]}"
 }

--- a/hooks/tfupdate.sh
+++ b/hooks/tfupdate.sh
@@ -12,6 +12,7 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 function main {
   common::initialize "$SCRIPT_DIR"
   common::parse_cmdline "$@"
+  common::parse_and_export_env_vars
   # shellcheck disable=SC2153 # False positive
   common::per_dir_hook "${ARGS[*]}" "$HOOK_ID" "${FILES[@]}"
 }


### PR DESCRIPTION
`*` - All hooks, except deprecated.

<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [x] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

Implement a use case from #347, but without affecting UX.

Use case:

>Context: I need to pass in the location of an alternate tflint config in CI.
The location is based on an environment variable in my CI environment, so
hard-coding the value as an argument isn't tenable.

Close #347

### How can we test changes

1. Export env vars, eg `export CONFIG_NAME=.tflint; export CONFIG_EXT=hcl`

2. Add env vars to your .pre-commit-config.yaml`

```yaml
repos:
- repo: https://github.com/antonbabenko/pre-commit-terraform
  rev: 182254e43fdfa6ff79f849cbaeb150d9c593a383
  hooks:
    - id: terraform_tflint
      args:
        # - '--args=--config=__GIT_WORKING_DIR__/${CONFIG_FILE}' # export CONFIG_FILE=.tflint.hcl
        - --args=--config=__GIT_WORKING_DIR__/${CONFIG_NAME}.${CONFIG_EXT} # export CONFIG_NAME=.tflint; export CONFIG_EXT=hcl
        - --args=--module
```

3. Make sure that tested hook will fail during the code issue
3. Run `pre-commit run`

Output: 
![image](https://user-images.githubusercontent.com/11096782/163600782-81bb7a4d-c31a-44f0-bda4-64d3a643fdc3.png)

