### PR TITLE
feat(docker): Add ssh-client to Docker image to access private modules via ssh

### DIFF
--- a/.github/.container-structure-test-config.yaml
+++ b/.github/.container-structure-test-config.yaml
@@ -76,7 +76,7 @@ commandTests:
   - name: "ssh"
     command: "ssh"
     args: [ "-V" ]
-    expectedOutput: ["^OpenSSH_[0-9]+\\.[0-9]+"]
+    expectedOutput: ["^OpenSSH_9\\.[0-9]+"]
 
 fileExistenceTests:
   - name: 'terrascan init'

--- a/.github/.container-structure-test-config.yaml
+++ b/.github/.container-structure-test-config.yaml
@@ -73,6 +73,11 @@ commandTests:
     command: "su-exec"
     expectedOutput: ["^Usage: su-exec user-spec command \\[args\\]\\n$"]
 
+  - name: "ssh"
+    command: "ssh"
+    expectedOutput: ["^usage: ssh [-46AaCfGgKkMNnqsTtVvXxYy] [-B bind_interface]$"]
+   
+
 fileExistenceTests:
   - name: 'terrascan init'
     path: '/root/.terrascan/pkg/policies/opa/rego/github/github_repository/privateRepoEnabled.rego'

--- a/.github/.container-structure-test-config.yaml
+++ b/.github/.container-structure-test-config.yaml
@@ -75,7 +75,7 @@ commandTests:
 
   - name: "ssh"
     command: "ssh"
-    expectedOutput: ["^usage: ssh [-46AaCfGgKkMNnqsTtVvXxYy] [-B bind_interface]$"]
+    expectedOutput: ["^usage: ssh \\[-46AaCfGgKkMNnqsTtVvXxYy\\] \\[-B bind_interface\\]\\n$"]
    
 
 fileExistenceTests:

--- a/.github/.container-structure-test-config.yaml
+++ b/.github/.container-structure-test-config.yaml
@@ -75,7 +75,8 @@ commandTests:
 
   - name: "ssh"
     command: "ssh"
-    expectedOutput: ["^usage: ssh \\[-46AaCfGgKkMNnqsTtVvXxYy\\] \\[-B bind_interface\\]\\n$"]
+    args: [ "-V" ]
+    expectedOutput: ["^OpenSSH_[0-9]+\\.[0-9]+.*\\n$"]
    
 
 fileExistenceTests:

--- a/.github/.container-structure-test-config.yaml
+++ b/.github/.container-structure-test-config.yaml
@@ -76,7 +76,7 @@ commandTests:
   - name: "ssh"
     command: "ssh"
     args: [ "-V" ]
-    expectedOutput: ["^OpenSSH_9\\.[0-9]+"]
+    expectedError: ["^OpenSSH_9\\.[0-9]+"]
 
 fileExistenceTests:
   - name: 'terrascan init'

--- a/.github/.container-structure-test-config.yaml
+++ b/.github/.container-structure-test-config.yaml
@@ -76,8 +76,7 @@ commandTests:
   - name: "ssh"
     command: "ssh"
     args: [ "-V" ]
-    expectedOutput: ["^OpenSSH_[0-9]+\\.[0-9]+.*\\n$"]
-   
+    expectedOutput: ["^OpenSSH_[0-9]+\\.[0-9]+"]
 
 fileExistenceTests:
   - name: 'terrascan init'

--- a/Dockerfile
+++ b/Dockerfile
@@ -189,7 +189,7 @@ RUN apk add --no-cache \
     
 # ssh-client for external private module in ssh
 RUN apk add --no-cache \
-    ssh-client
+    openssh-client
 
 # Copy tools
 COPY --from=builder \

--- a/Dockerfile
+++ b/Dockerfile
@@ -185,10 +185,8 @@ RUN apk add --no-cache \
     musl-dev=~1 \
     gcc=~12 \
     # entrypoint wrapper deps
-    su-exec=~0.2
-    
-# ssh-client for external private module in ssh
-RUN apk add --no-cache \
+    su-exec=~0.2 \
+    # ssh-client for external private module in ssh
     openssh-client
 
 # Copy tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -186,6 +186,10 @@ RUN apk add --no-cache \
     gcc=~12 \
     # entrypoint wrapper deps
     su-exec=~0.2
+    
+# ssh-client for external private module in ssh
+RUN apk add --no-cache \
+    ssh-client
 
 # Copy tools
 COPY --from=builder \

--- a/Dockerfile
+++ b/Dockerfile
@@ -187,7 +187,7 @@ RUN apk add --no-cache \
     # entrypoint wrapper deps
     su-exec=~0.2 \
     # ssh-client for external private module in ssh
-    openssh-client
+    openssh-client=~9
 
 # Copy tools
 COPY --from=builder \


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ X ] This PR enhances existing functionality.

### Description of your changes
I have external private module in my terraform code (source="ssh://git@...."). 

In checkov we need to clone external module.
I'm using private module in git. So git need to use ssh to clone them.

I add the installation of ssh-client in the docker image.
It fixes the issue "error: cannot run ssh: No such file or directory"

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123456":
-->

<!-- Fixes # -->

### How can we test changes

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
From a low level point of view, start the docker image and try to clone a repository via SSH.
From a high level point of view, create a module accessible in ssh, call it from terraform,  enable terraform_checkov in pre-commit.

