### PR TITLE
feat: When a config file is given, do not specify formatter on cli (terraform_docs)

### DIFF
--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -138,7 +138,7 @@ function terraform_docs {
   #
   # Override formatter if no config file set
   #
-  [[ "$args" != *"--config"* ]] && local tf_docs_formatter="md"
+  [[ ! $args =~ (^|[[:space:]])--config=[^[:space:]]+ ]] && local tf_docs_formatter="md"
 
   local dir_path
   for dir_path in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -135,6 +135,15 @@ function terraform_docs {
     esac
   done
 
+  #
+  # Decide formatter to use
+  #
+  local tf_docs_formatter="md"
+  if [[ "$args" == *"--config"* ]]; then
+    # Allow config file to specify formatter
+    tf_docs_formatter=""
+  fi
+
   local dir_path
   for dir_path in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
     dir_path="${dir_path//__REPLACED__SPACE__/ }"
@@ -181,7 +190,7 @@ function terraform_docs {
 
     if [[ "$terraform_docs_awk_file" == "0" ]]; then
       # shellcheck disable=SC2086
-      terraform-docs md $args ./ > "$tmp_file"
+      terraform-docs $tf_docs_formatter $args ./ > "$tmp_file"
     else
       # Can't append extension for mktemp, so renaming instead
       local tmp_file_docs
@@ -192,7 +201,7 @@ function terraform_docs {
 
       awk -f "$terraform_docs_awk_file" ./*.tf > "$tmp_file_docs_tf"
       # shellcheck disable=SC2086
-      terraform-docs md $args "$tmp_file_docs_tf" > "$tmp_file"
+      terraform-docs $tf_docs_formatter $args "$tmp_file_docs_tf" > "$tmp_file"
       rm -f "$tmp_file_docs_tf"
     fi
 

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -138,7 +138,7 @@ function terraform_docs {
   #
   # Override formatter if no config file set
   #
-  [[ ! $args =~ (^|[[:space:]])--config=[^[:space:]]+ ]] && local tf_docs_formatter="md"
+  [[ "$args" != *"--config="* ]] && local tf_docs_formatter="md"
 
   local dir_path
   for dir_path in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -141,7 +141,7 @@ function terraform_docs {
   local tf_docs_formatter="md"
   if [[ "$args" == *"--config"* ]]; then
     # Allow config file to specify formatter
-    tf_docs_formatter=""
+    unset tf_docs_formatter
   fi
 
   local dir_path

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -136,13 +136,9 @@ function terraform_docs {
   done
 
   #
-  # Decide formatter to use
+  # Override formatter if no config file set
   #
-  local tf_docs_formatter="md"
-  if [[ "$args" == *"--config"* ]]; then
-    # Allow config file to specify formatter
-    unset tf_docs_formatter
-  fi
+  [[ "$args" != *"--config"* ]] && local tf_docs_formatter="md"
 
   local dir_path
   for dir_path in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do


### PR DESCRIPTION
- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [x] This PR enhances existing functionality.

### Description of your changes

The change is to the `terraform_docs` hook. Currently this hook will ignore the formatter set in any specified config file, defaulting to the `md` formatter. On our project we use the `markdown document` formatter but this is ignored by the hook. I consider this a bug but thought a PR would be better than a new issue for you.

### How can we test changes

Run:

```shellscript
$ mkdir test-tf-docs-pre-commit
$ cd test-tf-docs-pre-commit
$ git init
$ pre-commit install
```

Create the following files.

`.terraform-docs.yml`
```yaml
formatter: toml
```

`.pre-commit-config.yaml`
```yaml
repos:
  - repo: https://github.com/acodeninja/pre-commit-terraform.git
    rev: v1.71.0
    hooks:
      - id: terraform_docs
        args:
          - --args=--config=.terraform-docs.yml
```

`main.tf`
```hcl
variable "some-input" {
  description = "An input variable"
  type        = string
}

output "some-output" {
  value = var.some-input
}
```

`README.md`
```markdown
<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
```

Then run `pre-commit run --all-files`.

You will see the output in the readme after running will be:

```markdown
<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
## Requirements

No requirements.

## Providers

No providers.

## Modules

No modules.

## Resources

No resources.

## Inputs

| Name | Description | Type | Default | Required |
|------|-------------|------|---------|:--------:|
| <a name="input_some-input"></a> [some-input](#input\_some-input) | An input variable | `string` | n/a | yes |

## Outputs

| Name | Description |
|------|-------------|
| <a name="output_some-output"></a> [some-output](#output\_some-output) | n/a |
<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
```

This is not the configured and desired format according to the `.terraform-docs.yml` configuration.

Now, change the `.pre-commit-config.yaml` file to the following:

```yaml
repos:
  - repo: https://github.com/acodeninja/pre-commit-terraform.git
    rev: 855f9c52ed0e717dd953a3cbe445bfee1cd17662
    hooks:
      - id: terraform_docs
        args:
          - --args=--config=.terraform-docs.yml
```

And run `pre-commit run --all-files` again.

You will now see the readme file contents is as expected from the configuration of terraform docs.

```markdown
<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
header = ""
footer = ""
modules = []
providers = []
requirements = []
resources = []

[[inputs]]
  name = "some-input"
  type = "string"
  description = "An input variable"
  required = true
  [inputs.default]

[[outputs]]
  name = "some-output"
  description = ""
<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
```