### PR TITLE
fix: Fix terraform_wrapper_module_for_each hook heredoc vars defaults

### DIFF
--- a/hooks/terraform_wrapper_module_for_each.sh
+++ b/hooks/terraform_wrapper_module_for_each.sh
@@ -361,7 +361,7 @@ EOF
         # As a result, wrappers in terraform-aws-security-group module are missing values of the rules variable and is not useful. :(
         var_value="try(each.value.${module_var}, var.defaults.${module_var}, {})"
       elif [[ $var_default == *EOF || $var_default == *EOT ]]; then
-        # Heredoc style default values produces HCL parsing error:
+        # Heredoc style default values produce HCL parsing error:
         # 'Unterminated template string; No closing marker was found for the string.'
         # Because closing marker must be alone on it's own line:
         # https://developer.hashicorp.com/terraform/language/expressions/strings#heredoc-strings

--- a/hooks/terraform_wrapper_module_for_each.sh
+++ b/hooks/terraform_wrapper_module_for_each.sh
@@ -360,7 +360,7 @@ EOF
         # https://github.com/terraform-aws-modules/terraform-aws-security-group/blob/0bd31aa88339194efff470d3b3f58705bd008db0/rules.tf#L8
         # As a result, wrappers in terraform-aws-security-group module are missing values of the rules variable and is not useful. :(
         var_value="try(each.value.${module_var}, var.defaults.${module_var}, {})"
-      elif [[ $var_default == *EOF || $var_default == *EOT ]]; then
+      elif [[ $var_default == \<\<* ]]; then
         # Heredoc style default values produce HCL parsing error:
         # 'Unterminated template string; No closing marker was found for the string.'
         # Because closing marker must be alone on it's own line:


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes
Fixes #552 comments

If default variable values are written in heredoc style, the hook produces an error:

```
Terraform wrapper with for_each in module................................Failed
- hook id: terraform_wrapper_module_for_each
- exit code: 1

failed to build expression at the parse phase: failed to parse input: generated_by_buildExpression:21,7-7: Unterminated template string; No closing marker was found for the string.

```

This error occurs because the heredoc syntax requires the closing marker to be alone on its own line. This pull request adds a new line at the end for heredoc default values.

Also, this pull request addresses @yermulnik's comment in issue #552.

### How can we test changes

Changes can be tested against any module that has heredoc default values for variables. For example, the [terraform-aws-appsync](https://github.com/terraform-aws-modules/terraform-aws-appsync/) module.