### PR TITLE
fix: Fixed `tfupdate` to work in all cases, not only `pre-commit run --all`

### DIFF
--- a/hooks/tfupdate.sh
+++ b/hooks/tfupdate.sh
@@ -33,7 +33,7 @@ function per_dir_hook_unique_part {
 
   # pass the arguments to hook
   # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
-  tfupdate ${args[@]} "${dir_path}"
+  tfupdate ${args[@]} .
 
   # return exit code to common::per_dir_hook
   local exit_code=$?


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

Fixes #371

### How can we test changes

```yaml
repos:
- repo: https://github.com/antonbabenko/pre-commit-terraform
  rev: dfe39915d72182819814919b21b73a741ab9ae6a
  hooks:
    - id: tfupdate
      name: Autoupdate AWS provider versions
      args:
        - --args=provider aws
        - --args=--version 4.1.0
    - id: tfupdate
      name: Autoupdate Helm provider versions
      args:
        - --args=provider helm
    - id: tfupdate
      name: Update Google provider to specified version
      args:
        - --args=provider google
        - --args=--version 4.18.0
    - id: tfupdate
      name: Update Terraform provider to specified version
      args:
        - --args=terraform
        - --args=--version 1.1.8
```