### PR TITLE
docs: Add steps to configure auth to source Terraform modules from private GitHub repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -865,6 +865,41 @@ $ ls -aldn .
 drwxr-xr-x 9 1000 1000 4096 Sep  1 16:23 .
 ```
 
+## Docker usage: Download Terraform modules from private GitHub repositories
+
+If you use a private git repository as your Terraform module source, you are required to authenticate to GitHub using a [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
+
+When running pre-commit on Docker, both locally or on CI, you need to configure the [~/.netrc](https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html) file, which contains login and initialization information used by the auto-login process.
+
+This can be achieved by firstly creating the `~/.netrc` file including your `GITHUB_PAT` and `GITHUB_SERVER_URL`
+
+```bash
+# set GH values (replace with your own values)
+GITHUB_PAT=ghp_bl481aBlabl481aBla
+GITHUB_SERVER_URL=github.com
+
+# create .netrc file
+echo -e "machine $GITHUB_SERVER_URL\n  login $GITHUB_PAT" > ~/.netrc
+```
+
+The `~/.netrc` file will look similar to the following:
+
+```
+machine github.com
+  login ghp_bl481aBlabl481aBla
+```
+
+> Note: The value of `GITHUB_SERVER_URL` can also refer to a GitHub Enterprise server (i.e. `github.my-enterprise.com`).
+
+Finally, you can execute `docker run` with an additional volume mount so that the `~/.netrc` is accessible within the container
+
+```bash
+# run pre-commit-terraform with docker
+# adding volume for .netrc file
+# .netrc needs to be in /root/ dir
+docker run --rm -e "USERID=$(id -u):$(id -g)" -v ~/.netrc:/root/.netrc -v $(pwd):/lint -w /lint ghcr.io/antonbabenko/pre-commit-terraform:latest run -a
+```
+
 ## Authors
 
 This repository is managed by [Anton Babenko](https://github.com/antonbabenko) with help from these awesome contributors:

--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ If you are using `pre-commit-terraform` already or want to support its developme
   * [terraform\_wrapper\_module\_for\_each](#terraform_wrapper_module_for_each)
   * [terrascan](#terrascan)
   * [tfupdate](#tfupdate)
-* [Docker Usage: File Permissions](#docker-usage-file-permissions)
-* [Docker usage: Download Terraform modules from private GitHub repositories](#docker-usage-download-terraform-modules-from-private-github-repositories)
+* [Docker Usage](#docker-usage)
+  * [File Permissions](#file-permissions)
+  * [Download Terraform modules from private GitHub repositories](#download-terraform-modules-from-private-github-repositories)
 * [Authors](#authors)
 * [License](#license)
   * [Additional information for users from Russia and Belarus](#additional-information-for-users-from-russia-and-belarus)
@@ -242,7 +243,7 @@ pre-commit run -a
 
 Or, using Docker ([available tags](https://github.com/antonbabenko/pre-commit-terraform/pkgs/container/pre-commit-terraform/versions)):
 
-> **Note**: This command uses your user id and group id for the docker container to use to access the local files.  If the files are owned by another user, update the `USERID` environment variable.  See [File Permissions section](#docker-usage-file-permissions) for more information.
+> **Note**: This command uses your user id and group id for the docker container to use to access the local files.  If the files are owned by another user, update the `USERID` environment variable.  See [File Permissions section](#file-permissions) for more information.
 
 ```bash
 TAG=latest
@@ -846,7 +847,9 @@ If the generated name is incorrect, set them by providing the `module-repo-short
 Check [`tfupdate` usage instructions](https://github.com/minamijoyo/tfupdate#usage) for other available options and usage examples.  
 No need to pass `--recursive .` as it is added automatically.
 
-## Docker Usage: File Permissions
+## Docker Usage
+
+### File Permissions
 
 A mismatch between the Docker container's user and the local repository file ownership can cause permission issues in the repository where `pre-commit` is run.  The container runs as the `root` user by default, and uses a `tools/entrypoint.sh` script to assume a user ID and group ID if specified by the environment variable `USERID`.
 
@@ -866,7 +869,7 @@ $ ls -aldn .
 drwxr-xr-x 9 1000 1000 4096 Sep  1 16:23 .
 ```
 
-## Docker usage: Download Terraform modules from private GitHub repositories
+### Download Terraform modules from private GitHub repositories
 
 If you use a private Git repository as your Terraform module source, you are required to authenticate to GitHub using a [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ If you are using `pre-commit-terraform` already or want to support its developme
   * [terrascan](#terrascan)
   * [tfupdate](#tfupdate)
 * [Docker Usage: File Permissions](#docker-usage-file-permissions)
+* [Docker usage: Download Terraform modules from private GitHub repositories](#docker-usage-download-terraform-modules-from-private-github-repositories)
 * [Authors](#authors)
 * [License](#license)
   * [Additional information for users from Russia and Belarus](#additional-information-for-users-from-russia-and-belarus)
@@ -867,19 +868,19 @@ drwxr-xr-x 9 1000 1000 4096 Sep  1 16:23 .
 
 ## Docker usage: Download Terraform modules from private GitHub repositories
 
-If you use a private git repository as your Terraform module source, you are required to authenticate to GitHub using a [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
+If you use a private Git repository as your Terraform module source, you are required to authenticate to GitHub using a [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
 
 When running pre-commit on Docker, both locally or on CI, you need to configure the [~/.netrc](https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html) file, which contains login and initialization information used by the auto-login process.
 
-This can be achieved by firstly creating the `~/.netrc` file including your `GITHUB_PAT` and `GITHUB_SERVER_URL`
+This can be achieved by firstly creating the `~/.netrc` file including your `GITHUB_PAT` and `GITHUB_SERVER_HOSTNAME`
 
 ```bash
 # set GH values (replace with your own values)
 GITHUB_PAT=ghp_bl481aBlabl481aBla
-GITHUB_SERVER_URL=github.com
+GITHUB_SERVER_HOSTNAME=github.com
 
 # create .netrc file
-echo -e "machine $GITHUB_SERVER_URL\n  login $GITHUB_PAT" > ~/.netrc
+echo -e "machine $GITHUB_SERVER_HOSTNAME\n\tlogin $GITHUB_PAT" >> ~/.netrc
 ```
 
 The `~/.netrc` file will look similar to the following:
@@ -889,7 +890,7 @@ machine github.com
   login ghp_bl481aBlabl481aBla
 ```
 
-> Note: The value of `GITHUB_SERVER_URL` can also refer to a GitHub Enterprise server (i.e. `github.my-enterprise.com`).
+> **Note**: The value of `GITHUB_SERVER_HOSTNAME` can also refer to a GitHub Enterprise server (i.e. `github.my-enterprise.com`).
 
 Finally, you can execute `docker run` with an additional volume mount so that the `~/.netrc` is accessible within the container
 


### PR DESCRIPTION
* add steps to configure netrc to source module from private GH
* fix #513

<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.
- [x] This PR adds to docs.

### Description of your changes

This PR adds a section to the docs to provide steps required to allow download of Terraform modules from private GitHub repositories. 

Fixes #513

### How can we test changes

1. Create a Terraform project with modules that are sources from a private GitHub repository
2. Create PAT
3. Follow steps added as part of this PR
4. Execute pre-commit on docker 
