### PR TITLE
fix: Fixed regression with exit code in `terraform_docs` hook

### DIFF
--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -230,7 +230,7 @@ function terraform_docs {
   done
 
   # Cleanup
-  [ -e "$config_file_no_color" ] && rm -f "$config_file_no_color"
+  rm -f "$config_file_no_color"
 }
 
 #######################################################################


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes
Fixes #413

`[ -e "" ]` produces result code 1 if the file is not found. And that implicitly return as result, which is not expected


### How can we test changes

```yaml
repos:
- repo: https://github.com/antonbabenko/pre-commit-terraform
  rev: 168b3aee5c9927ab104667173eb2555d381c8402
  hooks:
    - id: terraform_docs
```