### PR TITLE
feat: Add __GIT_WORKING_DIR__ to terraform_checkov

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,14 @@ For deprecated hook you need to specify each argument separately:
   ]
 ```
 
+2. When you have multiple directories and want to run `terraform_checkov` in all of them and share a single config file - use the `__GIT_WORKING_DIR__` placeholder. It will be replaced by `terraform_checkov` hooks with Git working directory (repo root) at run time. For example:
+
+    ```yaml
+    - id: terraform_checkov
+      args:
+        - --args=--config-file __GIT_WORKING_DIR__/.checkov.yml
+    ```
+
 ### infracost_breakdown
 
 `infracost_breakdown` executes `infracost breakdown` command and compare the estimated costs with those specified in the hook-config. `infracost breakdown` parses Terraform HCL code, and calls Infracost Cloud Pricing API (remote version or [self-hosted version](https://www.infracost.io/docs/cloud_pricing_api/self_hosted)).

--- a/hooks/terraform_checkov.sh
+++ b/hooks/terraform_checkov.sh
@@ -18,8 +18,7 @@ function main {
   # shellcheck disable=SC2178 # It's the simplest syntax for that case
   ARGS=${ARGS[*]/__GIT_WORKING_DIR__/$(pwd)\/}
   # shellcheck disable=SC2128 # It's the simplest syntax for that case
-  # shellcheck disable=SC2153 # False positive
-  common::per_dir_hook "${ARGS[*]}" "$HOOK_ID" "${FILES[@]}"
+  common::per_dir_hook "$ARGS" "$HOOK_ID" "${FILES[@]}"
 }
 
 #######################################################################

--- a/hooks/terraform_checkov.sh
+++ b/hooks/terraform_checkov.sh
@@ -14,6 +14,10 @@ function main {
   common::initialize "$SCRIPT_DIR"
   common::parse_cmdline "$@"
   common::parse_and_export_env_vars
+  # Support for setting PATH to repo root.
+  # shellcheck disable=SC2178 # It's the simplest syntax for that case
+  ARGS=${ARGS[*]/__GIT_WORKING_DIR__/$(pwd)\/}
+  # shellcheck disable=SC2128 # It's the simplest syntax for that case
   # shellcheck disable=SC2153 # False positive
   common::per_dir_hook "${ARGS[*]}" "$HOOK_ID" "${FILES[@]}"
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [x] This PR enhances existing functionality.

### Description of your changes

This PR adds support for `__GIT_WORKING_DIR__` to the new `terraform_checkov` hook.

Since the new hook cd into each directory, it now ignores the `checkov.yml` file in the root folder. The functionality can now be restored with:
```
- id: terraform_checkov
  args:
    - --args=--config-file __GIT_WORKING_DIR__/.checkov.yml
```

<!-- Fixes # -->

### How can we test changes

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

1. Create a `checkov.yml` in the top directory
2. Commit something that will trigger `terraform_checkov` in a subdirectory:
    -  the config file is ignored
4. Add `--args=--config-file __GIT_WORKING_DIR__/.checkov.yml` to the `.pre-commit-config.yaml` file
5. Commit something that will trigger `terraform_checkov` in a subdirectory
    - the config file is now taken into account
