### PR TITLE
docs: Fix README tflint example

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,14 +553,14 @@ Example:
 
 ### terraform_tflint
 
-1. `terraform_tflint` supports custom arguments so you can enable module inspection, deep check mode, etc.
+1. `terraform_tflint` supports custom arguments so you can enable module inspection, enable / disable rules, etc.
 
     Example:
 
     ```yaml
     - id: terraform_tflint
       args:
-        - --args=--deep
+        - --args=--module
         - --args=--enable-rule=terraform_documented_variables
     ```
 


### PR DESCRIPTION
The `deep` CLI option has been deprecated, I've replaced it in the example.

From tflint (0.16.1):
"Failed to parse CLI options; `deep` option was removed in v0.23.0. Deep checking is now a feature of the AWS plugin, so please configure the plugin instead"

<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123456":
-->

<!-- Fixes # -->

### How can we test changes

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
