### PR TITLE
feat: Allow running container as non-root UID/GID for ownership issues (docker)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 *
 !.dockerignore
 !Dockerfile
+!tools/entrypoint.sh

--- a/.github/.container-structure-test-config.yaml
+++ b/.github/.container-structure-test-config.yaml
@@ -60,7 +60,7 @@ commandTests:
     args: [ "version" ]
     expectedOutput: [ "([0-9]+\\.){2}[0-9]+\\n$" ]
 
-  - name: 'entrypoint.sh'
+  - name: "entrypoint.sh"
     envVars:
       - key: "USERID"
         value: "1000:1000"
@@ -69,14 +69,12 @@ commandTests:
     expectedOutput: ["^user:gid 1000:1000 lacks permissions to //\\n$"]
     exitCode: 1
 
+  - name: "su-exec"
+    command: "su-exec"
+    expectedOutput: ["^Usage: su-exec user-spec command \\[args\\]\\n$"]
+
 fileExistenceTests:
   - name: 'terrascan init'
-    path: '/root/.terrascan/pkg/policies/opa/rego/github/github_repository/privateRepoEnabled.rego'
-    shouldExist: true
-    uid: 0
-    gid: 0
-
-  - name: 'skeleton terrascan init'
     path: '/root/.terrascan/pkg/policies/opa/rego/github/github_repository/privateRepoEnabled.rego'
     shouldExist: true
     uid: 0

--- a/.github/.container-structure-test-config.yaml
+++ b/.github/.container-structure-test-config.yaml
@@ -60,8 +60,23 @@ commandTests:
     args: [ "version" ]
     expectedOutput: [ "([0-9]+\\.){2}[0-9]+\\n$" ]
 
+  - name: 'entrypoint.sh'
+    envVars:
+      - key: "USERID"
+        value: "1000:1000"
+    command: "/entrypoint.sh"
+    args: [ "-V" ]
+    expectedOutput: ["^user:gid 1000:1000 lacks permissions to //\\n$"]
+    exitCode: 1
+
 fileExistenceTests:
   - name: 'terrascan init'
+    path: '/root/.terrascan/pkg/policies/opa/rego/github/github_repository/privateRepoEnabled.rego'
+    shouldExist: true
+    uid: 0
+    gid: 0
+
+  - name: 'skeleton terrascan init'
     path: '/root/.terrascan/pkg/policies/opa/rego/github/github_repository/privateRepoEnabled.rego'
     shouldExist: true
     uid: 0

--- a/.github/.container-structure-test-config.yaml
+++ b/.github/.container-structure-test-config.yaml
@@ -66,7 +66,7 @@ commandTests:
         value: "1000:1000"
     command: "/entrypoint.sh"
     args: [ "-V" ]
-    expectedOutput: ["^user:gid 1000:1000 lacks permissions to //\\n$"]
+    expectedError: ["^ERROR:  uid:gid 1000:1000 lacks permissions to //\\n$"]
     exitCode: 1
 
   - name: "su-exec"

--- a/.github/workflows/build-image-test.yaml
+++ b/.github/workflows/build-image-test.yaml
@@ -19,6 +19,8 @@ jobs:
         with:
           files: |
             Dockerfile
+            .dockerignore
+            tools/entrypoint.sh
 
       - name: Build if Dockerfile changed
         if: steps.changed-files-specific.outputs.any_changed == 'true'

