### PR TITLE
fix: Extend `--retry-once-with-cleanup` terraform_validate errors list

### DIFF
--- a/hooks/terraform_validate.sh
+++ b/hooks/terraform_validate.sh
@@ -55,6 +55,7 @@ function match_validate_errors {
       "Module version requirements have changed") return 1 ;;
       "Module not installed") return 1 ;;
       "Could not load plugin") return 1 ;;
+      *"there is no package for"*"cached in .terraform/providers") return 1 ;;
     esac
   done < <(jq -rc '.diagnostics[]' <<< "$validate_output")
 
@@ -100,6 +101,7 @@ function per_dir_hook_unique_part {
 
     case $key in
       --retry-once-with-cleanup)
+        # shellcheck disable=SC2086 # It's just works. Maybe will be fixed later
         if [ $retry_once_with_cleanup ]; then
           common::colorify "yellow" 'Invalid hook config. Make sure that you specify not more than one "--retry-once-with-cleanup" flag'
           exit 1
@@ -117,7 +119,7 @@ function per_dir_hook_unique_part {
     return $exit_code
   }
 
-  # In case `terraform validate` failed to execute 
+  # In case `terraform validate` failed to execute
   # - check is simple `terraform init` will help
   common::terraform_init 'terraform validate' "$dir_path" || {
     exit_code=$?


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123456":
-->

Fixes #561

### How can we test changes

To reproduce:
```
gh repo clone osinfra-io/google-cloud-networking
cd google-cloud-networking
pre-commit run -a
rm -rf global/infra/.terraform/providers/registry.terraform.io/hashicorp/google/4.80.0 
pre-commit run -a
```

Test fix:

1. change in `.pre-commit-config.yaml`

from
```yaml
  - repo: https://github.com/antonbabenko/pre-commit-terraform
    rev: v1.83.0
```
to
```yaml
  - repo: https://github.com/antonbabenko/pre-commit-terraform
    rev: 043a10b51662786ef59ecba95d76984a21fd0d20
```
run
```
pre-commit run -a
```
