### PR TITLE
fix: Fix terraform_wrapper_module_for_each for when resource name contains 'variable'

### DIFF
--- a/hooks/terraform_wrapper_module_for_each.sh
+++ b/hooks/terraform_wrapper_module_for_each.sh
@@ -321,14 +321,14 @@ EOF
 
     # Get names of module variables in all terraform files
     # shellcheck disable=SC2207
-    module_vars=($(echo "$all_tf_content" | hcledit block list | { grep variable. | cut -d'.' -f 2 | sort || true; }))
+    module_vars=($(echo "$all_tf_content" | hcledit block list | { grep "^variable\." | cut -d'.' -f 2 | sort || true; }))
 
     # Get names of module outputs in all terraform files
     # shellcheck disable=SC2207
-    module_outputs=($(echo "$all_tf_content" | hcledit block list | { grep output. | cut -d'.' -f 2 || true; }))
+    module_outputs=($(echo "$all_tf_content" | hcledit block list | { grep "^output\." | cut -d'.' -f 2 || true; }))
 
     # Get names of module providers in all terraform files
-    module_providers=$(echo "$all_tf_content" | hcledit block list | { grep provider. || true; })
+    module_providers=$(echo "$all_tf_content" | hcledit block list | { grep "^provider\." || true; })
 
     if [[ $module_providers ]]; then
       common::colorify "yellow" "Skipping ${full_module_dir} because it is a legacy module which contains its own local provider configurations and so calls to it may not use the for_each argument."


### PR DESCRIPTION
Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

There are some providers with resources and data sources that have "variable" in their name, for example:

- [env0_configuration_variable](https://registry.terraform.io/providers/env0/env0/latest/docs/resources/configuration_variable)
- [env0_configuration_variable](https://registry.terraform.io/providers/env0/env0/latest/docs/data-sources/configuration_variable) data source

When using such resources, `terraform_wrapper_module_for_each` was adding these as variables to pass in `wrappers/main.tf` which breaks the wrapper 

> ╷
> │ Error: Unsupported argument
> │ 
> │   on main.tf line 14, in module "wrapper":
> │   14:   env0_configuration_variable              = try(each.value.env0_configuration_variable, var.defaults.env0_configuration_variable)
> │ 
> │ An argument named "env0_configuration_variable" is not expected here.
> ╵
> Validation failed: wrappers

My fix simply improves `grep` to ensure that `module_vars` (and `module_outputs` and `module_providers`) only find actual variables, outputs, and providers and NOT resources.

### How can we test changes

Use the examples provided in the documentation for [env0_configuration_variable](https://registry.terraform.io/providers/env0/env0/latest/docs/resources/configuration_variable) and try `terraform_wrapper_module_for_each` as-is today.  You'll see that it adds these as variables to pass to the module when it shouldn't.

Now test with my fix and you'll see that it fixes the issue.