### PR TITLE
chore: Fix deprecated Github Actions set-output command

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -15,7 +15,7 @@ jobs:
       run: |
         export DIFF=$(git diff --name-only origin/${{ github.base_ref }} ${{ github.sha }})
         echo "Diff between ${{ github.base_ref }} and ${{ github.sha }}"
-        echo "::set-output name=files::$( echo "$DIFF" | xargs echo )"
+        echo "name=files::$( echo "$DIFF" | xargs echo )" >> $GITHUB_OUTPUT
 
     - name: Install shfmt
       run: |


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->




Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes
As per this [Github Blog post](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/), `set-output` and `save-state` are now considered deprecated. As of the action runner version `2.298.2`, it will begin to warn you if you use either of these commands via stdout.

This PR addresses the deprecation of `set-output` using the suggested approach in the blog post.  It should result in preventing the following warning appearing in the "Common issues check" github action [output](https://github.com/antonbabenko/pre-commit-terraform/actions/runs/3396475501/jobs/5647582776#step:4:8):

>  Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/



<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123456":
-->

<!-- Fixes # -->

### How can we test changes
No functional changes are introduced, the github action checks should function as normal but without the warning mentioned above. 
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
