### PR TITLE
fix: Fix the terraform_wrapper_module_for_each hook for modules without outputs or variables

### DIFF
--- a/hooks/terraform_wrapper_module_for_each.sh
+++ b/hooks/terraform_wrapper_module_for_each.sh
@@ -323,11 +323,11 @@ EOF
 
     # Get names of module variables in all terraform files
     # shellcheck disable=SC2207
-    module_vars=($(echo "$all_tf_content" | hcledit block list | { grep variable. || true; } | cut -d'.' -f 2))
+    module_vars=($(echo "$all_tf_content" | hcledit block list | { grep variable. || true } | cut -d'.' -f 2))
 
     # Get names of module outputs in all terraform files
     # shellcheck disable=SC2207
-    module_outputs=($(echo "$all_tf_content" | hcledit block list | { grep output. || true; } | cut -d'.' -f 2))
+    module_outputs=($(echo "$all_tf_content" | hcledit block list | { grep output. || true } | cut -d'.' -f 2))
 
     # Looking for sensitive output
     local wrapper_output_sensitive="# sensitive = false # No sensitive module output found"

--- a/hooks/terraform_wrapper_module_for_each.sh
+++ b/hooks/terraform_wrapper_module_for_each.sh
@@ -323,11 +323,11 @@ EOF
 
     # Get names of module variables in all terraform files
     # shellcheck disable=SC2207
-    module_vars=($(echo "$all_tf_content" | hcledit block list | grep variable. | cut -d'.' -f 2))
+    module_vars=($(echo "$all_tf_content" | hcledit block list | { grep variable. || true; } | cut -d'.' -f 2))
 
     # Get names of module outputs in all terraform files
     # shellcheck disable=SC2207
-    module_outputs=($(echo "$all_tf_content" | hcledit block list | grep output. | cut -d'.' -f 2))
+    module_outputs=($(echo "$all_tf_content" | hcledit block list | { grep output. || true; } | cut -d'.' -f 2))
 
     # Looking for sensitive output
     local wrapper_output_sensitive="# sensitive = false # No sensitive module output found"

--- a/hooks/terraform_wrapper_module_for_each.sh
+++ b/hooks/terraform_wrapper_module_for_each.sh
@@ -323,11 +323,11 @@ EOF
 
     # Get names of module variables in all terraform files
     # shellcheck disable=SC2207
-    module_vars=($(echo "$all_tf_content" | hcledit block list | { grep variable. || true } | cut -d'.' -f 2))
+    module_vars=($(echo "$all_tf_content" | hcledit block list | { grep variable. || true; } | cut -d'.' -f 2))
 
     # Get names of module outputs in all terraform files
     # shellcheck disable=SC2207
-    module_outputs=($(echo "$all_tf_content" | hcledit block list | { grep output. || true } | cut -d'.' -f 2))
+    module_outputs=($(echo "$all_tf_content" | hcledit block list | { grep output. || true; } | cut -d'.' -f 2))
 
     # Looking for sensitive output
     local wrapper_output_sensitive="# sensitive = false # No sensitive module output found"


### PR DESCRIPTION
…do not have outputs or variables

<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes
The `terraform_wrapper_module_for_each` hook always exits with `1` code for modules that do not have outputs or variables defined. This is because `grep` returns an exit code of `1` when it does not find a match, and `pipefail` is set for the hook script.

This pull request resolves the issue by setting a `0` exit code for variables and outputs `grep` executions.

### How can we test changes

Run the `terraform_wrapper_module_for_each hook` against the module without outputs or variables. 🙃
