### PR TITLE
Add `terraform_graph` hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -143,3 +143,11 @@
     - --args=terraform
   files: \.tf$
   require_serial: true
+
+- id: terraform_graph
+  name: Terraform graph
+  description: Outputs Terraform dependency graphs in dot format.
+  entry: hooks/terraform_graph.sh
+  language: script
+  files: \.tf$
+  exclude: \.terraform\/.*$

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ If you are using `pre-commit-terraform` already or want to support its developme
 * [`infracost`](https://github.com/infracost/infracost) required for `infracost_breakdown` hook.
 * [`jq`](https://github.com/stedolan/jq) required for `terraform_validate` with `--retry-once-with-cleanup` flag, and for `infracost_breakdown` hook.
 * [`tfupdate`](https://github.com/minamijoyo/tfupdate) required for `tfupdate` hook.
+* [`graphviz`](https://www.graphviz.org/download)  required for `terraform_graph` hook.
 * [`hcledit`](https://github.com/minamijoyo/hcledit) required for `terraform_wrapper_module_for_each` hook.
 
 <details><summary><b>Docker</b></summary><br>
@@ -138,7 +139,7 @@ Set `-e PRE_COMMIT_COLOR=never` to disable the color output in `pre-commit`.
 <details><summary><b>MacOS</b></summary><br>
 
 ```bash
-brew install pre-commit terraform-docs tflint tfsec checkov terrascan infracost tfupdate minamijoyo/hcledit/hcledit jq
+brew install pre-commit terraform-docs tflint tfsec checkov terrascan infracost tfupdate minamijoyo/hcledit/hcledit jq graphviz
 ```
 
 </details>
@@ -161,6 +162,7 @@ sudo apt install -y jq && \
 curl -L "$(curl -s https://api.github.com/repos/infracost/infracost/releases/latest | grep -o -E -m 1 "https://.+?-linux-amd64.tar.gz")" > infracost.tgz && tar -xzf infracost.tgz && rm infracost.tgz && sudo mv infracost-linux-amd64 /usr/bin/infracost && infracost register
 curl -L "$(curl -s https://api.github.com/repos/minamijoyo/tfupdate/releases/latest | grep -o -E -m 1 "https://.+?_linux_amd64.tar.gz")" > tfupdate.tar.gz && tar -xzf tfupdate.tar.gz tfupdate && rm tfupdate.tar.gz && sudo mv tfupdate /usr/bin/
 curl -L "$(curl -s https://api.github.com/repos/minamijoyo/hcledit/releases/latest | grep -o -E -m 1 "https://.+?_linux_amd64.tar.gz")" > hcledit.tar.gz && tar -xzf hcledit.tar.gz hcledit && rm hcledit.tar.gz && sudo mv hcledit /usr/bin/
+sudo apt install -y graphviz
 ```
 
 </details>
@@ -182,6 +184,7 @@ sudo apt install -y jq && \
 curl -L "$(curl -s https://api.github.com/repos/infracost/infracost/releases/latest | grep -o -E -m 1 "https://.+?-linux-amd64.tar.gz")" > infracost.tgz && tar -xzf infracost.tgz && rm infracost.tgz && sudo mv infracost-linux-amd64 /usr/bin/infracost && infracost register
 curl -L "$(curl -s https://api.github.com/repos/minamijoyo/tfupdate/releases/latest | grep -o -E -m 1 "https://.+?_linux_amd64.tar.gz")" > tfupdate.tar.gz && tar -xzf tfupdate.tar.gz tfupdate && rm tfupdate.tar.gz && sudo mv tfupdate /usr/bin/
 curl -L "$(curl -s https://api.github.com/repos/minamijoyo/hcledit/releases/latest | grep -o -E -m 1 "https://.+?_linux_amd64.tar.gz")" > hcledit.tar.gz && tar -xzf hcledit.tar.gz hcledit && rm hcledit.tar.gz && sudo mv hcledit /usr/bin/
+sudo apt install -y graphviz
 ```
 
 </details>
@@ -280,6 +283,7 @@ There are several [pre-commit](https://pre-commit.com/) hooks to keep Terraform 
 | `terraform_wrapper_module_for_each`                    | Generates Terraform wrappers with `for_each` in module. [Hook notes](#terraform_wrapper_module_for_each)                                                                                                                                     | `hcledit`                                                                            |
 | `terrascan`                                            | [terrascan](https://github.com/tenable/terrascan) Detect compliance and security violations. [Hook notes](#terrascan)                                                                                                                        | `terrascan`                                                                          |
 | `tfupdate`                                             | [tfupdate](https://github.com/minamijoyo/tfupdate) Update version constraints of Terraform core, providers, and modules. [Hook notes](#tfupdate)                                                                                             | `tfupdate`                                                                           |
+| `terraform_graph`                                             | Generates charts using [terraform graph](https://developer.hashicorp.com/terraform/cli/commands/graph) and [GraphViz](https://www.graphviz.org/). [Hook notes](#terraform_graph)                                                                                             | `dot` from [GraphViz](https://www.graphviz.org/download)                                                                            |
 <!-- markdownlint-enable no-inline-html -->
 
 Check the [source file](https://github.com/antonbabenko/pre-commit-terraform/blob/master/.pre-commit-hooks.yaml) to know arguments used for each hook.
@@ -925,6 +929,16 @@ If the generated name is incorrect, set them by providing the `module-repo-short
 
 Check [`tfupdate` usage instructions](https://github.com/minamijoyo/tfupdate#usage) for other available options and usage examples.  
 No need to pass `--recursive .` as it is added automatically.
+
+### terraform_graph
+`terraform_graph` utilizes Terraform's built-in [`graph` command](https://developer.hashicorp.com/terraform/cli/commands/graph) and `dot` from [GraphViz](https://www.graphviz.org/) to generate charts of your configuration.
+
+```yaml
+- id: terraform_graph
+  args:
+  - --args=-type=apply # Default is `plan`
+  - --hook-config=--path-to-file=test-config.svg # Default is tf-graph.svg
+```
 
 ## Docker Usage
 

--- a/hooks/terraform_graph.sh
+++ b/hooks/terraform_graph.sh
@@ -44,7 +44,7 @@ function per_dir_hook_unique_part {
   fi
 
   # set file name passed from --hook-config
-  local text_file="graph.svg"
+  local text_file="tf-graph.svg"
   IFS=";" read -r -a configs <<< "${HOOK_CONFIG[*]}"
   for c in "${configs[@]}"; do
     IFS="=" read -r -a config <<< "$c"

--- a/hooks/terraform_graph.sh
+++ b/hooks/terraform_graph.sh
@@ -71,23 +71,4 @@ function per_dir_hook_unique_part {
   return $exit_code
 }
 
-#######################################################################
-# Unique part of `common::per_dir_hook`. The function is executed one time
-# in the root git repo
-# Arguments:
-#   args (array) arguments that configure wrapped tool behavior
-#######################################################################
-# function run_hook_on_whole_repo {
-#   local -a -r args=("$@")
-#   local text_file="graph.svg"
-
-#   # pass the arguments to hook
-#   echo "${args[@]}" >> run_hook_on_whole_repo
-#   terraform graph "$(pwd)" "${args[@]}" | dot -Tsvg > "$text_file"
-
-#   # return exit code to common::per_dir_hook
-#   local exit_code=$?
-#   return $exit_code
-# }
-
 [ "${BASH_SOURCE[0]}" != "$0" ] || main "$@"

--- a/hooks/terraform_graph.sh
+++ b/hooks/terraform_graph.sh
@@ -64,7 +64,7 @@ function per_dir_hook_unique_part {
 
   # check if files are the same
   cmp -s "$temp_file" "$text_file"
-  
+
   # return exit code to common::per_dir_hook
   local exit_code=$?
   mv "$temp_file" "$text_file"

--- a/hooks/terraform_graph.sh
+++ b/hooks/terraform_graph.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# globals variables
+# shellcheck disable=SC2155 # No way to assign to readonly variable in separate lines
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=_common.sh
+. "$SCRIPT_DIR/_common.sh"
+
+function main {
+  common::initialize "$SCRIPT_DIR"
+  common::parse_cmdline "$@"
+  common::export_provided_env_vars "${ENV_VARS[@]}"
+  common::parse_and_export_env_vars
+
+  # shellcheck disable=SC2153 # False positive
+  common::per_dir_hook "$HOOK_ID" "${#ARGS[@]}" "${ARGS[@]}" "${FILES[@]}"
+}
+
+#######################################################################
+# Unique part of `common::per_dir_hook`. The function is executed in loop
+# on each provided dir path. Run wrapped tool with specified arguments
+# Arguments:
+#   dir_path (string) PATH to dir relative to git repo root.
+#     Can be used in error logging
+#   change_dir_in_unique_part (string/false) Modifier which creates
+#     possibilities to use non-common chdir strategies.
+#     Availability depends on hook.
+#   args (array) arguments that configure wrapped tool behavior
+# Outputs:
+#   If failed - print out hook checks status
+#######################################################################
+function per_dir_hook_unique_part {
+  # shellcheck disable=SC2034 # Unused var.
+  local -r dir_path="$1"
+  # shellcheck disable=SC2034 # Unused var.
+  local -r change_dir_in_unique_part="$2"
+  shift 2
+  local -a -r args=("$@")
+
+  if [[ ! $(command -v dot) ]]; then
+    echo "ERROR: dot is required by terraform_graph pre-commit hook but is not installed or in the system's PATH."
+    exit 1
+  fi
+
+  # set file name passed from --hook-config
+  local text_file="graph.svg"
+  IFS=";" read -r -a configs <<< "${HOOK_CONFIG[*]}"
+  for c in "${configs[@]}"; do
+    IFS="=" read -r -a config <<< "$c"
+    key=${config[0]}
+    value=${config[1]}
+
+    case $key in
+      --path-to-file)
+        text_file=$value
+        ;;
+    esac
+  done
+
+  temp_file=$(mktemp)
+  # pass the arguments to hook
+  terraform graph "${args[@]}" | dot -Tsvg > "$temp_file"
+
+  # check if files are the same
+  cmp -s "$temp_file" "$text_file"
+  
+  # return exit code to common::per_dir_hook
+  local exit_code=$?
+  mv "$temp_file" "$text_file"
+  return $exit_code
+}
+
+#######################################################################
+# Unique part of `common::per_dir_hook`. The function is executed one time
+# in the root git repo
+# Arguments:
+#   args (array) arguments that configure wrapped tool behavior
+#######################################################################
+# function run_hook_on_whole_repo {
+#   local -a -r args=("$@")
+#   local text_file="graph.svg"
+
+#   # pass the arguments to hook
+#   echo "${args[@]}" >> run_hook_on_whole_repo
+#   terraform graph "$(pwd)" "${args[@]}" | dot -Tsvg > "$text_file"
+
+#   # return exit code to common::per_dir_hook
+#   local exit_code=$?
+#   return $exit_code
+# }
+
+[ "${BASH_SOURCE[0]}" != "$0" ] || main "$@"


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [X] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes
This adds a `terraform_graph` hook that generates charts using [`terraform graph`](https://developer.hashicorp.com/terraform/cli/commands/graph) and [GraphViz](https://www.graphviz.org/). My org finds something like this helpful to upkeep documentation.

#### Test results
200 runs '`terraform_graph` v0.0.1:'

| time command   | max    | min    | mean     | median |
| -------------- | ------ | ------ | -------- | ------ |
| users seconds  | 14.71 | 9.51 | 13.6592 | 13.84 |
| system seconds | 1.48 | 0.95 | 1.28115 | 1.29 |
| CPU %          | 415 | 149 | 371.545 | 377 |
| Total time     | 8.71 | 3.16 | 4.054 | 3.99 |

<details><summary>Run details</summary>

* Test Start: Mon 11 Dec 2023 04:41:22 PM UTC
* Test End: Mon 11 Dec 2023 04:54:54 PM UTC

| Variable name                | Value |
| ---------------------------- | --- |
| `TEST_NUM`                   | <code>200</code> |
| `TEST_COMMAND`               | <code>pre-commit try-repo -a /home/$user/Desktop/pre-commit-terraform terraform_graph</code> |
| `TEST_DIR`                   | <code>/home/$user/$repo</code> |
| `TEST_DESCRIPTION`           | <code>200 runs '`terraform_graph` v0.0.1:'</code> |
| `RAW_TEST_RESULTS_FILE_NAME` | <code>terraform_graph_results</code> |

Memory info (`head -n 6 /proc/meminfo`):

```bash
MemTotal:       32519148 kB
MemFree:         8189176 kB
MemAvailable:   27378808 kB
Buffers:          571396 kB
Cached:         14010628 kB
SwapCached:          120 kB
```

CPU info:

```bash
Real procs: 4
Virtual (hyper-threading) procs: 8
processor	: 7
vendor_id	: GenuineIntel
cpu family	: 6
model		: 142
model name	: Intel(R) Core(TM) i7-10610U CPU @ 1.80GHz
stepping	: 12
microcode	: 0xf8
cpu MHz		: 3400.063
cache size	: 8192 KB
physical id	: 0
siblings	: 8
core id		: 3
cpu cores	: 4
apicid		: 7
initial apicid	: 7
fpu		: yes
fpu_exception	: yes
cpuid level	: 22
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb invpcid_single ssbd ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid mpx rdseed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp md_clear flush_l1d arch_capabilities
vmx flags	: vnmi preemption_timer invvpid ept_x_only ept_ad ept_1gb flexpriority tsc_offset vtpr mtf vapic ept vpid unrestricted_guest ple shadow_vmcs pml ept_mode_based_exec
bugs		: spectre_v1 spectre_v2 spec_store_bypass swapgs taa itlb_multihit srbds mmio_stale_data retbleed eibrs_pbrsb gds
bogomips	: 4599.93
clflush size	: 64
cache_alignment	: 64
address sizes	: 39 bits physical, 48 bits virtual
power management:
```

</details>


### How can we test changes
Testing can be performed by running against a repo with `*.tf` files and ensuring that the correct `*.svg` files are output in each directory:
```yaml
- repo: https://github.com/jrdnbradford/pre-commit-terraform
  rev: add-graph-hook
  hooks:
    - id: terraform_graph
      args:
      - --args=-type=plan-destroy
      - --hook-config=--path-to-file=test-config.svg
 ```
The most important configs for the hook are [`-type`](https://developer.hashicorp.com/terraform/cli/commands/graph#type-plan) and a hook config `--path-to-file` that sets the name of the output `*.svg`.

I cannot say that I'm a particularly good shell scripter, so if there's interest in adding this please feel free to edit.

