### PR TITLE
chore: Avoid mention issue 123 during releases

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,7 @@ attention to anything that needs special consideration.
 
 We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
 can uncomment the below line to indicate which issue your PR fixes, for example
-"Fixes #123":
+"Fixes #123456":
 -->
 
 <!-- Fixes # -->


### PR DESCRIPTION
All PR's that have #123 in their description, that are added by the PR template, force release action to generate comments in #123 issue.