### PR TITLE
fix: Speed up x2 TFLint hook execution in dirs with violations

### DIFF
--- a/hooks/terraform_tflint.sh
+++ b/hooks/terraform_tflint.sh
@@ -50,12 +50,12 @@ function per_dir_hook_unique_part {
   shift
   local -a -r args=("$@")
 
-  COMMAND_OUTPUT=$({ tflint "${args[@]}"; } 2>&1)
+  TFLINT_OUTPUT=$({ tflint "${args[@]}"; } 2>&1)
   local exit_code=$?
 
   if [ $exit_code -ne 0 ]; then
     common::colorify "yellow" "TFLint in $dir_path/:"
-    echo "$COMMAND_OUTPUT"
+    echo "$TFLINT_OUTPUT"
   fi
 
   # return exit code to common::per_dir_hook

--- a/hooks/terraform_tflint.sh
+++ b/hooks/terraform_tflint.sh
@@ -50,7 +50,7 @@ function per_dir_hook_unique_part {
   shift
   local -a -r args=("$@")
 
-  TFLINT_OUTPUT=$({ tflint "${args[@]}"; } 2>&1)
+  TFLINT_OUTPUT=$(tflint "${args[@]}" 2>&1)
   local exit_code=$?
 
   if [ $exit_code -ne 0 ]; then

--- a/hooks/terraform_tflint.sh
+++ b/hooks/terraform_tflint.sh
@@ -50,16 +50,15 @@ function per_dir_hook_unique_part {
   shift
   local -a -r args=("$@")
 
-  # Print checked PATH **only** if TFLint have any messages
-  # shellcheck disable=SC2091,SC2068 # Suppress error output
-  $(tflint ${args[@]} 2>&1) 2> /dev/null || {
-    common::colorify "yellow" "TFLint in $dir_path/:"
+  COMMAND_OUTPUT=$({ tflint "${args[@]}"; } 2>&1)
+  local exit_code=$?
 
-    tflint "${args[@]}"
-  }
+  if [ $exit_code -ne 0 ]; then
+    common::colorify "yellow" "TFLint in $dir_path/:"
+    echo "$COMMAND_OUTPUT"
+  fi
 
   # return exit code to common::per_dir_hook
-  local exit_code=$?
   return $exit_code
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

Caches the output of the TFLint commands - upon failures the existing behavior was to re-run to present the output. This should speed up performance where there are lots of scattered failures in many directories.

<!-- Fixes # -->

### How can we test changes

I have tested locally with a single failing repo - showed a 48% reduction in wall clock time with the `try-repo` hooks.

Substantial speedup in a monorepo with scattered failures across many directories.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
