### PR TITLE
fix: Fixed `terraform_fmt` with `tfenv`, when `terraform` default version is not specified

### DIFF
--- a/hooks/terraform_fmt.sh
+++ b/hooks/terraform_fmt.sh
@@ -15,62 +15,7 @@ function main {
   common::parse_cmdline "$@"
   common::parse_and_export_env_vars
   # shellcheck disable=SC2153 # False positive
-  terraform_fmt_ "${ARGS[*]}" "${FILES[@]}"
-}
-
-#######################################################################
-# Hook execution boilerplate logic which is common to hooks, that run
-# on per dir basis. Little bit extended than `common::per_dir_hook`
-# 1. Because hook runs on whole dir, reduce file paths to uniq dir paths
-# (unique) 1.1. Collect paths to *.tfvars files in a separate variable
-# 2. Run for each dir `per_dir_hook_unique_part`, on all paths
-# (unique) 2.1. Run `terraform fmt` on each *.tfvars file
-# 2.2. If at least 1 check failed - change exit code to non-zero
-# 3. Complete hook execution and return exit code
-# Arguments:
-#   args (string with array) arguments that configure wrapped tool behavior
-#   files (array) filenames to check
-#######################################################################
-function terraform_fmt_ {
-  local -r args="$1"
-  shift 1
-  local -a -r files=("$@")
-  # consume modified files passed from pre-commit so that
-  # hook runs against only those relevant directories
-  local index=0
-  for file_with_path in "${files[@]}"; do
-    file_with_path="${file_with_path// /__REPLACED__SPACE__}"
-
-    dir_paths[index]=$(dirname "$file_with_path")
-
-    ((index += 1))
-  done
-
-  # preserve errexit status
-  shopt -qo errexit && ERREXIT_IS_SET=true
-  # allow hook to continue if exit_code is greater than 0
-  set +e
-  local final_exit_code=0
-
-  # run hook for each path
-  for dir_path in $(echo "${dir_paths[*]}" | tr ' ' '\n' | sort -u); do
-    dir_path="${dir_path//__REPLACED__SPACE__/ }"
-    pushd "$dir_path" > /dev/null || continue
-
-    per_dir_hook_unique_part "$args" "$dir_path"
-
-    local exit_code=$?
-    if [ $exit_code -ne 0 ]; then
-      final_exit_code=$exit_code
-    fi
-
-    popd > /dev/null
-  done
-  # restore errexit if it was set before the "for" loop
-  [[ $ERREXIT_IS_SET ]] && set -e
-  # return the hook final exit_code
-  exit $final_exit_code
-
+  common::per_dir_hook "${ARGS[*]}" "$HOOK_ID" "${FILES[@]}"
 }
 
 #######################################################################
@@ -85,6 +30,7 @@ function terraform_fmt_ {
 #######################################################################
 function per_dir_hook_unique_part {
   local -r args="$1"
+  # shellcheck disable=SC2034 # Unused var.
   local -r dir_path="$2"
 
   # pass the arguments to hook

--- a/hooks/terraform_fmt.sh
+++ b/hooks/terraform_fmt.sh
@@ -42,11 +42,7 @@ function terraform_fmt_ {
     file_with_path="${file_with_path// /__REPLACED__SPACE__}"
 
     dir_paths[index]=$(dirname "$file_with_path")
-    # TODO Unique part
-    if [[ "$file_with_path" == *".tfvars" ]]; then
-      tfvars_files+=("$file_with_path")
-    fi
-    #? End for unique part
+
     ((index += 1))
   done
 

--- a/hooks/terraform_fmt.sh
+++ b/hooks/terraform_fmt.sh
@@ -70,19 +70,6 @@ function terraform_fmt_ {
 
     popd > /dev/null
   done
-
-  # TODO: Unique part
-  # terraform.tfvars are excluded by `terraform fmt`
-  for tfvars_file in "${tfvars_files[@]}"; do
-    tfvars_file="${tfvars_file//__REPLACED__SPACE__/ }"
-
-    terraform fmt "${ARGS[@]}" "$tfvars_file"
-    local exit_code=$?
-    if [ $exit_code -ne 0 ]; then
-      final_exit_code=$exit_code
-    fi
-  done
-  #? End for unique part
   # restore errexit if it was set before the "for" loop
   [[ $ERREXIT_IS_SET ]] && set -e
   # return the hook final exit_code


### PR DESCRIPTION
Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [x] This PR enhances existing functionality.

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123456":
-->

Fixes #379 

### How can we test changes

```yaml
repos:
- repo: https://github.com/antonbabenko/pre-commit-terraform
  rev: d0c781e98a310b1b03900280feaf630832bef332
  hooks:
    - id: terraform_fmt
```

Also, test details exist in https://github.com/antonbabenko/pre-commit-terraform/issues/379#issuecomment-1137194598, and the same tests was performed for this PR too.