### PR TITLE
feat: TFLint: Add `--hook-config=--delegate-chdir` to use `tflint -chdir`

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,6 +599,14 @@ To replicate functionality in `terraform_docs` hook:
         - --args=--config=__GIT_WORKING_DIR__/.tflint.hcl
     ```
 
+3. By default pre-commit-terraform performs directory switching into the terraform modules for you. If you want to delgate the directory changing to the binary - this will allow tflint to determine the full paths for error/warning messages, rather than just module relative paths. *Note: this requires `tflint>=0.44.0`.* For example:
+
+    ```yaml
+    - id: terraform_tflint
+          args:
+            - --hook-config=--delegate-chdir
+    ```
+
 
 ### terraform_tfsec
 

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -257,7 +257,7 @@ function common::per_dir_hook {
       final_exit_code=$exit_code
     fi
 
-    if ! $DELEGATE_CHDIR; then
+    if [[ $DELEGATE_CHDIR != true ]]; then
       popd > /dev/null
     fi
 

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -218,7 +218,7 @@ function common::per_dir_hook {
   done
 
   # Lookup hook-config for modifiers that impact common behavior
-  local DELEGATE_CHDIR=false
+  local change_dir_in_unique_part=false
   IFS=";" read -r -a configs <<< "${HOOK_CONFIG[*]}"
   for c in "${configs[@]}"; do
     IFS="=" read -r -a config <<< "$c"
@@ -230,7 +230,7 @@ function common::per_dir_hook {
         # this flag will skip pushing and popping directories
         # delegating the responsibility to the hooked plugin/binary
         if [[ ! $value || $value == true ]]; then
-          DELEGATE_CHDIR=true
+          change_dir_in_unique_part="delegate_chdir"
         fi
         ;;
     esac
@@ -246,18 +246,18 @@ function common::per_dir_hook {
   for dir_path in $(echo "${dir_paths[*]}" | tr ' ' '\n' | sort -u); do
     dir_path="${dir_path//__REPLACED__SPACE__/ }"
 
-    if [[ $DELEGATE_CHDIR != true ]]; then
+    if [[ $change_dir_in_unique_part == false ]]; then
       pushd "$dir_path" > /dev/null || continue
     fi
 
-    per_dir_hook_unique_part "$dir_path" "${args[@]}"
+    per_dir_hook_unique_part "$dir_path" "$change_dir_in_unique_part" "${args[@]}"
 
     local exit_code=$?
     if [ $exit_code -ne 0 ]; then
       final_exit_code=$exit_code
     fi
 
-    if [[ $DELEGATE_CHDIR != true ]]; then
+    if [[ $change_dir_in_unique_part == false ]]; then
       popd > /dev/null
     fi
 

--- a/hooks/terraform_checkov.sh
+++ b/hooks/terraform_checkov.sh
@@ -31,6 +31,9 @@ function main {
 # Arguments:
 #   dir_path (string) PATH to dir relative to git repo root.
 #     Can be used in error logging
+#   change_dir_in_unique_part (string/false) Modifier which creates
+#     possibilities to use non-common chdir strategies.
+#     Availability depends on hook.
 #   args (array) arguments that configure wrapped tool behavior
 # Outputs:
 #   If failed - print out hook checks status
@@ -38,7 +41,9 @@ function main {
 function per_dir_hook_unique_part {
   # shellcheck disable=SC2034 # Unused var.
   local -r dir_path="$1"
-  shift
+  # shellcheck disable=SC2034 # Unused var.
+  local -r change_dir_in_unique_part="$2"
+  shift 2
   local -a -r args=("$@")
 
   checkov -d . "${args[@]}"

--- a/hooks/terraform_fmt.sh
+++ b/hooks/terraform_fmt.sh
@@ -28,6 +28,9 @@ function main {
 # Arguments:
 #   dir_path (string) PATH to dir relative to git repo root.
 #     Can be used in error logging
+#   change_dir_in_unique_part (string/false) Modifier which creates
+#     possibilities to use non-common chdir strategies.
+#     Availability depends on hook.
 #   args (array) arguments that configure wrapped tool behavior
 # Outputs:
 #   If failed - print out hook checks status
@@ -35,7 +38,9 @@ function main {
 function per_dir_hook_unique_part {
   # shellcheck disable=SC2034 # Unused var.
   local -r dir_path="$1"
-  shift
+  # shellcheck disable=SC2034 # Unused var.
+  local -r change_dir_in_unique_part="$2"
+  shift 2
   local -a -r args=("$@")
 
   # pass the arguments to hook

--- a/hooks/terraform_providers_lock.sh
+++ b/hooks/terraform_providers_lock.sh
@@ -25,6 +25,9 @@ function main {
 # Arguments:
 #   dir_path (string) PATH to dir relative to git repo root.
 #     Can be used in error logging
+#   change_dir_in_unique_part (string/false) Modifier which creates
+#     possibilities to use non-common chdir strategies.
+#     Availability depends on hook.
 #   args (array) arguments that configure wrapped tool behavior
 # Outputs:
 #   If failed - print out hook checks status

--- a/hooks/terraform_tflint.sh
+++ b/hooks/terraform_tflint.sh
@@ -28,7 +28,7 @@ function main {
   } || {
     local exit_code=$?
     common::colorify "red" "Command 'tflint --init' failed:"
-    echo "${TFLINT_INIT}"
+    echo -e "${TFLINT_INIT}"
     return ${exit_code}
   }
 
@@ -50,15 +50,19 @@ function per_dir_hook_unique_part {
   shift
   local -a -r args=("$@")
 
-  TFLINT_OUTPUT=$(tflint "${args[@]}" 2>&1)
+  if [[ $DELEGATE_CHDIR == true ]]; then
+    local dir_args="--chdir=$dir_path"
+  fi
+
+  # shellcheck disable=SC2086 # we need to remove the arg if its unset
+  TFLINT_OUTPUT=$(tflint ${dir_args:-} "${args[@]}" 2>&1)
   local exit_code=$?
 
   if [ $exit_code -ne 0 ]; then
     common::colorify "yellow" "TFLint in $dir_path/:"
-    echo "$TFLINT_OUTPUT"
+    echo -e "$TFLINT_OUTPUT"
   fi
 
-  # return exit code to common::per_dir_hook
   return $exit_code
 }
 

--- a/hooks/terraform_tflint.sh
+++ b/hooks/terraform_tflint.sh
@@ -41,16 +41,20 @@ function main {
 # Arguments:
 #   dir_path (string) PATH to dir relative to git repo root.
 #     Can be used in error logging
+#   change_dir_in_unique_part (string/false) Modifier which creates
+#     possibilities to use non-common chdir strategies.
+#     Availability depends on hook.
 #   args (array) arguments that configure wrapped tool behavior
 # Outputs:
 #   If failed - print out hook checks status
 #######################################################################
 function per_dir_hook_unique_part {
   local -r dir_path="$1"
-  shift
+  local -r change_dir_in_unique_part="$2"
+  shift 2
   local -a -r args=("$@")
 
-  if [[ $DELEGATE_CHDIR == true ]]; then
+  if [ "$change_dir_in_unique_part" == "delegate_chdir" ]; then
     local dir_args="--chdir=$dir_path"
   fi
 

--- a/hooks/terraform_tflint.sh
+++ b/hooks/terraform_tflint.sh
@@ -63,6 +63,7 @@ function per_dir_hook_unique_part {
     echo -e "$TFLINT_OUTPUT"
   fi
 
+  # return exit code to common::per_dir_hook
   return $exit_code
 }
 

--- a/hooks/terraform_tfsec.sh
+++ b/hooks/terraform_tfsec.sh
@@ -31,6 +31,9 @@ function main {
 # Arguments:
 #   dir_path (string) PATH to dir relative to git repo root.
 #     Can be used in error logging
+#   change_dir_in_unique_part (string/false) Modifier which creates
+#     possibilities to use non-common chdir strategies.
+#     Availability depends on hook.
 #   args (array) arguments that configure wrapped tool behavior
 # Outputs:
 #   If failed - print out hook checks status
@@ -38,7 +41,9 @@ function main {
 function per_dir_hook_unique_part {
   # shellcheck disable=SC2034 # Unused var.
   local -r dir_path="$1"
-  shift
+  # shellcheck disable=SC2034 # Unused var.
+  local -r change_dir_in_unique_part="$2"
+  shift 2
   local -a -r args=("$@")
 
   # pass the arguments to hook

--- a/hooks/terraform_validate.sh
+++ b/hooks/terraform_validate.sh
@@ -70,13 +70,18 @@ function match_validate_errors {
 # Arguments:
 #   dir_path (string) PATH to dir relative to git repo root.
 #     Can be used in error logging
+#   change_dir_in_unique_part (string/false) Modifier which creates
+#     possibilities to use non-common chdir strategies.
+#     Availability depends on hook.
 #   args (array) arguments that configure wrapped tool behavior
 # Outputs:
 #   If failed - print out hook checks status
 #######################################################################
 function per_dir_hook_unique_part {
   local -r dir_path="$1"
-  shift
+  # shellcheck disable=SC2034 # Unused var.
+  local -r change_dir_in_unique_part="$2"
+  shift 2
   local -a -r args=("$@")
 
   local exit_code
@@ -95,7 +100,7 @@ function per_dir_hook_unique_part {
 
     case $key in
       --retry-once-with-cleanup)
-        if [ $retry_once_with_cleanup ]; then 
+        if [ $retry_once_with_cleanup ]; then
           common::colorify "yellow" 'Invalid hook config. Make sure that you specify not more than one "--retry-once-with-cleanup" flag'
           exit 1
         fi

--- a/hooks/terragrunt_fmt.sh
+++ b/hooks/terragrunt_fmt.sh
@@ -24,6 +24,9 @@ function main {
 # Arguments:
 #   dir_path (string) PATH to dir relative to git repo root.
 #     Can be used in error logging
+#   change_dir_in_unique_part (string/false) Modifier which creates
+#     possibilities to use non-common chdir strategies.
+#     Availability depends on hook.
 #   args (array) arguments that configure wrapped tool behavior
 # Outputs:
 #   If failed - print out hook checks status
@@ -31,7 +34,9 @@ function main {
 function per_dir_hook_unique_part {
   # shellcheck disable=SC2034 # Unused var.
   local -r dir_path="$1"
-  shift
+  # shellcheck disable=SC2034 # Unused var.
+  local -r change_dir_in_unique_part="$2"
+  shift 2
   local -a -r args=("$@")
 
   # pass the arguments to hook

--- a/hooks/terragrunt_validate.sh
+++ b/hooks/terragrunt_validate.sh
@@ -24,6 +24,9 @@ function main {
 # Arguments:
 #   dir_path (string) PATH to dir relative to git repo root.
 #     Can be used in error logging
+#   change_dir_in_unique_part (string/false) Modifier which creates
+#     possibilities to use non-common chdir strategies.
+#     Availability depends on hook.
 #   args (array) arguments that configure wrapped tool behavior
 # Outputs:
 #   If failed - print out hook checks status
@@ -31,7 +34,9 @@ function main {
 function per_dir_hook_unique_part {
   # shellcheck disable=SC2034 # Unused var.
   local -r dir_path="$1"
-  shift
+  # shellcheck disable=SC2034 # Unused var.
+  local -r change_dir_in_unique_part="$2"
+  shift 2
   local -a -r args=("$@")
 
   # pass the arguments to hook

--- a/hooks/terrascan.sh
+++ b/hooks/terrascan.sh
@@ -24,6 +24,9 @@ function main {
 # Arguments:
 #   dir_path (string) PATH to dir relative to git repo root.
 #     Can be used in error logging
+#   change_dir_in_unique_part (string/false) Modifier which creates
+#     possibilities to use non-common chdir strategies.
+#     Availability depends on hook.
 #   args (array) arguments that configure wrapped tool behavior
 # Outputs:
 #   If failed - print out hook checks status
@@ -31,7 +34,9 @@ function main {
 function per_dir_hook_unique_part {
   # shellcheck disable=SC2034 # Unused var.
   local -r dir_path="$1"
-  shift
+  # shellcheck disable=SC2034 # Unused var.
+  local -r change_dir_in_unique_part="$2"
+  shift 2
   local -a -r args=("$@")
 
   # pass the arguments to hook

--- a/hooks/tfupdate.sh
+++ b/hooks/tfupdate.sh
@@ -34,6 +34,9 @@ function main {
 # Arguments:
 #   dir_path (string) PATH to dir relative to git repo root.
 #     Can be used in error logging
+#   change_dir_in_unique_part (string/false) Modifier which creates
+#     possibilities to use non-common chdir strategies.
+#     Availability depends on hook.
 #   args (array) arguments that configure wrapped tool behavior
 # Outputs:
 #   If failed - print out hook checks status
@@ -41,7 +44,9 @@ function main {
 function per_dir_hook_unique_part {
   # shellcheck disable=SC2034 # Unused var.
   local -r dir_path="$1"
-  shift
+  # shellcheck disable=SC2034 # Unused var.
+  local -r change_dir_in_unique_part="$2"
+  shift 2
   local -a -r args=("$@")
 
   # pass the arguments to hook


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [x] This PR enhances existing functionality.

### Description of your changes

This change leverages the `tflint -chdir` flag to do the nested lookup and provide fully qualified paths to the output.

It unwraps the `pushd`/`popd` functionality and delegates the directory changing to the binary process via chdir.

This would be a breaking behavior if a user tried to add a `-chdir` flag to the `args` - but I can't think of a valid reason that anyone would do this - or if that functionality would even work with the pre-commit-terraform hooks.

The `-chdir` flag was added in [tflint 0.44.0](https://github.com/terraform-linters/tflint/releases/tag/v0.44.0) - I don't know how to enforce specific versions of the binary or to trivially change the commit hook driver behavior based upon the version. This flag is forwards compatible, while the `dir` arg to tflint is being deprecated.

Totally happy to revisit the approach or just keep maintaining a fork for my use cases.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123456":
-->

<!-- Fixes # -->
Fixes #511 

### How can we test changes

Locally examine the output when the tflint succeeds vs fails.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
