### PR TITLE
fix: Add additional methods to find repository name (terraform_wrapper_module_for_each)

### DIFF
--- a/hooks/terraform_wrapper_module_for_each.sh
+++ b/hooks/terraform_wrapper_module_for_each.sh
@@ -155,7 +155,6 @@ function terraform_module_wrapper_ {
   local wrapper_dir="wrappers"
   local wrapper_relative_source_path="../" # From "wrappers" to root_dir.
   local module_repo_org
-  local module_repo_name
   local module_repo_shortname
   local module_repo_provider
   local dry_run="false"
@@ -163,8 +162,7 @@ function terraform_module_wrapper_ {
 
   root_dir=$(git rev-parse --show-toplevel 2> /dev/null || pwd)
   module_repo_org="terraform-aws-modules"
-  module_repo_name=${root_dir##*/}
-  module_repo_shortname="${module_repo_name#terraform-aws-}"
+  module_repo_shortname="$(determine_repo_shortname "${root_dir}")"
   module_repo_provider="aws"
 
   for argv in "${args[@]}"; do


### PR DESCRIPTION

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

Added function to ```terraform_wrapper_module_for_each``` to try a **little** harder to determine the repository name, instead of just looking at the directory name.  If the directory name doesn't match the expected pattern (terraform-aws-{shortname}), it checks for the "origin" and "upstream" remote URLs, to see if they do.  If it gets a match from there, return the module repo shortname to be used in the existing code.

This should not break existing functionality, since if the function can't find a name that matches the expected pattern, it returns a value that matches what the code previously did (the directory name stripped of path information).

```REPO_BASE_PATTERN``` - constant to provide the expected pattern match - "terraform-aws-(.*)"

```determine_repo_shortname()``` - checks if the provided directory name matches the pattern, and returns the shortname.  If not, will check the remote URLs and return shortnames there, if matches.  Otherwise returns the original provided name, with path information stripped.

```strip_path_url_to_shortname()``` - utility function to remove path or URL information from the repository name, as well as strip a trailing ```.git``` if there

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123456":
-->

Fixes #430 

### How can we test changes

<details><summary>(docker) Show current version fails in docker - Current version on terraform-aws-ec2-instance</summary>

```bash
❯ cat .pre-commit-config.yaml
repos:
  - repo: https://github.com/antonbabenko/pre-commit-terraform
    rev: v1.74.1
    hooks:
      - id: terraform_wrapper_module_for_each
❯ TAG=latest && docker run -v $(pwd):/lint -w /lint ghcr.io/antonbabenko/pre-commit-terraform:$TAG run -a
[INFO] Initializing environment for https://github.com/antonbabenko/pre-commit-terraform.
Terraform wrapper with for_each in module................................Failed
- hook id: terraform_wrapper_module_for_each
- files were modified by this hook

Saving files into "/lint/wrappers/"

❯ grep source wrappers/README.md
You may want to use a single Terragrunt configuration file to manage multiple resources without duplicating `terragrunt.hcl` files for each copy of the same module.
  source = "tfr:///terraform-aws-modules/lint/aws//wrappers"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-lint.git?ref=master//wrappers"
  source = "terraform-aws-modules/lint/aws//wrappers"
  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=master//wrappers"
```
</details>

<details><summary>(docker) Show fork gets origin from remote - Updated hook output (from fork), terraform-aws-ec2-instance repo has origin set to github repo</summary>

```bash
❯ cat .pre-commit-config.yaml
repos:
  - repo: https://github.com/tofupup/pre-commit-terraform
    rev: c98c97898c41ba0b2c61c4cb6dae1c5a2c7cc30f
    hooks:
      - id: terraform_wrapper_module_for_each
❯ TAG=latest && docker run -v $(pwd):/lint -w /lint ghcr.io/antonbabenko/pre-commit-terraform:$TAG run -a
[INFO] Initializing environment for https://github.com/tofupup/pre-commit-terraform.
Terraform wrapper with for_each in module................................Passed
❯ grep source wrappers/README.md
You may want to use a single Terragrunt configuration file to manage multiple resources without duplicating `terragrunt.hcl` files for each copy of the same module.
  source = "tfr:///terraform-aws-modules/ec2-instance/aws//wrappers"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-ec2-instance.git?ref=master//wrappers"
  source = "terraform-aws-modules/ec2-instance/aws//wrappers"
  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=master//wrappers"
```
</details>

<details><summary>(docker) Show current version fails in docker, different repo with multiple modules - Current version on terraform-aws-s3-bucket</summary>

```bash
❯ cat .pre-commit-config.yaml
repos:
  - repo: https://github.com/antonbabenko/pre-commit-terraform
    rev: v1.74.1
    hooks:
      - id: terraform_wrapper_module_for_each
❯ TAG=latest && docker run -v $(pwd):/lint -w /lint ghcr.io/antonbabenko/pre-commit-terraform:$TAG run -a
[INFO] Initializing environment for https://github.com/antonbabenko/pre-commit-terraform.
Terraform wrapper with for_each in module................................Failed
- hook id: terraform_wrapper_module_for_each
- files were modified by this hook

Saving files into "/lint/wrappers/"
Saving files into "/lint/wrappers/object"
Saving files into "/lint/wrappers/notification"
❯ find wrappers -iname "README.md" -exec grep -i source {} \;
You may want to use a single Terragrunt configuration file to manage multiple resources without duplicating `terragrunt.hcl` files for each copy of the same module.
  source = "tfr:///terraform-aws-modules/lint/aws//wrappers"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-lint.git?ref=master//wrappers"
  source = "terraform-aws-modules/lint/aws//wrappers"
  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=master//wrappers"
You may want to use a single Terragrunt configuration file to manage multiple resources without duplicating `terragrunt.hcl` files for each copy of the same module.
  source = "tfr:///terraform-aws-modules/lint/aws//wrappers/object"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-lint.git?ref=master//wrappers/object"
  source = "terraform-aws-modules/lint/aws//wrappers/object"
  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=master//wrappers"
You may want to use a single Terragrunt configuration file to manage multiple resources without duplicating `terragrunt.hcl` files for each copy of the same module.
  source = "tfr:///terraform-aws-modules/lint/aws//wrappers/notification"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-lint.git?ref=master//wrappers/notification"
  source = "terraform-aws-modules/lint/aws//wrappers/notification"
  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=master//wrappers"
```

</details>

<details><summary>(docker) Show fork gets origin from remote, different repo with multiple modules - Updated hook output (from fork), terraform-aws-s3-bucket repo has origin set to github repo</summary>

```bash
❯ cat .pre-commit-config.yaml
repos:
  - repo: https://github.com/tofupup/pre-commit-terraform
    rev: c98c97898c41ba0b2c61c4cb6dae1c5a2c7cc30f
    hooks:
      - id: terraform_wrapper_module_for_each
❯ TAG=latest && docker run -v $(pwd):/lint -w /lint ghcr.io/antonbabenko/pre-commit-terraform:$TAG run -a
[INFO] Initializing environment for https://github.com/tofupup/pre-commit-terraform.
Terraform wrapper with for_each in module................................Passed
❯ find wrappers -iname "README.md" -exec grep -i source {} \;
You may want to use a single Terragrunt configuration file to manage multiple resources without duplicating `terragrunt.hcl` files for each copy of the same module.
  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=master//wrappers"
  source = "terraform-aws-modules/s3-bucket/aws//wrappers"
  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=master//wrappers"
You may want to use a single Terragrunt configuration file to manage multiple resources without duplicating `terragrunt.hcl` files for each copy of the same module.
  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers/object"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=master//wrappers/object"
  source = "terraform-aws-modules/s3-bucket/aws//wrappers/object"
  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=master//wrappers"
You may want to use a single Terragrunt configuration file to manage multiple resources without duplicating `terragrunt.hcl` files for each copy of the same module.
  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers/notification"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=master//wrappers/notification"
  source = "terraform-aws-modules/s3-bucket/aws//wrappers/notification"
  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=master//wrappers"
```

</details>

<details><summary>(local) Show current version fails running local with repo directory renamed - Current version on terraform-aws-s3-bucket, with repo directory changed to junkname</summary>

Tool versions:
```bash
pre-commit 2.20.0
Terraform v1.2.8
checkov 2.1.179
Infracost v0.10.11
terraform-docs version v0.16.0 1f686b1 linux/amd64
terragrunt version v0.38.9
terrascan version: v1.15.2
TFLint version 0.39.3
tfsec v1.27.6
tfupdate 0.6.7
hcledit 0.2.6
```

```bash
❯ mv terraform-aws-s3-bucket junkname
❯ cd junkname
❯ cat .pre-commit-config.yaml
repos:
  - repo: https://github.com/antonbabenko/pre-commit-terraform
    rev: v1.74.1
    hooks:
      - id: terraform_wrapper_module_for_each
❯ pre-commit run -a
[INFO] Initializing environment for https://github.com/antonbabenko/pre-commit-terraform.
Terraform wrapper with for_each in module................................Failed
- hook id: terraform_wrapper_module_for_each
- files were modified by this hook

Saving files into "/workspaces/pre-commit-terraform/tmp/test/junkname/wrappers/"
Saving files into "/workspaces/pre-commit-terraform/tmp/test/junkname/wrappers/object"
Saving files into "/workspaces/pre-commit-terraform/tmp/test/junkname/wrappers/notification"
❯ find wrappers -iname "README.md" -exec grep -i source {} \;
You may want to use a single Terragrunt configuration file to manage multiple resources without duplicating `terragrunt.hcl` files for each copy of the same module.
  source = "tfr:///terraform-aws-modules/junkname/aws//wrappers"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-junkname.git?ref=master//wrappers"
  source = "terraform-aws-modules/junkname/aws//wrappers"
  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=master//wrappers"
You may want to use a single Terragrunt configuration file to manage multiple resources without duplicating `terragrunt.hcl` files for each copy of the same module.
  source = "tfr:///terraform-aws-modules/junkname/aws//wrappers/object"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-junkname.git?ref=master//wrappers/object"
  source = "terraform-aws-modules/junkname/aws//wrappers/object"
  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=master//wrappers"
You may want to use a single Terragrunt configuration file to manage multiple resources without duplicating `terragrunt.hcl` files for each copy of the same module.
  source = "tfr:///terraform-aws-modules/junkname/aws//wrappers/notification"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-junkname.git?ref=master//wrappers/notification"
  source = "terraform-aws-modules/junkname/aws//wrappers/notification"
  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=master//wrappers"
```

</details>

<details><summary>(local) Show fork gets origin from remote, with repo directory renamed - Updated hook output (from fork), terraform-aws-s3-bucket repo has origin set to github repo, repo directory name changed to junkname</summary>

Same tool versions as above run

```bash
❯ mv terraform-aws-s3-bucket junkname
❯ cd junkname
❯ cat .pre-commit-config.yaml
repos:
  - repo: https://github.com/tofupup/pre-commit-terraform
    rev: c98c97898c41ba0b2c61c4cb6dae1c5a2c7cc30f
    hooks:
      - id: terraform_wrapper_module_for_each
❯ git remote -v
origin  https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git (fetch)
origin  https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git (push)
❯ pre-commit run -a
[INFO] Initializing environment for https://github.com/tofupup/pre-commit-terraform.
Terraform wrapper with for_each in module................................Passed
❯ find wrappers -iname "README.md" -exec grep -i source {} \;
You may want to use a single Terragrunt configuration file to manage multiple resources without duplicating `terragrunt.hcl` files for each copy of the same module.
  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=master//wrappers"
  source = "terraform-aws-modules/s3-bucket/aws//wrappers"
  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=master//wrappers"
You may want to use a single Terragrunt configuration file to manage multiple resources without duplicating `terragrunt.hcl` files for each copy of the same module.
  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers/object"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=master//wrappers/object"
  source = "terraform-aws-modules/s3-bucket/aws//wrappers/object"
  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=master//wrappers"
You may want to use a single Terragrunt configuration file to manage multiple resources without duplicating `terragrunt.hcl` files for each copy of the same module.
  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers/notification"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=master//wrappers/notification"
  source = "terraform-aws-modules/s3-bucket/aws//wrappers/notification"
  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=master//wrappers"
```

</details>

<details><summary>(local) Show fork falls back to original behavior with renamed repo directory and no remote URL - Updated hook output (from fork), terraform-aws-s3-bucket repo host remote origin info removed, repo directory name changed to junkname</summary>

Same tool versions as above run

```bash
❯ mv terraform-aws-s3-bucket junkname
❯ cd junkname
❯ cat .pre-commit-config.yaml
repos:
  - repo: https://github.com/tofupup/pre-commit-terraform
    rev: c98c97898c41ba0b2c61c4cb6dae1c5a2c7cc30f
    hooks:
      - id: terraform_wrapper_module_for_each
❯ git remote -v
origin  https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git (fetch)
origin  https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git (push)
❯ git remote remove origin
❯ git remote -v
❯ pre-commit run -a
[INFO] Initializing environment for https://github.com/tofupup/pre-commit-terraform.
Terraform wrapper with for_each in module................................Failed
- hook id: terraform_wrapper_module_for_each
- files were modified by this hook

Saving files into "/workspaces/pre-commit-terraform/tmp/test/junkname/wrappers/"
Saving files into "/workspaces/pre-commit-terraform/tmp/test/junkname/wrappers/object"
Saving files into "/workspaces/pre-commit-terraform/tmp/test/junkname/wrappers/notification"
❯ find wrappers -iname "README.md" -exec grep -i source {} \;
You may want to use a single Terragrunt configuration file to manage multiple resources without duplicating `terragrunt.hcl` files for each copy of the same module.
  source = "tfr:///terraform-aws-modules/junkname/aws//wrappers"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-junkname.git?ref=master//wrappers"
  source = "terraform-aws-modules/junkname/aws//wrappers"
  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=master//wrappers"
You may want to use a single Terragrunt configuration file to manage multiple resources without duplicating `terragrunt.hcl` files for each copy of the same module.
  source = "tfr:///terraform-aws-modules/junkname/aws//wrappers/object"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-junkname.git?ref=master//wrappers/object"
  source = "terraform-aws-modules/junkname/aws//wrappers/object"
  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=master//wrappers"
You may want to use a single Terragrunt configuration file to manage multiple resources without duplicating `terragrunt.hcl` files for each copy of the same module.
  source = "tfr:///terraform-aws-modules/junkname/aws//wrappers/notification"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-junkname.git?ref=master//wrappers/notification"
  source = "terraform-aws-modules/junkname/aws//wrappers/notification"
  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=master//wrappers"
```

</details>


<details><summary>(local) Show --module-repo-shortname argument still takes precedence - Updated hook output (from fork), terraform-aws-s3-bucket repo has origin set to github repo, repo directory name changed to junkname</summary>

Same tool versions as above run

```bash
❯ cd terraform-aws-s3-bucket
❯ cat .pre-commit-config.yaml
repos:
  - repo: https://github.com/tofupup/pre-commit-terraform
    rev: c98c97898c41ba0b2c61c4cb6dae1c5a2c7cc30f
    hooks:
      - id: terraform_wrapper_module_for_each
        args:
          - '--args=--module-repo-shortname=junk-some-module'
❯ pre-commit run -a
[INFO] Initializing environment for https://github.com/tofupup/pre-commit-terraform.
Terraform wrapper with for_each in module................................Failed
- hook id: terraform_wrapper_module_for_each
- files were modified by this hook

Saving files into "/workspaces/pre-commit-terraform/tmp/test/terraform-aws-s3-bucket/wrappers/"
Saving files into "/workspaces/pre-commit-terraform/tmp/test/terraform-aws-s3-bucket/wrappers/object"
Saving files into "/workspaces/pre-commit-terraform/tmp/test/terraform-aws-s3-bucket/wrappers/notification"
❯ find wrappers -iname "README.md" -exec grep -i source {} \;
You may want to use a single Terragrunt configuration file to manage multiple resources without duplicating `terragrunt.hcl` files for each copy of the same module.
  source = "tfr:///terraform-aws-modules/junk-some-module/aws//wrappers"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-junk-some-module.git?ref=master//wrappers"
  source = "terraform-aws-modules/junk-some-module/aws//wrappers"
  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=master//wrappers"
You may want to use a single Terragrunt configuration file to manage multiple resources without duplicating `terragrunt.hcl` files for each copy of the same module.
  source = "tfr:///terraform-aws-modules/junk-some-module/aws//wrappers/object"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-junk-some-module.git?ref=master//wrappers/object"
  source = "terraform-aws-modules/junk-some-module/aws//wrappers/object"
  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=master//wrappers"
You may want to use a single Terragrunt configuration file to manage multiple resources without duplicating `terragrunt.hcl` files for each copy of the same module.
  source = "tfr:///terraform-aws-modules/junk-some-module/aws//wrappers/notification"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-junk-some-module.git?ref=master//wrappers/notification"
  source = "terraform-aws-modules/junk-some-module/aws//wrappers/notification"
  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=master//wrappers"
```

</details>
