### PR TITLE
feat: Removed `coreutils` (realpath) from dependencies for MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,8 @@ Set `-e PRE_COMMIT_COLOR=never` to disable the color output in `pre-commit`.
 
 <details><summary><b>MacOS</b></summary><br>
 
-[`coreutils`](https://formulae.brew.sh/formula/coreutils) is required for hooks on MacOS (due to use of `realpath`).
-
 ```bash
-brew install pre-commit terraform-docs tflint tfsec coreutils checkov terrascan infracost tfupdate jq
+brew install pre-commit terraform-docs tflint tfsec checkov terrascan infracost tfupdate jq
 ```
 
 </details>

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -69,7 +69,7 @@ function common::is_hook_run_on_whole_repo {
   shift 1
   local -a -r files=("$@")
   # get directory containing `.pre-commit-hooks.yaml` file
-  local -r root_config_dir="$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")"
+  local -r root_config_dir="$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)")"
   # get included and excluded files from .pre-commit-hooks.yaml file
   local -r hook_config_block=$(sed -n "/^- id: $hook_id$/,/^$/p" "$root_config_dir/.pre-commit-hooks.yaml")
   local -r included_files=$(awk '$1 == "files:" {print $2; exit}' <<< "$hook_config_block")

--- a/hooks/infracost_breakdown.sh
+++ b/hooks/infracost_breakdown.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 # shellcheck disable=SC2034 # Unused var.
 readonly HOOK_ID='infracost_breakdown'
 # shellcheck disable=SC2155 # No way to assign to readonly variable in separate lines
-readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 # shellcheck source=_common.sh
 . "$SCRIPT_DIR/_common.sh"
 

--- a/hooks/terraform_checkov.sh
+++ b/hooks/terraform_checkov.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 # shellcheck disable=SC2034 # Unused var.
 readonly HOOK_ID='terraform_checkov'
 # shellcheck disable=SC2155 # No way to assign to readonly variable in separate lines
-readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 # shellcheck source=_common.sh
 . "$SCRIPT_DIR/_common.sh"
 

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 # shellcheck disable=SC2034 # Unused var.
 readonly HOOK_ID='terraform_docs'
 # shellcheck disable=SC2155 # No way to assign to readonly variable in separate lines
-readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 # shellcheck source=_common.sh
 . "$SCRIPT_DIR/_common.sh"
 

--- a/hooks/terraform_fmt.sh
+++ b/hooks/terraform_fmt.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 # shellcheck disable=SC2034 # Unused var.
 readonly HOOK_ID='terraform_fmt'
 # shellcheck disable=SC2155 # No way to assign to readonly variable in separate lines
-readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 # shellcheck source=_common.sh
 . "$SCRIPT_DIR/_common.sh"
 

--- a/hooks/terraform_providers_lock.sh
+++ b/hooks/terraform_providers_lock.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 # hook ID, see `- id` for details in .pre-commit-hooks.yaml file
 readonly HOOK_ID='terraform_providers_lock'
 # shellcheck disable=SC2155 # No way to assign to readonly variable in separate lines
-readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 # shellcheck source=_common.sh
 . "$SCRIPT_DIR/_common.sh"
 

--- a/hooks/terraform_tflint.sh
+++ b/hooks/terraform_tflint.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 # hook ID, see `- id` for details in .pre-commit-hooks.yaml file
 readonly HOOK_ID='terraform_tflint'
 # shellcheck disable=SC2155 # No way to assign to readonly variable in separate lines
-readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 # shellcheck source=_common.sh
 . "$SCRIPT_DIR/_common.sh"
 

--- a/hooks/terraform_tfsec.sh
+++ b/hooks/terraform_tfsec.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 # hook ID, see `- id` for details in .pre-commit-hooks.yaml file
 readonly HOOK_ID='terraform_tfsec'
 # shellcheck disable=SC2155 # No way to assign to readonly variable in separate lines
-readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 # shellcheck source=_common.sh
 . "$SCRIPT_DIR/_common.sh"
 

--- a/hooks/terraform_validate.sh
+++ b/hooks/terraform_validate.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 # shellcheck disable=SC2034 # Unused var.
 readonly HOOK_ID='terraform_validate'
 # shellcheck disable=SC2155 # No way to assign to readonly variable in separate lines
-readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 # shellcheck source=_common.sh
 . "$SCRIPT_DIR/_common.sh"
 

--- a/hooks/terraform_validate.sh
+++ b/hooks/terraform_validate.sh
@@ -110,7 +110,7 @@ function terraform_validate_ {
 
     if [[ -n "$(find "$dir_path" -maxdepth 1 -name '*.tf' -print -quit)" ]]; then
 
-      pushd "$(realpath "$dir_path")" > /dev/null
+      pushd "$(cd "$dir_path" && pwd -P)" > /dev/null
 
       if [ ! -d .terraform ]; then
         set +e

--- a/hooks/terragrunt_fmt.sh
+++ b/hooks/terragrunt_fmt.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 # hook ID, see `- id` for details in .pre-commit-hooks.yaml file
 readonly HOOK_ID='terragrunt_fmt'
 # shellcheck disable=SC2155 # No way to assign to readonly variable in separate lines
-readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 # shellcheck source=_common.sh
 . "$SCRIPT_DIR/_common.sh"
 

--- a/hooks/terragrunt_validate.sh
+++ b/hooks/terragrunt_validate.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 # hook ID, see `- id` for details in .pre-commit-hooks.yaml file
 readonly HOOK_ID='terragrunt_validate'
 # shellcheck disable=SC2155 # No way to assign to readonly variable in separate lines
-readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 # shellcheck source=_common.sh
 . "$SCRIPT_DIR/_common.sh"
 

--- a/hooks/terrascan.sh
+++ b/hooks/terrascan.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 # hook ID, see `- id` for details in .pre-commit-hooks.yaml file
 readonly HOOK_ID='terrascan'
 # shellcheck disable=SC2155 # No way to assign to readonly variable in separate lines
-readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 # shellcheck source=_common.sh
 . "$SCRIPT_DIR/_common.sh"
 

--- a/hooks/tfupdate.sh
+++ b/hooks/tfupdate.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 # hook ID, see `- id` for details in .pre-commit-hooks.yaml file
 readonly HOOK_ID='tfupdate'
 # shellcheck disable=SC2155 # No way to assign to readonly variable in separate lines
-readonly SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 # shellcheck source=_common.sh
 . "$SCRIPT_DIR/_common.sh"
 


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [x] This PR enhances existing functionality.

### Description of your changes

Fixes #336, #349 and #367

### How can we test changes

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


Run any hook on MacOs w/o `coreutils`

```yaml
repos:
- repo: https://github.com/antonbabenko/pre-commit-terraform
  rev: 307f48dae422203f31fa888f6cad7d12014ad260
  hooks:
```