--- a/Dockerfile
+++ b/Dockerfile
@@ -205,6 +205,7 @@ RUN if [ "$(grep -o '^terraform-docs SKIPPED$' /usr/bin/tools_versions_info)" = 
     apk add --no-cache su-exec=~0
 
 COPY tools/entrypoint.sh /entrypoint.sh
+RUN cp -r /root/ /etc/skel/
 
 ENV PRE_COMMIT_COLOR=${PRE_COMMIT_COLOR:-always}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ WORKDIR /bin_dir
 
 RUN apk add --no-cache \
     # Builder deps
-    curl=~7 \
-    unzip=~6 && \
+    curl=~7 && \
     # Upgrade pip for be able get latest Checkov
     python3 -m pip install --no-cache-dir --upgrade pip
 
@@ -177,7 +176,9 @@ RUN apk add --no-cache \
     bash=~5 \
     # pre-commit-hooks deps: https://github.com/pre-commit/pre-commit-hooks
     musl-dev=~1 \
-    gcc=~10
+    gcc=~10 \
+    # entrypoint wrapper deps
+    su-exec=~0
 
 # Copy tools
 COPY --from=builder \
@@ -201,8 +202,7 @@ RUN if [ "$(grep -o '^terraform-docs SKIPPED$' /usr/bin/tools_versions_info)" = 
     ; fi && \
     # Fix git runtime fatal:
     # unsafe repository ('/lint' is owned by someone else)
-    git config --global --add safe.directory /lint && \
-    apk add --no-cache su-exec=~0
+    git config --global --add safe.directory /lint
 
 COPY tools/entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -178,7 +178,7 @@ RUN apk add --no-cache \
     musl-dev=~1 \
     gcc=~10 \
     # entrypoint wrapper deps
-    su-exec=~0
+    su-exec=~0.2
 
 # Copy tools
 COPY --from=builder \

--- a/Dockerfile
+++ b/Dockerfile
@@ -201,11 +201,14 @@ RUN if [ "$(grep -o '^terraform-docs SKIPPED$' /usr/bin/tools_versions_info)" = 
     ; fi && \
     # Fix git runtime fatal:
     # unsafe repository ('/lint' is owned by someone else)
-    git config --global --add safe.directory /lint
+    git config --global --add safe.directory /lint && \
+    apk add --no-cache su-exec=~0
+
+COPY tools/entrypoint.sh /entrypoint.sh
 
 ENV PRE_COMMIT_COLOR=${PRE_COMMIT_COLOR:-always}
 
 ENV INFRACOST_API_KEY=${INFRACOST_API_KEY:-}
 ENV INFRACOST_SKIP_UPDATE_CHECK=${INFRACOST_SKIP_UPDATE_CHECK:-false}
 
-ENTRYPOINT [ "pre-commit" ]
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -205,7 +205,6 @@ RUN if [ "$(grep -o '^terraform-docs SKIPPED$' /usr/bin/tools_versions_info)" = 
     apk add --no-cache su-exec=~0
 
 COPY tools/entrypoint.sh /entrypoint.sh
-RUN cp -r /root/ /etc/skel/ && rm -rf /etc/skel/.cache/pip
 
 ENV PRE_COMMIT_COLOR=${PRE_COMMIT_COLOR:-always}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -205,7 +205,7 @@ RUN if [ "$(grep -o '^terraform-docs SKIPPED$' /usr/bin/tools_versions_info)" = 
     apk add --no-cache su-exec=~0
 
 COPY tools/entrypoint.sh /entrypoint.sh
-RUN cp -r /root/ /etc/skel/
+RUN cp -r /root/ /etc/skel/ && rm -rf /etc/skel/.cache/pip
 
 ENV PRE_COMMIT_COLOR=${PRE_COMMIT_COLOR:-always}
 

--- a/README.md
+++ b/README.md
@@ -745,7 +745,7 @@ If the generated name is incorrect, set them by providing the `module-repo-short
 ```yaml
 - id: terraform_wrapper_module_for_each
   args:
-    - '--args=--module-repo-shortname=ec2-instance'   # module repo short name
+    - '--args=--module-repo-shortname=ec2-instance'
 ```
 
 ### terrascan

--- a/hooks/terraform_wrapper_module_for_each.sh
+++ b/hooks/terraform_wrapper_module_for_each.sh
@@ -414,6 +414,9 @@ function create_tmp_file_tf {
   mv "$tmp_file" "$tmp_file.tf"
   tmp_file_tf="$tmp_file.tf"
 
+  # mktemp creates with no group/other read permissions
+  chmod a+r "$tmp_file_tf"
+
   echo "$CONTENT_MAIN_TF" > "$tmp_file_tf"
 }
 

--- a/tools/entrypoint.sh
+++ b/tools/entrypoint.sh
@@ -18,9 +18,7 @@ uid=${USERID%%:*}
 gid=${USERID##*:}
 
 # if requested UID:GID is root, go ahead and run without other processing
-if [[ ${uid} == 0 && ${gid} == 0 ]]; then
-  exec su-exec "0:0" pre-commit "$@"
-fi
+[[ $USERID == "0:0" ]] && exec su-exec "$USERID" pre-commit "$@"
 
 # make sure workdir and some files are readable/writable by the provided UID/GID
 # combo, otherwise will have errors when processing hooks

--- a/tools/entrypoint.sh
+++ b/tools/entrypoint.sh
@@ -4,6 +4,7 @@ set -e
 
 readonly USERBASE="run"
 readonly BASHPATH="/bin/bash"
+readonly HOMEPATH="/home"
 
 function echo_error_and_exit {
   echo -e "ERROR: $@" >&2
@@ -15,7 +16,7 @@ function echo_error_and_exit {
 # could be more, so we accept any valid integers
 USERID=${USERID:-"0:0"}
 if [[ ! $USERID =~ ^[0-9]+:[0-9]+$ ]]; then
-  echo_error_and_exit "USERID environment variable invalid, format is userid:groupid.  Received: \"${USERID}\""
+  echo_error_and_exit "USERID environment variable invalid, format is userid:groupid.  Received: \"$USERID\""
 fi
 
 # separate uid and gid
@@ -28,44 +29,44 @@ gid=${USERID##*:}
 # make sure workdir and some files are readable/writable by the provided UID/GID
 # combo, otherwise will have errors when processing hooks
 wdir="$(pwd)"
-if ! su-exec "$USERID" "$BASHPATH" -c "test -w ${wdir} && test -r ${wdir}"; then
-  echo_error_and_exit "uid:gid $USERID lacks permissions to ${wdir}/"
+if ! su-exec "$USERID" "$BASHPATH" -c "test -w $wdir && test -r $wdir"; then
+  echo_error_and_exit "uid:gid $USERID lacks permissions to $wdir/"
 fi
 wdirgitindex="$wdir/.git/index"
 if ! su-exec "$USERID" "$BASHPATH" -c "test -w $wdirgitindex && test -r $wdirgitindex"; then
-  echo_error_and_exit "uid:gid $USERID cannot write to ${wdir}/.git/index"
+  echo_error_and_exit "uid:gid $USERID cannot write to $wdirgitindex"
 fi
 
 # check if group by this GID already exists, if so get the name since adduser
 # only accepts names
-if groupinfo="$(getent group "${gid}")"; then
+if groupinfo="$(getent group "$gid")"; then
   groupname="${groupinfo%%:*}"
 else
   # create group in advance in case GID is different than UID
-  groupname="${USERBASE}${gid}"
-  if ! err="$(addgroup -g "${gid}" "${groupname}" 2>&1)"; then
-    echo_error_and_exit "failed to create gid \"${gid}\" with name \"${groupname}\" command output: \"$err\""
+  groupname="$USERBASE$gid"
+  if ! err="$(addgroup -g "$gid" "$groupname" 2>&1)"; then
+    echo_error_and_exit "failed to create gid \"$gid\" with name \"$groupname\" command output: \"$err\""
   fi
 fi
 
 # check if user by this UID already exists, if so get the name since id
 # only accepts names
-if userinfo="$(getent passwd "${uid}")"; then
+if userinfo="$(getent passwd "$uid")"; then
   username="${userinfo%%:*}"
 else
-  username="${USERBASE}${uid}"
-  if ! err="$(adduser -h "/home/${username}" -s "$BASHPATH" -G "${groupname}" -D -u "${uid}" -k "${HOME}" "${username}" 2>&1)"; then
-    echo_error_and_exit "failed to create uid \"${uid}\" with name \"${username}\" and group \"${groupname}\" command output: \"$err\""
+  username="$USERBASE$uid"
+  if ! err="$(adduser -h "$HOMEPATH$username" -s "$BASHPATH" -G "$groupname" -D -u "$uid" -k "$HOME" "$username" 2>&1)"; then
+    echo_error_and_exit "failed to create uid \"$uid\" with name \"$username\" and group \"$groupname\" command output: \"$err\""
   fi
 fi
 
 # it's possible it was not in the group specified, add it
-if ! idgroupinfo="$(id -G "${username}" 2>&1)"; then
-  echo_error_and_exit "failed to get group list for username \"${username}\" command output: \"$idgroupinfo\""
+if ! idgroupinfo="$(id -G "$username" 2>&1)"; then
+  echo_error_and_exit "failed to get group list for username \"$username\" command output: \"$idgroupinfo\""
 fi
-if [[ ! " ${idgroupinfo} " =~ [:blank:]${gid}[:blank:] ]]; then
-  if ! err="$(addgroup "${username}" "${groupname}" 2>&1)"; then
-    echo_error_and_exit "failed to add user \"${username}\" to group \"${groupname}\" command output: \"${err}\""
+if [[ ! " $idgroupinfo " =~ [:blank:]${gid}[:blank:] ]]; then
+  if ! err="$(addgroup "$username" "$groupname" 2>&1)"; then
+    echo_error_and_exit "failed to add user \"$username\" to group \"$groupname\" command output: \"$err\""
   fi
 fi
 

--- a/tools/entrypoint.sh
+++ b/tools/entrypoint.sh
@@ -73,7 +73,7 @@ if ! idgroupinfo="$(id -G "$username" 2>&1)"; then
 fi
 if [[ ! " $idgroupinfo " =~ [:blank:]${gid}[:blank:] ]]; then
   if ! err="$(addgroup "$username" "$groupname" 2>&1)"; then
-    echo_error_and_exit "failed to add user \"$username\" to group \"$groupname\" command output: \"$err\""
+    echo_error_and_exit "failed to add user \"$username\" to group \"$groupname\"\ncommand output: \"$err\""
   fi
 fi
 

--- a/tools/entrypoint.sh
+++ b/tools/entrypoint.sh
@@ -4,13 +4,13 @@ set -e
 
 readonly USERBASE="run"
 
-# make sure USERID makes sense as UID:GID 
+# make sure USERID makes sense as UID:GID
 # it looks like the alpine distro limits UID and GID to 256000, but
 # could be more, so we accept any valid integers
 USERID=${USERID:-"0:0"}
 if [[ ! $USERID =~ ^[0-9]+:[0-9]+$ ]]; then
-    echo "USERID environment variable invalid, format is userid:groupid.  Received: \"${USERID}\""
-    exit 1
+  echo "USERID environment variable invalid, format is userid:groupid.  Received: \"${USERID}\""
+  exit 1
 fi
 
 # separate uid and gid
@@ -19,60 +19,60 @@ gid=${USERID##*:}
 
 # if requested UID:GID is root, go ahead and run without other processing
 if [[ ${uid} == 0 && ${gid} == 0 ]]; then
-    exec su-exec 0:0 pre-commit "$@"
+  exec su-exec 0:0 pre-commit "$@"
 fi
 
-# make sure workdir and some files are readable/writable by the provided UID/GID 
+# make sure workdir and some files are readable/writable by the provided UID/GID
 # combo, otherwise will have errors when processing hooks
 wdir="$(pwd)"
-if ! su-exec "${uid}:${gid}" "/bin/bash" -c "test -w ${wdir} && test -r ${wdir}" ; then
-    echo "user:gid ${uid}:${gid} lacks permissions to ${wdir}/"
-    exit 1
+if ! su-exec "${uid}:${gid}" "/bin/bash" -c "test -w ${wdir} && test -r ${wdir}"; then
+  echo "user:gid ${uid}:${gid} lacks permissions to ${wdir}/"
+  exit 1
 fi
-if ! su-exec "${uid}:${gid}" "/bin/bash" -c "test -w ${wdir}/.git/index && test -r ${wdir}/.git/index" ; then
-    echo "user:gid ${uid}:${gid} cannot write to ${wdir}/.git/index2"
-    exit 1
+if ! su-exec "${uid}:${gid}" "/bin/bash" -c "test -w ${wdir}/.git/index && test -r ${wdir}/.git/index"; then
+  echo "user:gid ${uid}:${gid} cannot write to ${wdir}/.git/index2"
+  exit 1
 fi
 
 # check if group by this GID already exists, if so get the name since adduser
 # only accepts names
 if groupinfo="$(getent group "${gid}")"; then
-    groupname="${groupinfo%%:*}"
+  groupname="${groupinfo%%:*}"
 else
-    # create group in advance in case GID is different than UID
-    groupname="${USERBASE}${gid}"
-    if ! err="$(addgroup -g "${gid}" "${groupname}" 2>&1)" ; then
-        echo "failed to create gid \"${gid}\" with name \"${groupname}\""
-        echo "command output: ${err}"
-        exit 1
-    fi
+  # create group in advance in case GID is different than UID
+  groupname="${USERBASE}${gid}"
+  if ! err="$(addgroup -g "${gid}" "${groupname}" 2>&1)"; then
+    echo "failed to create gid \"${gid}\" with name \"${groupname}\""
+    echo "command output: ${err}"
+    exit 1
+  fi
 fi
 
 # check if user by this UID already exists, if so get the name since id
 # only accepts names
 if userinfo="$(getent passwd "${uid}")"; then
-    username="${userinfo%%:*}"
+  username="${userinfo%%:*}"
 else
-    username="${USERBASE}${uid}"
-    if ! err="$(adduser -h "/home/${username}" -s "/bin/bash" -G "${groupname}" -D -u "${uid}" -k "/etc/skel" "${username}")" ; then
-        echo "failed to create uid \"${uid}\" with name \"${username}\" and group \"${groupname}\""
-        echo "command output: ${err}"
-        exit 1
-    fi
+  username="${USERBASE}${uid}"
+  if ! err="$(adduser -h "/home/${username}" -s "/bin/bash" -G "${groupname}" -D -u "${uid}" -k "/etc/skel" "${username}")"; then
+    echo "failed to create uid \"${uid}\" with name \"${username}\" and group \"${groupname}\""
+    echo "command output: ${err}"
+    exit 1
+  fi
 fi
 
 # it's possible it was not in the group specified, add it
-if ! idgroupinfo="$(id -G "${username}" 2>&1)" ; then
-    echo "failed to get group list for username \"${username}\""
-    echo "command output: ${idgroupinfo}"
-    exit 1
+if ! idgroupinfo="$(id -G "${username}" 2>&1)"; then
+  echo "failed to get group list for username \"${username}\""
+  echo "command output: ${idgroupinfo}"
+  exit 1
 fi
-if [[ ! " ${idgroupinfo} " =~ [:blank:]${gid}[:blank:] ]] ; then
-    if ! err="$(addgroup "${username}" "${groupname}")" ; then
-        echo "failed to add user \"${username}\" to group \"${groupname}\""
-        echo "command output: ${err}"
-        exit 1
-    fi
+if [[ ! " ${idgroupinfo} " =~ [:blank:]${gid}[:blank:] ]]; then
+  if ! err="$(addgroup "${username}" "${groupname}")"; then
+    echo "failed to add user \"${username}\" to group \"${groupname}\""
+    echo "command output: ${err}"
+    exit 1
+  fi
 fi
 
 # user and group of specified UID/GID should exist now, and user should be

--- a/tools/entrypoint.sh
+++ b/tools/entrypoint.sh
@@ -52,7 +52,7 @@ else
   # create group in advance in case GID is different than UID
   groupname="$USERBASE$gid"
   if ! err="$(addgroup -g "$gid" "$groupname" 2>&1)"; then
-    echo_error_and_exit "failed to create gid \"$gid\" with name \"$groupname\" command output: \"$err\""
+    echo_error_and_exit "failed to create gid \"$gid\" with name \"$groupname\"\ncommand output: \"$err\""
   fi
 fi
 

--- a/tools/entrypoint.sh
+++ b/tools/entrypoint.sh
@@ -71,7 +71,7 @@ fi
 if ! idgroupinfo="$(id -G "$username" 2>&1)"; then
   echo_error_and_exit "failed to get group list for username \"$username\"\ncommand output: \"$idgroupinfo\""
 fi
-if [[ ! " $idgroupinfo " =~ [:blank:]${gid}[:blank:] ]]; then
+if [[ ! " $idgroupinfo " =~ [[:blank:]]${gid}[[:blank:]] ]]; then
   if ! err="$(addgroup "$username" "$groupname" 2>&1)"; then
     echo_error_and_exit "failed to add user \"$username\" to group \"$groupname\"\ncommand output: \"$err\""
   fi

--- a/tools/entrypoint.sh
+++ b/tools/entrypoint.sh
@@ -19,7 +19,7 @@ gid=${USERID##*:}
 
 # if requested UID:GID is root, go ahead and run without other processing
 if [[ ${uid} == 0 && ${gid} == 0 ]]; then
-  exec su-exec 0:0 pre-commit "$@"
+  exec su-exec "0:0" pre-commit "$@"
 fi
 
 # make sure workdir and some files are readable/writable by the provided UID/GID
@@ -54,7 +54,7 @@ if userinfo="$(getent passwd "${uid}")"; then
   username="${userinfo%%:*}"
 else
   username="${USERBASE}${uid}"
-  if ! err="$(adduser -h "/home/${username}" -s "/bin/bash" -G "${groupname}" -D -u "${uid}" -k "/etc/skel" "${username}")"; then
+  if ! err="$(adduser -h "/home/${username}" -s "/bin/bash" -G "${groupname}" -D -u "${uid}" -k "${HOME}" "${username}")"; then
     echo "failed to create uid \"${uid}\" with name \"${username}\" and group \"${groupname}\""
     echo "command output: ${err}"
     exit 1

--- a/tools/entrypoint.sh
+++ b/tools/entrypoint.sh
@@ -63,7 +63,7 @@ if userinfo="$(getent passwd "$uid")"; then
 else
   username="$USERBASE$uid"
   if ! err="$(adduser -h "$HOMEPATH$username" -s "$BASHPATH" -G "$groupname" -D -u "$uid" -k "$HOME" "$username" 2>&1)"; then
-    echo_error_and_exit "failed to create uid \"$uid\" with name \"$username\" and group \"$groupname\" command output: \"$err\""
+    echo_error_and_exit "failed to create uid \"$uid\" with name \"$username\" and group \"$groupname\"\ncommand output: \"$err\""
   fi
 fi
 

--- a/tools/entrypoint.sh
+++ b/tools/entrypoint.sh
@@ -7,7 +7,7 @@ readonly BASHPATH="/bin/bash"
 readonly HOMEPATH="/home"
 
 function echo_error_and_exit {
-  echo -e "ERROR: $@" >&2
+  echo -e "ERROR: " "$@" >&2
   exit 1
 }
 

--- a/tools/entrypoint.sh
+++ b/tools/entrypoint.sh
@@ -2,16 +2,79 @@
 #exit on error
 set -e
 
+readonly USERBASE="run"
+
+# make sure USERID makes sense as UID:GID 
+# it looks like the alpine distro limits UID and GID to 256000, but
+# could be more, so we accept any valid integers
 USERID=${USERID:-"0:0"}
 if [[ ! $USERID =~ ^[0-9]+:[0-9]+$ ]]; then
     echo "USERID environment variable invalid, format is userid:groupid.  Received: \"${USERID}\""
     exit 1
 fi
 
+# separate uid and gid
 uid=${USERID%%:*}
 gid=${USERID##*:}
 
+# if requested UID:GID is root, go ahead and run without other processing
 if [[ ${uid} == 0 && ${gid} == 0 ]]; then
-    su-exec 0:0 pre-commit "$@"
+    exec su-exec 0:0 pre-commit "$@"
 fi
 
+# make sure workdir and some files are readable/writable by the provided UID/GID 
+# combo, otherwise will have errors when processing hooks
+wdir="$(pwd)"
+if ! su-exec "${uid}:${gid}" "/bin/bash" -c "test -w ${wdir} && test -r ${wdir}" ; then
+    echo "user:gid ${uid}:${gid} lacks permissions to ${wdir}/"
+    exit 1
+fi
+if ! su-exec "${uid}:${gid}" "/bin/bash" -c "test -w ${wdir}/.git/index && test -r ${wdir}/.git/index" ; then
+    echo "user:gid ${uid}:${gid} cannot write to ${wdir}/.git/index2"
+    exit 1
+fi
+
+# check if group by this GID already exists, if so get the name since adduser
+# only accepts names
+if groupinfo="$(getent group "${gid}")"; then
+    groupname="${groupinfo%%:*}"
+else
+    # create group in advance in case GID is different than UID
+    groupname="${USERBASE}${gid}"
+    if ! err="$(addgroup -g "${gid}" "${groupname}" 2>&1)" ; then
+        echo "failed to create gid \"${gid}\" with name \"${groupname}\""
+        echo "command output: ${err}"
+        exit 1
+    fi
+fi
+
+# check if user by this UID already exists, if so get the name since id
+# only accepts names
+if userinfo="$(getent passwd "${uid}")"; then
+    username="${userinfo%%:*}"
+else
+    username="${USERBASE}${uid}"
+    if ! err="$(adduser -h "/home/${username}" -s "/bin/bash" -G "${groupname}" -D -u "${uid}" -k "/etc/skel" "${username}")" ; then
+        echo "failed to create uid \"${uid}\" with name \"${username}\" and group \"${groupname}\""
+        echo "command output: ${err}"
+        exit 1
+    fi
+fi
+
+# it's possible it was not in the group specified, add it
+if ! idgroupinfo="$(id -G "${username}" 2>&1)" ; then
+    echo "failed to get group list for username \"${username}\""
+    echo "command output: ${idgroupinfo}"
+    exit 1
+fi
+if [[ ! " ${idgroupinfo} " =~ [:blank:]${gid}[:blank:] ]] ; then
+    if ! err="$(addgroup "${username}" "${groupname}")" ; then
+        echo "failed to add user \"${username}\" to group \"${groupname}\""
+        echo "command output: ${err}"
+        exit 1
+    fi
+fi
+
+# user and group of specified UID/GID should exist now, and user should be
+# a member of group, so execute pre-commit
+exec su-exec "${uid}:${gid}" pre-commit "$@"

--- a/tools/entrypoint.sh
+++ b/tools/entrypoint.sh
@@ -11,6 +11,12 @@ function echo_error_and_exit {
   exit 1
 }
 
+# make sure entrypoint is running as root
+[[ ! $(id -u) == "0" ]] && \
+  echo_error_and_exit "Container must run as root.  Use environment variable USERID to set user.\n"\
+    " example: \"TAG=latest &&" \
+    "docker run -e USERID=$(id -u):$(id -g) -v $(pwd):/lint -w /lint ghcr.io/antonbabenko/pre-commit-terraform:$TAG run -a\""
+
 # make sure USERID makes sense as UID:GID
 # it looks like the alpine distro limits UID and GID to 256000, but
 # could be more, so we accept any valid integers

--- a/tools/entrypoint.sh
+++ b/tools/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#exit on error
+set -e
+
+USERID=${USERID:-"0:0"}
+if [[ ! $USERID =~ ^[0-9]+:[0-9]+$ ]]; then
+    echo "USERID environment variable invalid, format is userid:groupid.  Received: \"${USERID}\""
+    exit 1
+fi
+
+uid=${USERID%%:*}
+gid=${USERID##*:}
+
+if [[ ${uid} == 0 && ${gid} == 0 ]]; then
+    su-exec 0:0 pre-commit "$@"
+fi
+

--- a/tools/entrypoint.sh
+++ b/tools/entrypoint.sh
@@ -12,10 +12,11 @@ function echo_error_and_exit {
 }
 
 # make sure entrypoint is running as root
-[[ ! $(id -u) == "0" ]] && \
-  echo_error_and_exit "Container must run as root.  Use environment variable USERID to set user.\n"\
-    " example: \"TAG=latest &&" \
+if [[ $(id -u) -ne 0 ]]; then
+  echo_error_and_exit "Container must run as root. Use environment variable USERID to set user.\n" \
+    "Example: \"TAG=latest && " \
     "docker run -e USERID=$(id -u):$(id -g) -v $(pwd):/lint -w /lint ghcr.io/antonbabenko/pre-commit-terraform:$TAG run -a\""
+fi
 
 # make sure USERID makes sense as UID:GID
 # it looks like the alpine distro limits UID and GID to 256000, but

--- a/tools/entrypoint.sh
+++ b/tools/entrypoint.sh
@@ -69,7 +69,7 @@ fi
 
 # it's possible it was not in the group specified, add it
 if ! idgroupinfo="$(id -G "$username" 2>&1)"; then
-  echo_error_and_exit "failed to get group list for username \"$username\" command output: \"$idgroupinfo\""
+  echo_error_and_exit "failed to get group list for username \"$username\"\ncommand output: \"$idgroupinfo\""
 fi
 if [[ ! " $idgroupinfo " =~ [:blank:]${gid}[:blank:] ]]; then
   if ! err="$(addgroup "$username" "$groupname" 2>&1)"; then


### PR DESCRIPTION

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

To fix permission issues for the container running as root, the ```terraform_wrapper_module_for_each``` module is changed to add read permissions to generated ```main.tf``` files.  Also, an entrypoint wrapper script is added to create a user/group in the container that matches the desired UID and GID.

There is a "naive" version that just patches ```terraform_wrapper_module_for_each``` and updates the README documentation with a changed ```docker run``` command at https://github.com/tofupup/pre-commit-terraform/tree/4f3d2386a2d10a1a99276bd6f69f9bbe3590a15e (first 2 commits in this branch in my fork)

The entrypoint wrapper script supports su-ing to a non-root user.  It should not break existing functionality/usage of the container.  If the container is run without specifying the ```USERID``` environment variable it will run as root.  Running as root and su-ing to another user gives flexibility for the UID and GID used to run the container, without having to pre-build an image with static values, and also allows creating a "real" user and group inside the container.

Example run command:

```
docker run -e "USERID=$(id -u):$(id -g)" -v $(pwd):/lint -w /lint ghcr.io/antonbabenko/pre-commit-terraform:$TAG run -a
```

```Dockerfile```
* install ```su-exec```, copy entrypoint script and configure ```ENTRYPOINT```

```tools/entrypoint.sh``` 
* ```USERID``` as ```0:0```, or not set, short circuits and runs pre-commit.  
* checks if provided UID and GID have read and write permissions to the ```workdir```, and will error if not
* ```/root``` is used as the skeleton for new user's directory.  This gets the .gitconfig that marks the workdir as safe, as well as avoids another ```terrascan init```.  
* ```su-exec``` is used to su to the requested user, instead of ```gosu```.  

```.github/.container-structure-test-config.yaml```
* Added container structure tests

```.github/workflows/build-image-test.yaml```
* Add .dockerignore and tools/entrypoint.sh to change watch, as either could modify the container functionality

```hooks/terraform_wrapper_module_for_each.sh```
* Add read permissions to temporary files in function ```create_tmp_file_tf```, as these files are moved into the repo.  Other calls to ```mktemp``` in other hooks are truly temporary files.

```README.md```
* Added documentation about ```USERID``` and permissions/ownership


Fixes #432 

### How can we test changes

All tests run using the terraform-aws-ec2-instance repo as base for testing.  We compare sha256sums of all files after a run -a (excluding .git/ and .terraform/ directories and the files within, as they can vary without the contents being different).  We also compare the stat output of all of the files (excluding .git/ as some filenames are variable) to verify permissions are the same, or what we're expecting.

<details><summary>build container with entrypoint script</summary>

```bash
❯ docker build --no-cache -t pre-commit-terraform:entrypoint --build-arg INSTALL_ALL=true .
```
</details>


<details><summary>current docker container</summary>

```bash
❯ TAG=latest && docker run -v $(pwd):/lint -w /lint ghcr.io/antonbabenko/pre-commit-terraform:$TAG run -a
[INFO] Initializing environment for https://github.com/antonbabenko/pre-commit-terraform.
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
Terraform fmt............................................................Passed
Terraform wrapper with for_each in module................................Failed
- hook id: terraform_wrapper_module_for_each
- files were modified by this hook

Saving files into "/lint/wrappers/"

Terraform validate.......................................................Passed
Terraform docs...........................................................Passed
Terraform validate with tflint...........................................Passed
check for merge conflicts................................................Passed
fix end of files.........................................................Passed
❯ sudo sh -c 'find . -type d -name '.git' -prune -o -type d -name '.terraform' -prune -o -type f -print0  | xargs -0 sha256sum | sort > $(pwd).sha256sum'
❯ find . -type d -name '.git' -prune -o -exec stat --format='%n %A %U %G' {} \; | sort > $(pwd).stat
```
</details>

<details><summary>new container version</summary>

```bash
❯ docker run -v $(pwd):/lint -w /lint pre-commit-terraform:entrypoint --version
pre-commit 2.20.0
❯ docker run --entrypoint cat pre-commit-terraform:entrypoint /usr/bin/tools_versions_info
pre-commit 2.20.0
Terraform v1.2.8
checkov 2.1.182
Infracost v0.10.11
terraform-docs version v0.16.0 1f686b1 linux/amd64
terragrunt version v0.38.9
terrascan version: v1.15.2
TFLint version 0.39.3
tfsec v1.27.6
tfupdate 0.6.7
hcledit 0.2.6
```
</details>

<details><summary>new container with no user environment variable specified</summary>

```bash
❯ docker run -v $(pwd):/lint -w /lint pre-commit-terraform:entrypoint run -a
[INFO] Initializing environment for https://github.com/antonbabenko/pre-commit-terraform.
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
Terraform fmt............................................................Passed
Terraform wrapper with for_each in module................................Failed
- hook id: terraform_wrapper_module_for_each
- files were modified by this hook

Saving files into "/lint/wrappers/"

Terraform validate.......................................................Passed
Terraform docs...........................................................Passed
Terraform validate with tflint...........................................Passed
check for merge conflicts................................................Passed
fix end of files.........................................................Passed
❯ sudo sh -c 'find . -type d -name '.git' -prune -o -type d -name '.terraform' -prune -o -type f -print0  | xargs -0 sha256sum | sort > $(pwd).sha256sum'
❯ find . -type d -name '.git' -prune -o -exec stat --format='%n %A %U %G' {} \; | sort > $(pwd).stat
```
</details>

<details><summary>new container with USERID=0:0</summary>

```bash
❯ docker run -e "USERID=0:0" -v $(pwd):/lint -w /lint pre-commit-terraform:entrypoint run -a
[INFO] Initializing environment for https://github.com/antonbabenko/pre-commit-terraform.
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
Terraform fmt............................................................Passed
Terraform wrapper with for_each in module................................Failed
- hook id: terraform_wrapper_module_for_each
- files were modified by this hook

Saving files into "/lint/wrappers/"

Terraform validate.......................................................Passed
Terraform docs...........................................................Passed
Terraform validate with tflint...........................................Passed
check for merge conflicts................................................Passed
fix end of files.........................................................Passed
❯ sudo sh -c 'find . -type d -name '.git' -prune -o -type d -name '.terraform' -prune -o -type f -print0  | xargs -0 sha256sum | sort > $(pwd).sha256sum'
[sudo] password for john:
❯ find . -type d -name '.git' -prune -o -exec stat --format='%n %A %U %G' {} \; | sort > $(pwd).stat
```
</details>

<details><summary>Verify the output of the original container, and the new containers run with root permissions output the same files and permissions</summary>

```bash
❯ sha256sum *.stat
340bc54ce35d476c90cb9274611dccc3e829b84b95bc515b6de0eb727e24a0be  terraform-aws-ec2-instance.newcont-0x0.stat
340bc54ce35d476c90cb9274611dccc3e829b84b95bc515b6de0eb727e24a0be  terraform-aws-ec2-instance.newcont-nouser.stat
340bc54ce35d476c90cb9274611dccc3e829b84b95bc515b6de0eb727e24a0be  terraform-aws-ec2-instance.orig.stat
❯ sha256sum *.sha256sum
8878c7373eb5d89130efed62d74336eaaf3e773335b7a82d9f02b3495200bbb6  terraform-aws-ec2-instance.newcont-0x0.sha256sum
8878c7373eb5d89130efed62d74336eaaf3e773335b7a82d9f02b3495200bbb6  terraform-aws-ec2-instance.newcont-nouser.sha256sum
8878c7373eb5d89130efed62d74336eaaf3e773335b7a82d9f02b3495200bbb6  terraform-aws-ec2-instance.orig.sha256sum
```
</details>

<details><summary>Files not owned by UID 1000 after run</summary>

```bash
generated .terraform/ directories and files, throughout repository
.git/index
wrappers/main.tf
```
</details>

<details><summary>Run setting USERID to 1000:1000 (matching repository files)</summary>

```bash
❯ docker run -e "USERID=1000:1000" -v $(pwd):/lint -w /lint pre-commit-terraform:entrypoint run -a
[INFO] Initializing environment for https://github.com/antonbabenko/pre-commit-terraform.
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
Terraform fmt............................................................Passed
Terraform wrapper with for_each in module................................Failed
- hook id: terraform_wrapper_module_for_each
- files were modified by this hook

Saving files into "/lint/wrappers/"

Terraform validate.......................................................Passed
Terraform docs...........................................................Passed
Terraform validate with tflint...........................................Passed
check for merge conflicts................................................Passed
fix end of files.........................................................Passed
❯ sudo sh -c 'find . -type d -name '.git' -prune -o -type d -name '.terraform' -prune -o -type f -print0  | xargs -0 sha256sum | sort > $(pwd).sha256sum'
❯ sha256sum ../terraform-aws-ec2-instance.newcont-1000x1000.sha256sum ../terraform-aws-ec2-instance.orig.sha256sum
8878c7373eb5d89130efed62d74336eaaf3e773335b7a82d9f02b3495200bbb6  ../terraform-aws-ec2-instance.newcont-1000x1000.sha256sum
8878c7373eb5d89130efed62d74336eaaf3e773335b7a82d9f02b3495200bbb6  ../terraform-aws-ec2-instance.orig.sha256sum
❯ find . ! -user 1000
❯ find . ! -group 1000
```

</details>

<details><summary>new container verify running single hook</summary>

```bash
❯ docker run -e "USERID=1000:1000" -v $(pwd):/lint -w /lint pre-commit-terraform:entrypoint run -a terraform_validate
[INFO] Initializing environment for https://github.com/antonbabenko/pre-commit-terraform.
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
Terraform validate.......................................................Passed
❯ find . ! -user 1000
❯ find . ! -group 1000
```
</details>

<details><summary>Run setting USERID to 1000:2000 (UID matches, but GID does not)</summary>

As expected the UIDs of all files are correct, but the GID of the same files that were set to root in the original run is now 2000.
```bash
❯ docker run -e "USERID=1000:2000" -v $(pwd):/lint -w /lint pre-commit-terraform:entrypoint run -a
[INFO] Initializing environment for https://github.com/antonbabenko/pre-commit-terraform.
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
Terraform fmt............................................................Passed
Terraform wrapper with for_each in module................................Failed
- hook id: terraform_wrapper_module_for_each
- files were modified by this hook

Saving files into "/lint/wrappers/"

Terraform validate.......................................................Passed
Terraform docs...........................................................Passed
Terraform validate with tflint...........................................Passed
check for merge conflicts................................................Passed
fix end of files.........................................................Passed
❯ sudo sh -c 'find . -type d -name '.git' -prune -o -type d -name '.terraform' -prune -o -type f -print0  | xargs -0 sha256sum | sort > $(pwd).sha256sum'
❯ sha256sum ../terraform-aws-ec2-instance.newcont-1000x2000.sha256sum ../terraform-aws-ec2-instance.orig.sha256sum
8878c7373eb5d89130efed62d74336eaaf3e773335b7a82d9f02b3495200bbb6  ../terraform-aws-ec2-instance.newcont-1000x2000.sha256sum
8878c7373eb5d89130efed62d74336eaaf3e773335b7a82d9f02b3495200bbb6  ../terraform-aws-ec2-instance.orig.sha256sum
❯ find . ! -user 1000
❯ find . -group 2000
```
</details>

<details><summary>Run with invalid USERID</summary>

```bash
❯ docker run -e "USERID=10t0:2000" -v $(pwd):/lint -w /lint pre-commit-terraform:entrypoint run -a
USERID environment variable invalid, format is userid:groupid.  Received: "10t0:2000"
```
</details>

<details><summary>Run with USERID 2000:3000, no permissions on repository</summary>

```bash
❯ docker run -e "USERID=2000:3000" -v $(pwd):/lint -w /lint pre-commit-terraform:entrypoint run -a
user:gid 2000:3000 lacks permissions to /lint/
```
</details>

<details><summary>Run with USERID 2000:1000, no write permissions on repository, but do have read</summary>

```bash
❯ docker run -e "USERID=2000:1000" -v $(pwd):/lint -w /lint pre-commit-terraform:entrypoint run -a
user:gid 2000:1000 lacks permissions to /lint/
```
</details>
