### PR TITLE
fix: Terraform validate - run first validate without running terraform init

### DIFF
--- a/hooks/terraform_validate.sh
+++ b/hooks/terraform_validate.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
+
 # globals variables
 # shellcheck disable=SC2155 # No way to assign to readonly variable in separate lines
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
@@ -103,6 +104,12 @@ function per_dir_hook_unique_part {
         ;;
     esac
   done
+
+  # first try to terraform validate without prior terraform init call
+  terraform validate "${args[@]}" 2>&1 && {
+    exit_code=$?
+    return $exit_code
+  }
 
   common::terraform_init 'terraform validate' "$dir_path" || {
     exit_code=$?


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123456":
-->

As discussed in https://github.com/antonbabenko/pre-commit-terraform/pull/509#issuecomment-1521825264 i would like to introduce a change to run terraform validate in the hook first without running the checks if terraform init is needed.
This helps in situations where there is no `.terraform/modules` or `.terraform/providers` directory as terraform init would be called every time. 

### How can we test changes

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Run the terraform_validate.sh hook against your test repositories, if `terraform validate` should run *first* without any additional checks. If it fails, the normal workflow continues.
