### PR TITLE
fix: Fixed spacing in `terraform_wrapper_module_for_each` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
 
 # Dockerfile linter
 - repo: https://github.com/hadolint/hadolint
-  rev: v2.12.0
+  rev: v2.12.1-beta
   hooks:
     - id: hadolint
       args: [

--- a/hooks/terraform_wrapper_module_for_each.sh
+++ b/hooks/terraform_wrapper_module_for_each.sh
@@ -330,13 +330,13 @@ EOF
     module_outputs=($(echo "$all_tf_content" | hcledit block list | grep output. | cut -d'.' -f 2))
 
     # Looking for sensitive output
-    local wrapper_output_sensitive="# sensitive = false  # No sensitive module output found"
+    local wrapper_output_sensitive="# sensitive = false # No sensitive module output found"
     for module_output in "${module_outputs[@]}"; do
       module_output_sensitive=$(echo "$all_tf_content" | hcledit attribute get "output.${module_output}.sensitive")
 
       # At least one output is sensitive - the wrapper's output should be sensitive, too
       if [[ "$module_output_sensitive" == "true" ]]; then
-        wrapper_output_sensitive="sensitive   = true  # At least one sensitive module output (${module_output}) found (requires Terraform 0.14+)"
+        wrapper_output_sensitive="sensitive   = true # At least one sensitive module output (${module_output}) found (requires Terraform 0.14+)"
         break
       fi
     done


### PR DESCRIPTION
Fixed spacing in `terraform_wrapper_module_for_each` hook which was a problem when sensitive was `true` ( https://github.com/terraform-aws-modules/terraform-aws-ecs/pull/76#issuecomment-1500329275 )