### PR TITLE
fix: Terraform validate - only run tf init if providers directory is missing in .terraform

### DIFF
--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -299,7 +299,8 @@ function common::terraform_init {
     TF_INIT_ARGS+=("-no-color")
   fi
 
-  if [ ! -d .terraform/modules ] || [ ! -d .terraform/providers ]; then
+  # only check for providers directory here as /modules is only present if code uses terraform modules
+  if [ ! -d .terraform/providers ]; then
     init_output=$(terraform init -backend=false "${TF_INIT_ARGS[@]}" 2>&1)
     exit_code=$?
 


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123456":
-->

<!-- Fixes # -->

If a terraform states does not include modules, a `.terraform/modules` directory is not present. For these cases, the tf init is run every time the validate hook runs, which takes extra time + causes issues if e.g. a remote state is used which causes the init to fail.

### How can we test changes

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I checked it with my repositories as described above, and the tf init did now only run if the .terraform/providers directly is not present.