### PR TITLE
Fix hooks/terraform_validate.sh

### DIFF
--- a/hooks/terraform_validate.sh
+++ b/hooks/terraform_validate.sh
@@ -111,7 +111,7 @@ function terraform_validate_ {
 
     if [[ -n "$(find "$dir_path" -maxdepth 1 -name '*.tf' -print -quit)" ]]; then
 
-      pushd "$(cd "$dir_path" && pwd -P)" > /dev/null
+      pushd "$(cd "$dir_path" >/dev/null 2>&1 && pwd -P)" > /dev/null
 
       if [ ! -d .terraform ]; then
         set +e


### PR DESCRIPTION
Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [X] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

This PR simple redirects `stdout` and `stderror` to `/dev/null` for the `cd` command.

### Fixes `hooks/terraform_validate.sh`

The `terraform_validate` hook was failing for me because the script was getting `No such file or directory` error:

```NOFORMAT
hnicholas@hnicholas-a01:~/Repositories/terraform/modules/aws/kms$ pre-commit run -a
Terraform fmt............................................................Passed
Terraform validate.......................................................Failed
- hook id: terraform_validate
- exit code: 1

/Users/hnicholas/.cache/pre-commit/repo7ebw704n/hooks/terraform_validate.sh: line 114: pushd: $'/Users/hnicholas/Repositories/terraform/modules/aws/kms/examples/backend_account\n/Users/hnicholas/Repositories/terraform/modules/aws/kms/examples/backend_account': No such file or directory

Terraform docs...........................................................Passed
Terraform validate with tflint...........................................Passed
Terraform validate with tfsec............................................Passed
check for added large files..............................................Passed
check for merge conflicts................................................Passed
don't commit to branch...................................................Passed
```

Digging deeper, it seems that `cd` was outputting the name of the directory, but we don't want that, we only want output from `pwd -P`.

### How can we test changes

I changed this locally and it fixed the issue.
