### PR TITLE
fix: Make text color work in MacOS zsh

### DIFF
--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -256,13 +256,13 @@ function common::per_dir_hook {
 #######################################################################
 function common::colorify {
   # shellcheck disable=SC2034
-  local -r red="\e[0m\e[31m"
+  local -r red="\x1b[0m\x1b[31m"
   # shellcheck disable=SC2034
-  local -r green="\e[0m\e[32m"
+  local -r green="\x1b[0m\x1b[32m"
   # shellcheck disable=SC2034
-  local -r yellow="\e[0m\e[33m"
+  local -r yellow="\x1b[0m\x1b[33m"
   # Color reset
-  local -r RESET="\e[0m"
+  local -r RESET="\x1b[0m"
 
   # Params start #
   local COLOR="${!1}"


### PR DESCRIPTION
Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [X] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [X] This PR enhances existing functionality.

### Description of your changes

Changes the escape sequence used for coloring text output to the terminal so that the colors work in zsh on MacOS.

### How can we test changes

I have tested that the output is colored correctly in zsh on MacOS and bash on MacOS.