### PR TITLE
chore: Update pr-title to remove deprecation warning

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       # Please look up the latest version from
       # https://github.com/amannn/action-semantic-pull-request/releases
-      - uses: amannn/action-semantic-pull-request@v3.4.6
+      - uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Resolves deprecation warnings like the following: https://github.com/antonbabenko/pre-commit-terraform/actions/runs/3550048303

<img width="994" alt="image" src="https://user-images.githubusercontent.com/697964/206317508-a86a1054-1aab-4281-8bb4-1ab6484715ab.png">
