### PR TITLE
fix: Fixed ordering issue in terraform_wrapper_module_for_each hook

### DIFF
--- a/hooks/terraform_wrapper_module_for_each.sh
+++ b/hooks/terraform_wrapper_module_for_each.sh
@@ -325,7 +325,7 @@ EOF
 
     # Get names of module outputs in all terraform files
     # shellcheck disable=SC2207
-    module_outputs=($(echo "$all_tf_content" | hcledit block list | { grep output. | cut -d'.' -f 2 | sort || true; }))
+    module_outputs=($(echo "$all_tf_content" | hcledit block list | { grep output. | cut -d'.' -f 2 || true; }))
 
     # Get names of module providers in all terraform files
     module_providers=$(echo "$all_tf_content" | hcledit block list | { grep provider. || true; })

--- a/hooks/terraform_wrapper_module_for_each.sh
+++ b/hooks/terraform_wrapper_module_for_each.sh
@@ -321,11 +321,11 @@ EOF
 
     # Get names of module variables in all terraform files
     # shellcheck disable=SC2207
-    module_vars=($(echo "$all_tf_content" | hcledit block list | { grep variable. | cut -d'.' -f 2 || true; }))
+    module_vars=($(echo "$all_tf_content" | hcledit block list | { grep variable. | cut -d'.' -f 2 | sort || true; }))
 
     # Get names of module outputs in all terraform files
     # shellcheck disable=SC2207
-    module_outputs=($(echo "$all_tf_content" | hcledit block list | { grep output. | cut -d'.' -f 2 || true; }))
+    module_outputs=($(echo "$all_tf_content" | hcledit block list | { grep output. | cut -d'.' -f 2 | sort || true; }))
 
     # Get names of module providers in all terraform files
     module_providers=$(echo "$all_tf_content" | hcledit block list | { grep provider. || true; })


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an x into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123456":
-->

I have a module with variables defined in two `.tf` files. When I run the `terraform_wrapper_module_for_each hook` locally on macOS, no changes are shown. However, when the same hooks run against the same module by GitHub Actions on Ubuntu, a difference in the order of the wrapper module input variables is shown. After researching the root cause of this behavior, I discovered that the `find` utility returns files in a different order on macOS and Ubuntu because these OS use different virtual file systems:
https://unix.stackexchange.com/questions/13451/what-is-the-directory-order-of-files-in-a-directory-used-by-ls-u

To solve this issue, I added sorting for the outputs and variables before appending them to the wrapper module.

#### Note: These changes could cause updates to already generated wrappers.

<!-- Fixes # -->

### How can we test changes

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Run the hooks against module with the next structure in MacOS and Ubuntu:
```
main.tf
variables.tf             # Some variables are defined here
additional_variables.tf  # Some variables are defined here