### PR TITLE
feat: Add support for `pre-commit/pre-commit-hooks` in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -162,7 +162,9 @@ RUN apk add --no-cache \
     git=~2 \
     # All hooks deps
     bash=~5 \
-    alpine-sdk
+    # pre-commit-hooks deps: https://github.com/pre-commit/pre-commit-hooks
+    musl-dev=~1 \
+    gcc=~10
 
 # Copy tools
 COPY --from=builder \

--- a/Dockerfile
+++ b/Dockerfile
@@ -161,7 +161,8 @@ RUN apk add --no-cache \
     # pre-commit deps
     git=~2 \
     # All hooks deps
-    bash=~5
+    bash=~5 \
+    alpine-sdk
 
 # Copy tools
 COPY --from=builder \


### PR DESCRIPTION
Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [x] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

Fixes #359 :
Add `alpine-sdk` package so we are able to run third party checks. This is mostly to be able to run directly this docker image with checks coming from `https://github.com/pre-commit/pre-commit-hooks` since they are widely use in combination with `pre-commit-terraform`.

This is to avoid all the users of the community using pre-commit-terraform to build their own image on top of the one existing.

FIY: This was working before the  v1.63.0. So I guess it is a change coming directly from the image of Python.

-->

<!-- Fixes # -->

### How can we test changes

1. Create a `.pre-commit-config.yaml` file containing:
```yaml
repos:
  - repo: https://github.com/pre-commit/pre-commit-hooks
    rev: v4.2.0
    hooks:
      # Common errors
      - id: end-of-file-fixer
      - id: trailing-whitespace
        args: [--markdown-linebreak-ext=md]
      - id: check-yaml

      # Security
      - id: detect-aws-credentials
        args: ["--allow-missing-credentials"]
      - id: detect-private-key

  - repo: https://github.com/antonbabenko/pre-commit-terraform
    rev: v1.68.1
    hooks:
      - id: terraform_fmt
      - id: terraform_docs
      - id: terraform_tfsec
      - id: terraform_tflint
      - id: terraform_validate
```
2. Build the docker image using my branch `docker build -t pre-commit-terraform --build-arg INSTALL_ALL=true .`
3. Run it `docker run -v $(pwd):/lint -it -w /lint pre-commit-terraform run -a`

All the tests should run.