### PR TITLE
feat(`terraform_providers_lock`): Add `--mode` option and deprecate previous workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,7 +549,7 @@ To replicate functionality in `terraform_docs` hook:
 
 1. The hook can work in a few different modes: `only-check-is-current-lockfile-cross-platform` with and without [terraform_validate hook](#terraform_validate) and `always-regenerate-lockfile` - only with terraform_validate hook.
 
-    * `only-check-is-current-lockfile-cross-platform` without terraform_validate - only checks that lockfile have all required SHAs for all already added to lockfile providers.
+    * `only-check-is-current-lockfile-cross-platform` without terraform_validate - only checks that lockfile has all required SHAs for all providers already added to lockfile.
 
         ```yaml
         - id: terraform_providers_lock
@@ -610,7 +610,7 @@ To replicate functionality in `terraform_docs` hook:
 
 5. `terraform_providers_lock` support passing custom arguments to its `terraform init`:
 
-    > **Warning** - DEPRECATION NOTICE: This available only in `no-mode` mode, which will be removed in v2.0. Please provide this keys to [`terraform_validate`](#terraform_validate) hook, which, to take effect, should be called before `terraform_providers_lock`
+    > **Warning** - DEPRECATION NOTICE: This is available only in `no-mode` mode, which will be removed in v2.0. Please provide this keys to [`terraform_validate`](#terraform_validate) hook, which, to take effect, should be called before `terraform_providers_lock`
 
     ```yaml
     - id: terraform_providers_lock

--- a/README.md
+++ b/README.md
@@ -545,7 +545,34 @@ To replicate functionality in `terraform_docs` hook:
 ### terraform_providers_lock
 
 > **Note**: The hook requires Terraform 0.14 or later.
+
 > **Note**: The hook can invoke `terraform providers lock` that can be really slow and requires fetching metadata from remote Terraform registries - not all of that metadata is currently being cached by Terraform.
+
+> <details><summary><b>Note</b>: Read this if you used this hook before v1.80.0 | Planned breaking changes in v2.0</summary>
+> We introduced '--mode' flag for this hook. If you'd like to continue using this hook as before, please:
+>
+> * Specify `--hook-config=--mode=always-regenerate-lockfile` in `args:`
+> * Before `terraform_providers_lock`, add `terraform_validate` hook with `--hook-config=--retry-once-with-cleanup=true`
+> * Move `--tf-init-args=` to `terraform_validate` hook
+>
+> In the end, you should get config like this:
+>
+> ```yaml
+> - id: terraform_validate
+>   args:
+>     - --hook-config=--retry-once-with-cleanup=true
+>     # - --tf-init-args=-upgrade
+>
+> - id: terraform_providers_lock
+>   args:
+>   - --hook-config=--mode=always-regenerate-lockfile
+> ```
+>
+> Why? When v2.x will be introduced - the default mode will be changed, probably, to `only-check-is-current-lockfile-cross-platform`.
+>
+> You can check available modes for hook below.
+> </details>
+
 
 1. The hook can work in a few different modes: `only-check-is-current-lockfile-cross-platform` with and without [terraform_validate hook](#terraform_validate) and `always-regenerate-lockfile` - only with terraform_validate hook.
 

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -312,6 +312,7 @@ function common::colorify {
 # Outputs:
 #   If failed - print out terraform init output
 #######################################################################
+# TODO: v2.0: Move it inside terraform_validate.sh
 function common::terraform_init {
   local -r command_name=$1
   local -r dir_path=$2

--- a/hooks/terraform_providers_lock.sh
+++ b/hooks/terraform_providers_lock.sh
@@ -153,19 +153,16 @@ Why? When v2.x will be introduced - the default mode will be changed.
 
 You can check available modes for hook at https://github.com/antonbabenko/pre-commit-terraform#terraform_providers_lock
 "
+    common::terraform_init 'terraform providers lock' "$dir_path" || {
+      exit_code=$?
+      return $exit_code
+    }
   fi
 
   if [ "$mode" == "only-check-is-current-lockfile-cross-platform" ] &&
     lockfile_contains_all_needed_sha "$platforms_count"; then
 
     exit 0
-  fi
-
-  if [ "$mode" == "no-mode" ]; then
-    common::terraform_init 'terraform providers lock' "$dir_path" || {
-      exit_code=$?
-      return $exit_code
-    }
   fi
 
   #? Don't require `tf init`` for providers, but required `tf init` for modules

--- a/hooks/terraform_providers_lock.sh
+++ b/hooks/terraform_providers_lock.sh
@@ -56,6 +56,10 @@ function lockfile_contains_all_needed_sha {
     # No all SHA in provider found
     if [ "$(echo "$line" | grep -o '^}')" == "}" ]; then
       if [ "$h1_counter" -ge 1 ] || [ "$zh_counter" -ge 1 ]; then
+        # h1_counter can be less than 0, in the case when lockfile
+        # contains more platforms than you currently specify
+        # That's why here extra +50 - for safety reasons, to be sure
+        # that error goes exactly from this part of the function
         return $((150 + h1_counter + zh_counter))
       fi
     fi

--- a/hooks/terraform_providers_lock.sh
+++ b/hooks/terraform_providers_lock.sh
@@ -127,10 +127,8 @@ function per_dir_hook_unique_part {
   # Available options:
   #   only-check-is-current-lockfile-cross-platform (will be default)
   #   always-regenerate-lockfile
-  #   no-mode # TODO: Remove in 2.0
-  [ ! "$mode" ] && mode="no-mode"
-
-  if [ "$mode" == "no-mode" ]; then
+  # TODO: Remove in 2.0
+  if [ ! "$mode" ]; then
     common::colorify "yellow" "DEPRECATION NOTICE: We introduced '--mode' flag for this hook.
 If you'd like to continue using this hook as before, please:
 * Specify '--hook-config=--mode=always-regenerate-lockfile' in 'args:'

--- a/hooks/terraform_providers_lock.sh
+++ b/hooks/terraform_providers_lock.sh
@@ -56,13 +56,17 @@ function lockfile_contains_all_needed_sha {
     # No all SHA in provider found
     if [ "$(echo "$line" | grep -o '^}')" == "}" ]; then
       if [ "$h1_counter" -ge 1 ] || [ "$zh_counter" -ge 1 ]; then
-        return $((100 + h1_counter + zh_counter))
+        return $((150 + h1_counter + zh_counter))
       fi
     fi
 
     # lockfile always exists, because the hook triggered only on
     # `files: (\.terraform\.lock\.hcl)$`
   done < ".terraform.lock.hcl"
+
+# When you specify `-platform``, but don't specify current platform -
+# platforms_count will be less than `h1:` headers`
+[ $h1_counter -lt 0 ] && h1_counter=0
 
 echo lockfile_contains_all_needed_sha return $((h1_counter + zh_counter))
   # 0 if all OK, 2+ when invalid lockfile

--- a/hooks/terraform_providers_lock.sh
+++ b/hooks/terraform_providers_lock.sh
@@ -53,7 +53,7 @@ function lockfile_contains_all_needed_sha {
       zh_counter=$((zh_counter + 1))
       continue
     fi
-    # Not all SHA inside provider found
+    # Not all SHA inside provider lock definition block found
     if [ "$(echo "$line" | grep -o '^}')" == "}" ]; then
       if [ "$h1_counter" -ge 1 ] || [ "$zh_counter" -ge 1 ]; then
         # h1_counter can be less than 0, in the case when lockfile
@@ -134,26 +134,7 @@ function per_dir_hook_unique_part {
   # TODO: Remove in 2.0
   if [ ! "$mode" ]; then
     common::colorify "yellow" "DEPRECATION NOTICE: We introduced '--mode' flag for this hook.
-If you'd like to continue using this hook as before, please:
-* Specify '--hook-config=--mode=always-regenerate-lockfile' in 'args:'
-* Before 'terraform_providers_lock', add 'terraform_validate' hook with '--hook-config=--retry-once-with-cleanup=true'
-* Move '--tf-init-args=' to 'terraform_validate' hook
-
-At the end, you should get config like this:
-
-        - id: terraform_validate
-          args:
-            - --hook-config=--retry-once-with-cleanup=true
-            # - --tf-init-args=-upgrade
-
-        - id: terraform_providers_lock
-          args:
-          - --hook-config=--mode=always-regenerate-lockfile
-
-
-Why? When v2.x will be introduced - the default mode will be changed.
-
-You can check available modes for hook at https://github.com/antonbabenko/pre-commit-terraform#terraform_providers_lock
+Check migration instructions at https://github.com/antonbabenko/pre-commit-terraform#terraform_providers_lock
 "
     common::terraform_init 'terraform providers lock' "$dir_path" || {
       exit_code=$?

--- a/hooks/terraform_providers_lock.sh
+++ b/hooks/terraform_providers_lock.sh
@@ -20,6 +20,55 @@ function main {
 }
 
 #######################################################################
+# Check that all needed `h1` and `zh` SHAs are included in lockfile for
+# each provider.
+# Arguments:
+#   platforms_count (number) How many `-platform` flags provided
+# Outputs:
+#   Return 0 when lockfile has all needed SHAs
+#   Return 1-99 when lockfile is invalid
+#   Return 100+ when not all SHAs found
+#######################################################################
+function lockfile_contains_all_needed_sha {
+  local -r platforms_count="$1"
+
+  local h1_counter="$platforms_count"
+  local zh_counter=0
+
+  # Reading each line
+  while read -r line; do
+
+    if [ "$(echo "$line" | grep -o '^"h1:')" == '"h1:' ]; then
+      h1_counter=$((h1_counter - 1))
+      continue
+    fi
+
+    if [ "$(echo "$line" | grep -o '^"zh:')" == '"zh:' ]; then
+      zh_counter=0
+      continue
+    fi
+
+    if [ "$(echo "$line" | grep -o ^provider)" == "provider" ]; then
+      h1_counter="$platforms_count"
+      zh_counter=$((zh_counter + 1))
+      continue
+    fi
+    # No all SHA in provider found
+    if [ "$(echo "$line" | grep -o '^}')" == "}" ]; then
+      if [ "$h1_counter" -ge 1 ] || [ "$zh_counter" -ge 1 ]; then
+        return $((100 + h1_counter + zh_counter))
+      fi
+    fi
+
+    # lockfile always exists, because the hook triggered only on
+    # `files: (\.terraform\.lock\.hcl)$`
+  done < ".terraform.lock.hcl"
+
+  # 0 if all OK, 2+ when invalid lockfile
+  return $((h1_counter + zh_counter))
+}
+
+#######################################################################
 # Unique part of `common::per_dir_hook`. The function is executed in loop
 # on each provided dir path. Run wrapped tool with specified arguments
 # Arguments:
@@ -39,12 +88,57 @@ function per_dir_hook_unique_part {
   shift 2
   local -a -r args=("$@")
 
+  local platforms_count=0
+  for arg in "${args[@]}"; do
+    if [ "$(echo "$arg" | grep -o '^-platform=')" == "-platform=" ]; then
+      platforms_count=$((platforms_count + 1))
+    fi
+  done
+
   local exit_code
+  #
+  # Get hook settings
+  #
+  local hook_mode
+
+  IFS=";" read -r -a configs <<< "${HOOK_CONFIG[*]}"
+
+  for c in "${configs[@]}"; do
+
+    IFS="=" read -r -a config <<< "$c"
+    key=${config[0]}
+    value=${config[1]}
+
+    case $key in
+      --hook-mode)
+        if [ "$hook_mode" ]; then
+          common::colorify "yellow" 'Invalid hook config. Make sure that you specify not more than one "--hook-mode" flag'
+          exit 1
+        fi
+        hook_mode=$value
+        ;;
+    esac
+  done
+
+  # only-check-is-current-lockfile-cross-platform
+  # check-is-there-new-providers-added---run-terraform-init
+  # always-regenerate-lockfile (default)
+  [ ! "$hook_mode" ] && hook_mode="always-regenerate-lockfile"
+
+  if [ "$hook_mode" == "only-check-is-current-lockfile-cross-platform" ] &&
+    [ "$(lockfile_contains_all_needed_sha "$platforms_count")" == 0 ]; then
+    exit 0
+  fi
 
   common::terraform_init 'terraform providers lock' "$dir_path" || {
     exit_code=$?
     return $exit_code
   }
+
+  if [ "$hook_mode" == "check-is-there-new-providers-added---run-terraform-init" ] &&
+    [ "$(lockfile_contains_all_needed_sha "$platforms_count")" == 0 ]; then
+    exit 0
+  fi
 
   # pass the arguments to hook
   terraform providers lock "${args[@]}"

--- a/hooks/terraform_providers_lock.sh
+++ b/hooks/terraform_providers_lock.sh
@@ -53,7 +53,7 @@ function lockfile_contains_all_needed_sha {
       zh_counter=$((zh_counter + 1))
       continue
     fi
-    # No all SHA in provider found
+    # No all SHA inside provider found
     if [ "$(echo "$line" | grep -o '^}')" == "}" ]; then
       if [ "$h1_counter" -ge 1 ] || [ "$zh_counter" -ge 1 ]; then
         # h1_counter can be less than 0, in the case when lockfile

--- a/hooks/terraform_providers_lock.sh
+++ b/hooks/terraform_providers_lock.sh
@@ -53,7 +53,7 @@ function lockfile_contains_all_needed_sha {
       zh_counter=$((zh_counter + 1))
       continue
     fi
-    # No all SHA inside provider found
+    # Not all SHA inside provider found
     if [ "$(echo "$line" | grep -o '^}')" == "}" ]; then
       if [ "$h1_counter" -ge 1 ] || [ "$zh_counter" -ge 1 ]; then
         # h1_counter can be less than 0, in the case when lockfile

--- a/hooks/terraform_providers_lock.sh
+++ b/hooks/terraform_providers_lock.sh
@@ -38,7 +38,7 @@ function lockfile_contains_all_needed_sha {
   # Reading each line
   while read -r line; do
 
-    if [ "$(echo "$line" | grep -o '^"h1:')" == '"h1:' ]; then
+    if grep -Eq '^"h1:' <<< "$line"; then
       h1_counter=$((h1_counter - 1))
       continue
     fi

--- a/hooks/terraform_providers_lock.sh
+++ b/hooks/terraform_providers_lock.sh
@@ -68,7 +68,6 @@ function lockfile_contains_all_needed_sha {
 # platforms_count will be less than `h1:` headers`
 [ $h1_counter -lt 0 ] && h1_counter=0
 
-echo lockfile_contains_all_needed_sha return $((h1_counter + zh_counter))
   # 0 if all OK, 2+ when invalid lockfile
   return $((h1_counter + zh_counter))
 }
@@ -100,8 +99,6 @@ function per_dir_hook_unique_part {
     fi
   done
 
-echo platforms_count $platforms_count
-
   local exit_code
   #
   # Get hook settings
@@ -132,12 +129,8 @@ echo platforms_count $platforms_count
   # always-regenerate-lockfile (default)
   [ ! "$mode" ] && mode="always-regenerate-lockfile"
 
-lockfile_contains_all_needed_sha "$platforms_count"
-echo $?
-exit 1
-
   if [ "$mode" == "only-check-is-current-lockfile-cross-platform" ] &&
-    [ "$(lockfile_contains_all_needed_sha "$platforms_count")" == "0" ]; then
+    lockfile_contains_all_needed_sha "$platforms_count"; then
 echo "inside if only-check-is-current-lockfile-cross-platform"
     exit 0
   fi
@@ -151,7 +144,7 @@ echo before tf init
 echo after tf init
 
   if [ "$mode" == "check-is-there-new-providers-added---run-terraform-init" ] &&
-    [ "$(lockfile_contains_all_needed_sha "$platforms_count")" == "0" ]; then
+    lockfile_contains_all_needed_sha "$platforms_count"; then
 echo inside if check-is-there-new-providers-added---run-terraform-init
     exit 0
   fi

--- a/hooks/terraform_providers_lock.sh
+++ b/hooks/terraform_providers_lock.sh
@@ -148,7 +148,7 @@ Check migration instructions at https://github.com/antonbabenko/pre-commit-terra
     exit 0
   fi
 
-  #? Don't require `tf init`` for providers, but required `tf init` for modules
+  #? Don't require `tf init` for providers, but required `tf init` for modules
   #? Mitigated by `function match_validate_errors` from terraform_validate hook
   # pass the arguments to hook
   terraform providers lock "${args[@]}"

--- a/hooks/terraform_providers_lock.sh
+++ b/hooks/terraform_providers_lock.sh
@@ -43,18 +43,18 @@ function lockfile_contains_all_needed_sha {
       continue
     fi
 
-    if [ "$(echo "$line" | grep -o '^"zh:')" == '"zh:' ]; then
+    if grep -Eq '^"zh:' <<< "$line"; then
       zh_counter=0
       continue
     fi
 
-    if [ "$(echo "$line" | grep -o ^provider)" == "provider" ]; then
+    if grep -Eq '^provider' <<< "$line"; then
       h1_counter="$platforms_count"
       zh_counter=$((zh_counter + 1))
       continue
     fi
     # Not all SHA inside provider lock definition block found
-    if [ "$(echo "$line" | grep -o '^}')" == "}" ]; then
+    if grep -Eq '^}' <<< "$line"; then
       if [ "$h1_counter" -ge 1 ] || [ "$zh_counter" -ge 1 ]; then
         # h1_counter can be less than 0, in the case when lockfile
         # contains more platforms than you currently specify
@@ -98,7 +98,7 @@ function per_dir_hook_unique_part {
 
   local platforms_count=0
   for arg in "${args[@]}"; do
-    if [ "$(echo "$arg" | grep -o '^-platform=')" == "-platform=" ]; then
+    if grep -Eq '^-platform=' <<< "$arg"; then
       platforms_count=$((platforms_count + 1))
     fi
   done


### PR DESCRIPTION
> **Note**: Please review only after merge #527 and rebase `master` to this branch


<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [x] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

Close #526 

### How can we test changes

```yaml
repos:
- repo: https://github.com/antonbabenko/pre-commit-terraform
  rev: 6ac6f293237ac6ad7c259a72c1112e99e7ff57b4
  hooks:
    - id: terraform_providers_lock
      args:
      - --hook-config=--mode=only-check-is-current-lockfile-cross-platform
```

```yaml
repos:
- repo: https://github.com/antonbabenko/pre-commit-terraform
  rev: 6ac6f293237ac6ad7c259a72c1112e99e7ff57b4
  hooks:
    - id: terraform_validate
      args:
        - --hook-config=--retry-once-with-cleanup=true

    - id: terraform_providers_lock
      args:
      - --hook-config=--mode=only-check-is-current-lockfile-cross-platform
```

```yaml
repos:
- repo: https://github.com/antonbabenko/pre-commit-terraform
  rev: 6ac6f293237ac6ad7c259a72c1112e99e7ff57b4
  hooks:
    - id: terraform_validate
      args:
        - --hook-config=--retry-once-with-cleanup=true
        - --tf-init-args=-upgrade

    - id: terraform_providers_lock
      args:
      - --hook-config=--mode=always-regenerate-lockfile
```


Backward-compatible legacy mode:

```yaml
repos:
- repo: https://github.com/antonbabenko/pre-commit-terraform
  rev: 6ac6f293237ac6ad7c259a72c1112e99e7ff57b4
  hooks:
    - id: terraform_providers_lock
```