### PR TITLE
feat: Add support for version constraints in `tfupdate`

### DIFF
--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -164,17 +164,21 @@ function common::is_hook_run_on_whole_repo {
 # 3. Complete hook execution and return exit code
 # Arguments:
 #   hook_id (string) hook ID, see `- id` for details in .pre-commit-hooks.yaml file
-#   args (string with array) arguments that configure wrapped tool behavior
+#   args_array_length (integer) Count of arguments in args array.
+#   args (array) arguments that configure wrapped tool behavior
 #   files (array) filenames to check
 #######################################################################
 function common::per_dir_hook {
   local -r hook_id="$1"
-  # Expand args to a true array
-  local -a args=()
-  while read -r -d '' ARG; do
-    args+=("$ARG")
-  done < <(echo "$2" | xargs printf '%s\0')
+  local -i args_array_length=$2
   shift 2
+  local -a args=()
+  # Expand args to a true array.
+  # Based on https://stackoverflow.com/a/10953834
+  while ((args_array_length-- > 0)); do
+    args+=("$1")
+    shift
+  done
   # assign rest of function's positional ARGS into `files` array,
   # despite there's only one positional ARG left
   local -a -r files=("$@")

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -164,21 +164,17 @@ function common::is_hook_run_on_whole_repo {
 # 3. Complete hook execution and return exit code
 # Arguments:
 #   hook_id (string) hook ID, see `- id` for details in .pre-commit-hooks.yaml file
-#   args_array_length (integer) Count of arguments in args array.
-#   args (array) arguments that configure wrapped tool behavior
+#   args (string with array) arguments that configure wrapped tool behavior
 #   files (array) filenames to check
 #######################################################################
 function common::per_dir_hook {
   local -r hook_id="$1"
-  local -i args_array_length=$2
-  shift 2
+  # Expand args to a true array
   local -a args=()
-  # Expand args to a true array.
-  # Based on https://stackoverflow.com/a/10953834
-  while ((args_array_length-- > 0)); do
-    args+=("$1")
-    shift
-  done
+  while read -r -d '' ARG; do
+    args+=("$ARG")
+  done < <(echo "$2" | xargs printf '%s\0')
+  shift 2
   # assign rest of function's positional ARGS into `files` array,
   # despite there's only one positional ARG left
   local -a -r files=("$@")

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -129,7 +129,7 @@ function common::parse_and_export_env_vars {
 #######################################################################
 function common::is_hook_run_on_whole_repo {
   local -r hook_id="$1"
-  shift 1
+  shift
   local -a -r files=("$@")
   # get directory containing `.pre-commit-hooks.yaml` file
   local -r root_config_dir="$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)")"
@@ -170,16 +170,17 @@ function common::is_hook_run_on_whole_repo {
 #######################################################################
 function common::per_dir_hook {
   local -r hook_id="$1"
-  declare -i args_array_length=$2
+  local -i args_array_length=$2
   shift 2
-  declare -a args=()
+  local -a args=()
   # Expand args to a true array.
   # Based on https://stackoverflow.com/a/10953834
   while ((args_array_length-- > 0)); do
     args+=("$1")
     shift
   done
-
+  # assign rest of function's positional ARGS into `files` array,
+  # despite there's only one positional ARG left
   local -a -r files=("$@")
 
   # check is (optional) function defined

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -168,8 +168,8 @@ function common::is_hook_run_on_whole_repo {
 #   files (array) filenames to check
 #######################################################################
 function common::per_dir_hook {
-  local -r args="$1"
-  local -r hook_id="$2"
+  local -r hook_id="$1"
+  local -r args="$2"
   shift 2
   local -a -r files=("$@")
 

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -212,7 +212,7 @@ function common::per_dir_hook {
     dir_path="${dir_path//__REPLACED__SPACE__/ }"
     pushd "$dir_path" > /dev/null || continue
 
-    per_dir_hook_unique_part "${args[@]}" "$dir_path"
+    per_dir_hook_unique_part "$dir_path" "${args[@]}"
 
     local exit_code=$?
     if [ $exit_code -ne 0 ]; then

--- a/hooks/terraform_checkov.sh
+++ b/hooks/terraform_checkov.sh
@@ -20,7 +20,7 @@ function main {
     export ANSI_COLORS_DISABLED=true
   fi
   # shellcheck disable=SC2128 # It's the simplest syntax for that case
-  common::per_dir_hook "$ARGS" "$HOOK_ID" "${FILES[@]}"
+  common::per_dir_hook "$HOOK_ID" "$ARGS" "${FILES[@]}"
 }
 
 #######################################################################

--- a/hooks/terraform_checkov.sh
+++ b/hooks/terraform_checkov.sh
@@ -22,27 +22,26 @@ function main {
     export ANSI_COLORS_DISABLED=true
   fi
 
-  common::per_dir_hook "$HOOK_ID" "${ARGS[*]}" "${FILES[@]}"
+  common::per_dir_hook "$HOOK_ID" "${#ARGS[@]}" "${ARGS[@]}" "${FILES[@]}"
 }
 
 #######################################################################
 # Unique part of `common::per_dir_hook`. The function is executed in loop
 # on each provided dir path. Run wrapped tool with specified arguments
 # Arguments:
-#   args (string with array) arguments that configure wrapped tool behavior
 #   dir_path (string) PATH to dir relative to git repo root.
 #     Can be used in error logging
+#   args (array) arguments that configure wrapped tool behavior
 # Outputs:
 #   If failed - print out hook checks status
 #######################################################################
 function per_dir_hook_unique_part {
-  # common logic located in common::per_dir_hook
-  local -r args="$1"
   # shellcheck disable=SC2034 # Unused var.
-  local -r dir_path="$2"
+  local -r dir_path="$1"
+  shift
+  local -a -r args=("$@")
 
-  # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
-  checkov -d . ${args[@]}
+  checkov -d . "${args[@]}"
 
   # return exit code to common::per_dir_hook
   local exit_code=$?
@@ -53,14 +52,13 @@ function per_dir_hook_unique_part {
 # Unique part of `common::per_dir_hook`. The function is executed one time
 # in the root git repo
 # Arguments:
-#   args (string with array) arguments that configure wrapped tool behavior
+#   args (array) arguments that configure wrapped tool behavior
 #######################################################################
 function run_hook_on_whole_repo {
-  local -r args="$1"
+  local -a -r args=("$@")
 
   # pass the arguments to hook
-  # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
-  checkov -d "$(pwd)" ${args[@]}
+  checkov -d "$(pwd)" "${args[@]}"
 
   # return exit code to common::per_dir_hook
   local exit_code=$?

--- a/hooks/terraform_checkov.sh
+++ b/hooks/terraform_checkov.sh
@@ -13,14 +13,16 @@ function main {
   common::export_provided_env_vars "${ENV_VARS[@]}"
   common::parse_and_export_env_vars
   # Support for setting PATH to repo root.
-  # shellcheck disable=SC2178 # It's the simplest syntax for that case
-  ARGS=${ARGS[*]/__GIT_WORKING_DIR__/$(pwd)\/}
+  for i in "${!ARGS[@]}"; do
+    ARGS[i]=${ARGS[i]/__GIT_WORKING_DIR__/$(pwd)\/}
+  done
+
   # Suppress checkov color
   if [ "$PRE_COMMIT_COLOR" = "never" ]; then
     export ANSI_COLORS_DISABLED=true
   fi
-  # shellcheck disable=SC2128 # It's the simplest syntax for that case
-  common::per_dir_hook "$HOOK_ID" "$ARGS" "${FILES[@]}"
+
+  common::per_dir_hook "$HOOK_ID" "${ARGS[*]}" "${FILES[@]}"
 }
 
 #######################################################################

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -91,7 +91,7 @@ function terraform_docs {
   shift 3
   local -a -r files=("$@")
 
-  declare -a paths
+  local -a paths
 
   local index=0
   local file_with_path

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -12,12 +12,12 @@ function main {
   common::parse_cmdline "$@"
   common::export_provided_env_vars "${ENV_VARS[@]}"
   common::parse_and_export_env_vars
-  # Support for setting relative PATH to .terraform-docs.yml config.
-  # shellcheck disable=SC2178 # It's the simplest syntax for that case
-  ARGS=${ARGS[*]/--config=/--config=$(pwd)\/}
-  # shellcheck disable=SC2128 # It's the simplest syntax for that case
+  # Support for setting PATH to repo root.
+  for i in "${!ARGS[@]}"; do
+    ARGS[i]=${ARGS[i]/__GIT_WORKING_DIR__/$(pwd)\/}
+  done
   # shellcheck disable=SC2153 # False positive
-  terraform_docs_ "${HOOK_CONFIG[*]}" "$ARGS" "${FILES[@]}"
+  terraform_docs_ "${HOOK_CONFIG[*]}" "${ARGS[*]}" "${FILES[@]}"
 }
 
 #######################################################################

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -14,7 +14,7 @@ function main {
   common::parse_and_export_env_vars
   # Support for setting PATH to repo root.
   for i in "${!ARGS[@]}"; do
-    ARGS[i]=${ARGS[i]/__GIT_WORKING_DIR__/$(pwd)\/}
+    ARGS[i]=${ARGS[i]/--config=/--config=$(pwd)\/}
   done
   # shellcheck disable=SC2153 # False positive
   terraform_docs_ "${HOOK_CONFIG[*]}" "${ARGS[*]}" "${FILES[@]}"

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -12,7 +12,7 @@ function main {
   common::parse_cmdline "$@"
   common::export_provided_env_vars "${ENV_VARS[@]}"
   common::parse_and_export_env_vars
-  # Support for setting PATH to repo root.
+  # Support for setting relative PATH to .terraform-docs.yml config.
   for i in "${!ARGS[@]}"; do
     ARGS[i]=${ARGS[i]/--config=/--config=$(pwd)\/}
   done

--- a/hooks/terraform_fmt.sh
+++ b/hooks/terraform_fmt.sh
@@ -19,27 +19,27 @@ function main {
   fi
 
   # shellcheck disable=SC2153 # False positive
-  common::per_dir_hook "$HOOK_ID" "${ARGS[*]}" "${FILES[@]}"
+  common::per_dir_hook "$HOOK_ID" "${#ARGS[@]}" "${ARGS[@]}" "${FILES[@]}"
 }
 
 #######################################################################
 # Unique part of `common::per_dir_hook`. The function is executed in loop
 # on each provided dir path. Run wrapped tool with specified arguments
 # Arguments:
-#   args (string with array) arguments that configure wrapped tool behavior
 #   dir_path (string) PATH to dir relative to git repo root.
 #     Can be used in error logging
+#   args (array) arguments that configure wrapped tool behavior
 # Outputs:
 #   If failed - print out hook checks status
 #######################################################################
 function per_dir_hook_unique_part {
-  local -r args="$1"
   # shellcheck disable=SC2034 # Unused var.
-  local -r dir_path="$2"
+  local -r dir_path="$1"
+  shift
+  local -a -r args=("$@")
 
   # pass the arguments to hook
-  # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
-  terraform fmt ${args[@]}
+  terraform fmt "${args[@]}"
 
   # return exit code to common::per_dir_hook
   local exit_code=$?

--- a/hooks/terraform_fmt.sh
+++ b/hooks/terraform_fmt.sh
@@ -19,7 +19,7 @@ function main {
   fi
 
   # shellcheck disable=SC2153 # False positive
-  common::per_dir_hook "${ARGS[*]}" "$HOOK_ID" "${FILES[@]}"
+  common::per_dir_hook "$HOOK_ID" "${ARGS[*]}" "${FILES[@]}"
 }
 
 #######################################################################

--- a/hooks/terraform_providers_lock.sh
+++ b/hooks/terraform_providers_lock.sh
@@ -16,7 +16,7 @@ function main {
   # JFYI: suppress color for `terraform providers lock` is N/A`
 
   # shellcheck disable=SC2153 # False positive
-  common::per_dir_hook "${ARGS[*]}" "$HOOK_ID" "${FILES[@]}"
+  common::per_dir_hook "$HOOK_ID" "${ARGS[*]}" "${FILES[@]}"
 }
 
 #######################################################################

--- a/hooks/terraform_providers_lock.sh
+++ b/hooks/terraform_providers_lock.sh
@@ -16,22 +16,23 @@ function main {
   # JFYI: suppress color for `terraform providers lock` is N/A`
 
   # shellcheck disable=SC2153 # False positive
-  common::per_dir_hook "$HOOK_ID" "${ARGS[*]}" "${FILES[@]}"
+  common::per_dir_hook "$HOOK_ID" "${#ARGS[@]}" "${ARGS[@]}" "${FILES[@]}"
 }
 
 #######################################################################
 # Unique part of `common::per_dir_hook`. The function is executed in loop
 # on each provided dir path. Run wrapped tool with specified arguments
 # Arguments:
-#   args (string with array) arguments that configure wrapped tool behavior
 #   dir_path (string) PATH to dir relative to git repo root.
 #     Can be used in error logging
+#   args (array) arguments that configure wrapped tool behavior
 # Outputs:
 #   If failed - print out hook checks status
 #######################################################################
 function per_dir_hook_unique_part {
-  local -r args="$1"
-  local -r dir_path="$2"
+  local -r dir_path="$1"
+  shift
+  local -a -r args=("$@")
 
   local exit_code
 
@@ -41,8 +42,7 @@ function per_dir_hook_unique_part {
   }
 
   # pass the arguments to hook
-  # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
-  terraform providers lock ${args[@]}
+  terraform providers lock "${args[@]}"
 
   # return exit code to common::per_dir_hook
   exit_code=$?

--- a/hooks/terraform_tflint.sh
+++ b/hooks/terraform_tflint.sh
@@ -31,7 +31,7 @@ function main {
     return ${exit_code}
   }
   # shellcheck disable=SC2128 # It's the simplest syntax for that case
-  common::per_dir_hook "$ARGS" "$HOOK_ID" "${FILES[@]}"
+  common::per_dir_hook "$HOOK_ID" "$ARGS" "${FILES[@]}"
 }
 
 #######################################################################

--- a/hooks/terraform_tflint.sh
+++ b/hooks/terraform_tflint.sh
@@ -32,30 +32,30 @@ function main {
     return ${exit_code}
   }
 
-  common::per_dir_hook "$HOOK_ID" "${ARGS[*]}" "${FILES[@]}"
+  common::per_dir_hook "$HOOK_ID" "${#ARGS[@]}" "${ARGS[@]}" "${FILES[@]}"
 }
 
 #######################################################################
 # Unique part of `common::per_dir_hook`. The function is executed in loop
 # on each provided dir path. Run wrapped tool with specified arguments
 # Arguments:
-#   args (string with array) arguments that configure wrapped tool behavior
 #   dir_path (string) PATH to dir relative to git repo root.
 #     Can be used in error logging
+#   args (array) arguments that configure wrapped tool behavior
 # Outputs:
 #   If failed - print out hook checks status
 #######################################################################
 function per_dir_hook_unique_part {
-  local -r args="$1"
-  local -r dir_path="$2"
+  local -r dir_path="$1"
+  shift
+  local -a -r args=("$@")
 
   # Print checked PATH **only** if TFLint have any messages
   # shellcheck disable=SC2091,SC2068 # Suppress error output
   $(tflint ${args[@]} 2>&1) 2> /dev/null || {
     common::colorify "yellow" "TFLint in $dir_path/:"
 
-    # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
-    tflint ${args[@]}
+    tflint "${args[@]}"
   }
 
   # return exit code to common::per_dir_hook

--- a/hooks/terraform_tflint.sh
+++ b/hooks/terraform_tflint.sh
@@ -14,8 +14,9 @@ function main {
   common::export_provided_env_vars "${ENV_VARS[@]}"
   common::parse_and_export_env_vars
   # Support for setting PATH to repo root.
-  # shellcheck disable=SC2178 # It's the simplest syntax for that case
-  ARGS=${ARGS[*]/__GIT_WORKING_DIR__/$(pwd)\/}
+  for i in "${!ARGS[@]}"; do
+    ARGS[i]=${ARGS[i]/__GIT_WORKING_DIR__/$(pwd)\/}
+  done
   # JFYI: tflint color already suppressed via PRE_COMMIT_COLOR=never
 
   # Run `tflint --init` for check that plugins installed.
@@ -30,8 +31,8 @@ function main {
     echo "${TFLINT_INIT}"
     return ${exit_code}
   }
-  # shellcheck disable=SC2128 # It's the simplest syntax for that case
-  common::per_dir_hook "$HOOK_ID" "$ARGS" "${FILES[@]}"
+
+  common::per_dir_hook "$HOOK_ID" "${ARGS[*]}" "${FILES[@]}"
 }
 
 #######################################################################

--- a/hooks/terraform_tfsec.sh
+++ b/hooks/terraform_tfsec.sh
@@ -23,7 +23,7 @@ function main {
   fi
 
   # shellcheck disable=SC2128 # It's the simplest syntax for that case
-  common::per_dir_hook "$ARGS" "$HOOK_ID" "${FILES[@]}"
+  common::per_dir_hook "$HOOK_ID" "$ARGS" "${FILES[@]}"
 }
 
 #######################################################################

--- a/hooks/terraform_tfsec.sh
+++ b/hooks/terraform_tfsec.sh
@@ -19,7 +19,6 @@ function main {
 
   # Suppress tfsec color
   if [ "$PRE_COMMIT_COLOR" = "never" ]; then
-    # shellcheck disable=SC2178,SC2128 # It's the simplest syntax for that case
     ARGS+=("--no-color")
   fi
 

--- a/hooks/terraform_tfsec.sh
+++ b/hooks/terraform_tfsec.sh
@@ -13,17 +13,17 @@ function main {
   common::export_provided_env_vars "${ENV_VARS[@]}"
   common::parse_and_export_env_vars
   # Support for setting PATH to repo root.
-  # shellcheck disable=SC2178 # It's the simplest syntax for that case
-  ARGS=${ARGS[*]/__GIT_WORKING_DIR__/$(pwd)\/}
+  for i in "${!ARGS[@]}"; do
+    ARGS[i]=${ARGS[i]/__GIT_WORKING_DIR__/$(pwd)\/}
+  done
 
   # Suppress tfsec color
   if [ "$PRE_COMMIT_COLOR" = "never" ]; then
     # shellcheck disable=SC2178,SC2128 # It's the simplest syntax for that case
-    ARGS+=" --no-color"
+    ARGS+=("--no-color")
   fi
 
-  # shellcheck disable=SC2128 # It's the simplest syntax for that case
-  common::per_dir_hook "$HOOK_ID" "$ARGS" "${FILES[@]}"
+  common::per_dir_hook "$HOOK_ID" "${ARGS[*]}" "${FILES[@]}"
 }
 
 #######################################################################

--- a/hooks/terraform_tfsec.sh
+++ b/hooks/terraform_tfsec.sh
@@ -22,27 +22,27 @@ function main {
     ARGS+=("--no-color")
   fi
 
-  common::per_dir_hook "$HOOK_ID" "${ARGS[*]}" "${FILES[@]}"
+  common::per_dir_hook "$HOOK_ID" "${#ARGS[@]}" "${ARGS[@]}" "${FILES[@]}"
 }
 
 #######################################################################
 # Unique part of `common::per_dir_hook`. The function is executed in loop
 # on each provided dir path. Run wrapped tool with specified arguments
 # Arguments:
-#   args (string with array) arguments that configure wrapped tool behavior
 #   dir_path (string) PATH to dir relative to git repo root.
 #     Can be used in error logging
+#   args (array) arguments that configure wrapped tool behavior
 # Outputs:
 #   If failed - print out hook checks status
 #######################################################################
 function per_dir_hook_unique_part {
-  local -r args="$1"
   # shellcheck disable=SC2034 # Unused var.
-  local -r dir_path="$2"
+  local -r dir_path="$1"
+  shift
+  local -a -r args=("$@")
 
   # pass the arguments to hook
-  # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
-  tfsec ${args[@]}
+  tfsec "${args[@]}"
 
   # return exit code to common::per_dir_hook
   local exit_code=$?
@@ -53,14 +53,13 @@ function per_dir_hook_unique_part {
 # Unique part of `common::per_dir_hook`. The function is executed one time
 # in the root git repo
 # Arguments:
-#   args (string with array) arguments that configure wrapped tool behavior
+#   args (array) arguments that configure wrapped tool behavior
 #######################################################################
 function run_hook_on_whole_repo {
-  local -r args="$1"
+  local -a -r args=("$@")
 
   # pass the arguments to hook
-  # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
-  tfsec "$(pwd)" ${args[@]}
+  tfsec "$(pwd)" "${args[@]}"
 
   # return exit code to common::per_dir_hook
   local exit_code=$?

--- a/hooks/terraform_validate.sh
+++ b/hooks/terraform_validate.sh
@@ -21,7 +21,7 @@ function main {
     ARGS+=("-no-color")
   fi
   # shellcheck disable=SC2153 # False positive
-  common::per_dir_hook "${ARGS[*]}" "$HOOK_ID" "${FILES[@]}"
+  common::per_dir_hook "$HOOK_ID" "${ARGS[*]}" "${FILES[@]}"
 }
 
 #######################################################################

--- a/hooks/terraform_validate.sh
+++ b/hooks/terraform_validate.sh
@@ -21,7 +21,7 @@ function main {
     ARGS+=("-no-color")
   fi
   # shellcheck disable=SC2153 # False positive
-  common::per_dir_hook "$HOOK_ID" "${ARGS[*]}" "${FILES[@]}"
+  common::per_dir_hook "$HOOK_ID" "${#ARGS[@]}" "${ARGS[@]}" "${FILES[@]}"
 }
 
 #######################################################################
@@ -31,17 +31,16 @@ function main {
 # 2. Run `terraform validate`
 # 3. If at least 1 check failed - change the exit code to non-zero
 # Arguments:
-#   args (string with array) arguments that configure wrapped tool behavior
 #   dir_path (string) PATH to dir relative to git repo root.
 #     Can be used in error logging
-#   ENV_VARS (array) environment variables that will be used with
-#     `terraform` commands
+#   args (array) arguments that configure wrapped tool behavior
 # Outputs:
 #   If failed - print out hook checks status
 #######################################################################
 function per_dir_hook_unique_part {
-  local -r args="$1"
-  local -r dir_path="$2"
+  local -r dir_path="$1"
+  shift
+  local -a -r args=("$@")
 
   local exit_code
   local validate_output
@@ -52,8 +51,7 @@ function per_dir_hook_unique_part {
   }
 
   # pass the arguments to hook
-  # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
-  validate_output=$(terraform validate ${args[@]} 2>&1)
+  validate_output=$(terraform validate "${args[@]}" 2>&1)
   exit_code=$?
 
   if [ $exit_code -ne 0 ]; then

--- a/hooks/terragrunt_fmt.sh
+++ b/hooks/terragrunt_fmt.sh
@@ -15,7 +15,7 @@ function main {
   # JFYI: terragrunt hclfmt color already suppressed via PRE_COMMIT_COLOR=never
 
   # shellcheck disable=SC2153 # False positive
-  common::per_dir_hook "${ARGS[*]}" "$HOOK_ID" "${FILES[@]}"
+  common::per_dir_hook "$HOOK_ID" "${ARGS[*]}" "${FILES[@]}"
 }
 
 #######################################################################

--- a/hooks/terragrunt_fmt.sh
+++ b/hooks/terragrunt_fmt.sh
@@ -15,27 +15,27 @@ function main {
   # JFYI: terragrunt hclfmt color already suppressed via PRE_COMMIT_COLOR=never
 
   # shellcheck disable=SC2153 # False positive
-  common::per_dir_hook "$HOOK_ID" "${ARGS[*]}" "${FILES[@]}"
+  common::per_dir_hook "$HOOK_ID" "${#ARGS[@]}" "${ARGS[@]}" "${FILES[@]}"
 }
 
 #######################################################################
 # Unique part of `common::per_dir_hook`. The function is executed in loop
 # on each provided dir path. Run wrapped tool with specified arguments
 # Arguments:
-#   args (string with array) arguments that configure wrapped tool behavior
 #   dir_path (string) PATH to dir relative to git repo root.
 #     Can be used in error logging
+#   args (array) arguments that configure wrapped tool behavior
 # Outputs:
 #   If failed - print out hook checks status
 #######################################################################
 function per_dir_hook_unique_part {
-  local -r args="$1"
   # shellcheck disable=SC2034 # Unused var.
-  local -r dir_path="$2"
+  local -r dir_path="$1"
+  shift
+  local -a -r args=("$@")
 
   # pass the arguments to hook
-  # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
-  terragrunt hclfmt ${args[@]}
+  terragrunt hclfmt "${args[@]}"
 
   # return exit code to common::per_dir_hook
   local exit_code=$?
@@ -46,14 +46,13 @@ function per_dir_hook_unique_part {
 # Unique part of `common::per_dir_hook`. The function is executed one time
 # in the root git repo
 # Arguments:
-#   args (string with array) arguments that configure wrapped tool behavior
+#   args (array) arguments that configure wrapped tool behavior
 #######################################################################
 function run_hook_on_whole_repo {
-  local -r args="$1"
+  local -a -r args=("$@")
 
   # pass the arguments to hook
-  # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
-  terragrunt hclfmt "$(pwd)" ${args[@]}
+  terragrunt hclfmt "$(pwd)" "${args[@]}"
 
   # return exit code to common::per_dir_hook
   local exit_code=$?

--- a/hooks/terragrunt_validate.sh
+++ b/hooks/terragrunt_validate.sh
@@ -15,7 +15,7 @@ function main {
   # JFYI: terragrunt validate color already suppressed via PRE_COMMIT_COLOR=never
 
   # shellcheck disable=SC2153 # False positive
-  common::per_dir_hook "${ARGS[*]}" "$HOOK_ID" "${FILES[@]}"
+  common::per_dir_hook "$HOOK_ID" "${ARGS[*]}" "${FILES[@]}"
 }
 
 #######################################################################

--- a/hooks/terragrunt_validate.sh
+++ b/hooks/terragrunt_validate.sh
@@ -15,27 +15,27 @@ function main {
   # JFYI: terragrunt validate color already suppressed via PRE_COMMIT_COLOR=never
 
   # shellcheck disable=SC2153 # False positive
-  common::per_dir_hook "$HOOK_ID" "${ARGS[*]}" "${FILES[@]}"
+  common::per_dir_hook "$HOOK_ID" "${#ARGS[@]}" "${ARGS[@]}" "${FILES[@]}"
 }
 
 #######################################################################
 # Unique part of `common::per_dir_hook`. The function is executed in loop
 # on each provided dir path. Run wrapped tool with specified arguments
 # Arguments:
-#   args (string with array) arguments that configure wrapped tool behavior
 #   dir_path (string) PATH to dir relative to git repo root.
 #     Can be used in error logging
+#   args (array) arguments that configure wrapped tool behavior
 # Outputs:
 #   If failed - print out hook checks status
 #######################################################################
 function per_dir_hook_unique_part {
-  local -r args="$1"
   # shellcheck disable=SC2034 # Unused var.
-  local -r dir_path="$2"
+  local -r dir_path="$1"
+  shift
+  local -a -r args=("$@")
 
   # pass the arguments to hook
-  # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
-  terragrunt validate ${args[@]}
+  terragrunt validate "${args[@]}"
 
   # return exit code to common::per_dir_hook
   local exit_code=$?
@@ -46,14 +46,13 @@ function per_dir_hook_unique_part {
 # Unique part of `common::per_dir_hook`. The function is executed one time
 # in the root git repo
 # Arguments:
-#   args (string with array) arguments that configure wrapped tool behavior
+#   args (array) arguments that configure wrapped tool behavior
 #######################################################################
 function run_hook_on_whole_repo {
-  local -r args="$1"
+  local -a -r args=("$@")
 
   # pass the arguments to hook
-  # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
-  terragrunt run-all validate ${args[@]}
+  terragrunt run-all validate "${args[@]}"
 
   # return exit code to common::per_dir_hook
   local exit_code=$?

--- a/hooks/terrascan.sh
+++ b/hooks/terrascan.sh
@@ -15,27 +15,27 @@ function main {
   # JFYI: terrascan color already suppressed via PRE_COMMIT_COLOR=never
 
   # shellcheck disable=SC2153 # False positive
-  common::per_dir_hook "$HOOK_ID" "${ARGS[*]}" "${FILES[@]}"
+  common::per_dir_hook "$HOOK_ID" "${#ARGS[@]}" "${ARGS[@]}" "${FILES[@]}"
 }
 
 #######################################################################
 # Unique part of `common::per_dir_hook`. The function is executed in loop
 # on each provided dir path. Run wrapped tool with specified arguments
 # Arguments:
-#   args (string with array) arguments that configure wrapped tool behavior
 #   dir_path (string) PATH to dir relative to git repo root.
 #     Can be used in error logging
+#   args (array) arguments that configure wrapped tool behavior
 # Outputs:
 #   If failed - print out hook checks status
 #######################################################################
 function per_dir_hook_unique_part {
-  local -r args="$1"
   # shellcheck disable=SC2034 # Unused var.
-  local -r dir_path="$2"
+  local -r dir_path="$1"
+  shift
+  local -a -r args=("$@")
 
   # pass the arguments to hook
-  # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
-  terrascan scan -i terraform ${args[@]}
+  terrascan scan -i terraform "${args[@]}"
 
   # return exit code to common::per_dir_hook
   local exit_code=$?
@@ -46,14 +46,13 @@ function per_dir_hook_unique_part {
 # Unique part of `common::per_dir_hook`. The function is executed one time
 # in the root git repo
 # Arguments:
-#   args (string with array) arguments that configure wrapped tool behavior
+#   args (array) arguments that configure wrapped tool behavior
 #######################################################################
 function run_hook_on_whole_repo {
-  local -r args="$1"
+  local -a -r args=("$@")
 
   # pass the arguments to hook
-  # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
-  terrascan scan -i terraform ${args[@]}
+  terrascan scan -i terraform "${args[@]}"
 
   # return exit code to common::per_dir_hook
   local exit_code=$?

--- a/hooks/terrascan.sh
+++ b/hooks/terrascan.sh
@@ -15,7 +15,7 @@ function main {
   # JFYI: terrascan color already suppressed via PRE_COMMIT_COLOR=never
 
   # shellcheck disable=SC2153 # False positive
-  common::per_dir_hook "${ARGS[*]}" "$HOOK_ID" "${FILES[@]}"
+  common::per_dir_hook "$HOOK_ID" "${ARGS[*]}" "${FILES[@]}"
 }
 
 #######################################################################

--- a/hooks/tfupdate.sh
+++ b/hooks/tfupdate.sh
@@ -15,7 +15,7 @@ function main {
   # JFYI: suppress color for `tfupdate` is N/A`
 
   # shellcheck disable=SC2153 # False positive
-  common::per_dir_hook "$HOOK_ID" "${#ARGS[@]}" "${ARGS[@]}" "${FILES[@]}"
+  common::per_dir_hook "$HOOK_ID" "${ARGS[*]}" "${FILES[@]}"
 }
 #######################################################################
 # Unique part of `common::per_dir_hook`. The function is executed in loop

--- a/hooks/tfupdate.sh
+++ b/hooks/tfupdate.sh
@@ -56,7 +56,7 @@ function per_dir_hook_unique_part {
 # Unique part of `common::per_dir_hook`. The function is executed one time
 # in the root git repo
 # Arguments:
-#   args (string with array) arguments that configure wrapped tool behavior
+#   args (array) arguments that configure wrapped tool behavior
 #######################################################################
 function run_hook_on_whole_repo {
   local -a -r args=("$@")

--- a/hooks/tfupdate.sh
+++ b/hooks/tfupdate.sh
@@ -30,8 +30,8 @@ function main {
 function per_dir_hook_unique_part {
   # shellcheck disable=SC2034 # Unused var.
   local -r dir_path="$1"
-  shift 1
-  declare -a -r args=("$@")
+  shift
+  local -a -r args=("$@")
 
   local expand_args=()
 
@@ -54,7 +54,7 @@ function per_dir_hook_unique_part {
 #   args (string with array) arguments that configure wrapped tool behavior
 #######################################################################
 function run_hook_on_whole_repo {
-  declare -a -r args=("$@")
+  local -a -r args=("$@")
 
   local expand_args=()
 

--- a/hooks/tfupdate.sh
+++ b/hooks/tfupdate.sh
@@ -15,7 +15,7 @@ function main {
   # JFYI: suppress color for `tfupdate` is N/A`
 
   # shellcheck disable=SC2153 # False positive
-  common::per_dir_hook "${ARGS[*]}" "$HOOK_ID" "${FILES[@]}"
+  common::per_dir_hook "$HOOK_ID" "${ARGS[*]}" "${FILES[@]}"
 }
 #######################################################################
 # Unique part of `common::per_dir_hook`. The function is executed in loop

--- a/hooks/tfupdate.sh
+++ b/hooks/tfupdate.sh
@@ -51,7 +51,7 @@ function run_hook_on_whole_repo {
   local -a -r args=("$@")
 
   # pass the arguments to hook
-  tfupdate "${args[@]}" .
+  tfupdate "${args[@]}" --recursive .
 
   # return exit code to common::per_dir_hook
   local exit_code=$?

--- a/hooks/tfupdate.sh
+++ b/hooks/tfupdate.sh
@@ -33,27 +33,8 @@ function per_dir_hook_unique_part {
   shift
   local -a -r args=("$@")
 
-  local -a expand_args=()
-  # `args` is an array with content like:
-  #     ('provider aws' '--version "> 0.14"' '--ignore-path "some/path"')
-  #   where each element is the value of each `--args` from hook config.
-  # `echo` prints contents of `args` array as an expanded string:
-  #     `provider aws --version "> 0.14" --ignore-path "some/path"`
-  # `xargs` passes expanded string to `printf`
-  # `printf` which splits it into NUL-separated elements,
-  # NUL-separated elements read by `read` using empty separator
-  #     (`-d ''` or `-d $'\0'`)
-  #     into an `expand_args` array
-
-  # This allows to "rebuild" initial `args` array of sort of groupped elements
-  # into a proper array, where each element is a standalone array slice
-  # with quoted elements being treated as a standalone slice of array as well.
-  while read -r -d '' ARG; do
-    expand_args+=("$ARG")
-  done < <(echo "${args[@]}" | xargs printf '%s\0')
-
   # pass the arguments to hook
-  tfupdate "${expand_args[@]}" .
+  tfupdate "${args[@]}" .
 
   # return exit code to common::per_dir_hook
   local exit_code=$?
@@ -69,14 +50,8 @@ function per_dir_hook_unique_part {
 function run_hook_on_whole_repo {
   local -a -r args=("$@")
 
-  local -a expand_args=()
-
-  while read -r -d '' ARG; do
-    expand_args+=("$ARG")
-  done < <(echo "${args[@]}" | xargs printf '%s\0')
-
   # pass the arguments to hook
-  tfupdate "${expand_args[@]}" .
+  tfupdate "${args[@]}" .
 
   # return exit code to common::per_dir_hook
   local exit_code=$?

--- a/hooks/tfupdate.sh
+++ b/hooks/tfupdate.sh
@@ -34,7 +34,20 @@ function per_dir_hook_unique_part {
   local -a -r args=("$@")
 
   local -a expand_args=()
+  # `args` is an array with content like:
+  #     ('provider aws' '--version "> 0.14"' '--ignore-path "some/path"')
+  #   where each element is the value of each `--args` from hook config.
+  # `echo` prints contents of `args` array as an expanded string:
+  #     `provider aws --version "> 0.14" --ignore-path "some/path"`
+  # `xargs` passes expanded string to `printf`
+  # `printf` which splits it into NUL-separated elements,
+  # NUL-separated elements read by `read` using empty separator
+  #     (`-d ''` or `-d $'\0'`)
+  #     into an `expand_args` array
 
+  # This allows to "rebuild" initial `args` array of sort of groupped elements
+  # into a proper array, where each element is a standalone array slice
+  # with quoted elements being treated as a standalone slice of array as well.
   while read -r -d '' ARG; do
     expand_args+=("$ARG")
   done < <(echo "${args[@]}" | xargs printf '%s\0')

--- a/hooks/tfupdate.sh
+++ b/hooks/tfupdate.sh
@@ -15,7 +15,7 @@ function main {
   # JFYI: suppress color for `tfupdate` is N/A`
 
   # shellcheck disable=SC2153 # False positive
-  common::per_dir_hook "$HOOK_ID" "${ARGS[*]}" "${FILES[@]}"
+  common::per_dir_hook "$HOOK_ID" "${#ARGS[@]}" "${ARGS[@]}" "${FILES[@]}"
 }
 #######################################################################
 # Unique part of `common::per_dir_hook`. The function is executed in loop

--- a/hooks/tfupdate.sh
+++ b/hooks/tfupdate.sh
@@ -14,6 +14,17 @@ function main {
   common::parse_and_export_env_vars
   # JFYI: suppress color for `tfupdate` is N/A`
 
+
+  # Prevent PASSED scenarios for things like:
+  #   - --args=--version '~> 4.2.0'
+  #   - --args=provider aws
+  if ! [[ ${ARGS[0]} =~ ^[a-z] ]]; then
+    common::colorify 'red' "Check the hook args order in .pre-commit.config.yaml."
+    common::colorify 'red' "Current command looks like:"
+    common::colorify 'red' "tfupdate ${ARGS[*]}"
+    exit 1
+  fi
+
   # shellcheck disable=SC2153 # False positive
   common::per_dir_hook "$HOOK_ID" "${#ARGS[@]}" "${ARGS[@]}" "${FILES[@]}"
 }

--- a/hooks/tfupdate.sh
+++ b/hooks/tfupdate.sh
@@ -34,80 +34,10 @@ function per_dir_hook_unique_part {
   declare -a -r args=("$@")
 
   local expand_args=()
-  for arg in "${args[@]}"; do
-    if [[ "$arg" == *'"'* ]]; then
-      elements=($arg)
-      unset start
-      unset end
-      unset quoted_var
 
-      for i in "${!elements[@]}"; do
-
-        if [[ "${elements[i]}" =~ ^\" ]]; then
-          start=$i
-        fi
-
-        if [[ "${elements[i]}" =~ \"$ ]]; then
-          end=$i
-        fi
-      done
-
-      for i in $(seq 0 $((start - 1))); do
-        expand_args+=("${elements[i]}")
-      done
-
-      for i in $(seq "$start" "$end"); do
-        quoted_var+="${elements[i]} "
-      done
-      quoted_var2=${quoted_var#'"'}
-      quoted_var2=${quoted_var2%'" '}
-      expand_args+=("$quoted_var2")
-
-      for i in $(seq $((end + 1)) $((${#elements[@]} - 1))); do
-        expand_args+=("${elements[i]}")
-      done
-
-    elif
-      [[ "$arg" == *"'"* ]]
-    then
-      # Mostly copy-paste
-
-      elements=($arg)
-      unset start
-      unset end
-      unset quoted_var
-
-      for i in "${!elements[@]}"; do
-
-        if [[ "${elements[i]}" =~ ^\' ]]; then
-          start=$i
-        fi
-
-        if [[ "${elements[i]}" =~ \'$ ]]; then
-          end=$i
-        fi
-      done
-
-      for i in $(seq 0 $((start - 1))); do
-        expand_args+=("${elements[i]}")
-      done
-
-      for i in $(seq "$start" "$end"); do
-        quoted_var+="${elements[i]} "
-      done
-      quoted_var2=${quoted_var#"'"}
-      quoted_var2=${quoted_var2%"' "}
-      expand_args+=("$quoted_var2")
-
-      for i in $(seq $((end + 1)) $((${#elements[@]} - 1))); do
-        expand_args+=("${elements[i]}")
-      done
-
-    else
-      #
-      expand_args+=($arg)
-    fi
-  done
+  while read -r -d '' ARG; do
+    expand_args+=("$ARG")
+  done < <(echo "${args[@]}" | xargs printf '%s\0')
 
   # pass the arguments to hook
   tfupdate "${expand_args[@]}" .
@@ -124,12 +54,16 @@ function per_dir_hook_unique_part {
 #   args (string with array) arguments that configure wrapped tool behavior
 #######################################################################
 function run_hook_on_whole_repo {
-  local -r args="$1"
+  declare -a -r args=("$@")
+
+  local expand_args=()
+
+  while read -r -d '' ARG; do
+    expand_args+=("$ARG")
+  done < <(echo "${args[@]}" | xargs printf '%s\0')
+
   # pass the arguments to hook
-  # shellcheck disable=SC2068 # hook fails when quoting is used ("$arg[@]")
-  # shellcheck disable=SC2048 # Use "${array[@]}" (with quotes) to prevent whitespace problems.
-  # shellcheck disable=SC2086 #  Double quote to prevent globbing and word splitting.
-  tfupdate ${args[*]} --recursive .
+  tfupdate "${expand_args[@]}" .
 
   # return exit code to common::per_dir_hook
   local exit_code=$?

--- a/hooks/tfupdate.sh
+++ b/hooks/tfupdate.sh
@@ -33,7 +33,7 @@ function per_dir_hook_unique_part {
   shift
   local -a -r args=("$@")
 
-  local expand_args=()
+  local -a expand_args=()
 
   while read -r -d '' ARG; do
     expand_args+=("$ARG")
@@ -56,7 +56,7 @@ function per_dir_hook_unique_part {
 function run_hook_on_whole_repo {
   local -a -r args=("$@")
 
-  local expand_args=()
+  local -a expand_args=()
 
   while read -r -d '' ARG; do
     expand_args+=("$ARG")

--- a/hooks/tfupdate.sh
+++ b/hooks/tfupdate.sh
@@ -14,10 +14,10 @@ function main {
   common::parse_and_export_env_vars
   # JFYI: suppress color for `tfupdate` is N/A`
 
-
   # Prevent PASSED scenarios for things like:
   #   - --args=--version '~> 4.2.0'
   #   - --args=provider aws
+  # shellcheck disable=SC2153 # False positive
   if ! [[ ${ARGS[0]} =~ ^[a-z] ]]; then
     common::colorify 'red' "Check the hook args order in .pre-commit.config.yaml."
     common::colorify 'red' "Current command looks like:"


### PR DESCRIPTION
Replace for #436 ?
Close #436 #388


- [x] shellcheck violation
- [x] fix other hooks, by adding `"${#ARGS[@]}"` and change `per_dir_hook_unique_part` args
- [x] fix pre-commit --all
- [x] fix the PASSED case, when args in the wrong order
```
      args:
        - --args=--version '~> 4.2.0'
        - --args=provider aws
```