### PR TITLE
feat: Investigate and fix issue with wrong CPU count for containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,11 +397,11 @@ If you'd like to set parallelism value relative to number of CPU logical cores -
 
 ```yaml
 args:
-  - --hook-config=--parallelism-ci-cpu-cores=N
+  - --hook-config=--parallelism-cpu-cores=N
 ```
 
 If you don't see code above in your `pre-commit-config.yaml` or logs - you don't need it.  
-`--parallelism-ci-cpu-cores` used only in edge cases. Check-out it usage in [hooks/_common.sh](hooks/_common.sh)
+`--parallelism-cpu-cores` used only in edge cases. Check-out it usage in [hooks/_common.sh](hooks/_common.sh)
 
 ### checkov (deprecated) and terraform_checkov
 

--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ args:
 ```
 
 If you don't see code above in your `pre-commit-config.yaml` or logs - you don't need it.  
-`--parallelism-ci-cpu-cores` used only in corner cases. Check-out it usage in [hooks/_common.sh](hooks/_common.sh)
+`--parallelism-ci-cpu-cores` used only in edge cases. Check-out it usage in [hooks/_common.sh](hooks/_common.sh)
 
 ### checkov (deprecated) and terraform_checkov
 

--- a/README.md
+++ b/README.md
@@ -393,6 +393,16 @@ If you'd like to set parallelism value relative to number of CPU logical cores -
 >
 > </details>
 
+
+
+```yaml
+args:
+  - --hook-config=--parallelism-ci-cpu-cores=N
+```
+
+If you don't see code above in your `pre-commit-config.yaml` or logs - you don't need it.  
+`--parallelism-ci-cpu-cores` used only in corner cases. Check-out it usage in [hooks/_common.sh](hooks/_common.sh)
+
 ### checkov (deprecated) and terraform_checkov
 
 > `checkov` hook is deprecated, please use `terraform_checkov`.

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -223,6 +223,8 @@ function common::per_dir_hook {
   # `nproc` - linux, `sysctl -n hw.ncpu` - macOS, `echo 1` - fallback
   local CPU
 
+  apt update
+  apt install -y tree
   tree /sys/fs/cgroup/
 
   exit 1

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -193,7 +193,7 @@ function common::get_cpu_num {
         common::colorify "yellow" "Unable to derive number of available CPU cores.\n" \
           "Running inside K8s pod without limits or inside DinD without limits propagation.\n" \
           "To avoid possible harm, parallelism is disabled.\n" \
-          "If you'd like reenable it - set corresponding limits, or set next for current hook:\n" \
+          "To re-enable it, set corresponding limits, or set the following for the current hook:\n" \
           "  args:\n" \
           "    - --hook-config=--parallelism-ci-cpu-cores=N\n" \
           "where N is the number of CPU cores to allocate to pre-commit."

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -314,8 +314,7 @@ function common::per_dir_hook {
 
   if [[ ! $parallelism_limit ]]; then
     parallelism_limit=$((CPU - 1))
-  fi
-  if [[ $parallelism_limit -le 1 ]]; then
+  elif [[ $parallelism_limit -le 1 ]]; then
     parallelism_limit=1
     parallelism_disabled=true
   fi

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -228,6 +228,9 @@ function common::per_dir_hook {
   tree /sys/fs/cgroup/
   more /sys/fs/cgroup/cpu/* | cat
 
+  echo cpuset-------------------------------------------
+  more /sys/fs/cgroup/cpuset/* | cat
+
   exit 1
 
   if [[ ! -f /sys/fs/cgroup/cpu.max ]]; then

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -292,7 +292,8 @@ function common::per_dir_hook {
     esac
   done
 
-  CPU=$(common::get_cpu_num "$parallelism_limit")
+  common::get_cpu_num "$parallelism_limit"
+  CPU=$?
   # parallelism_limit can include reference to 'CPU' variable
   parallelism_limit=$((parallelism_limit))
   local parallelism_disabled=false

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -174,13 +174,11 @@ function common::is_hook_run_on_whole_repo {
 # Get the number of CPU logical cores available to pre-commit use
 # Arguments:
 #  parallelism_limit (string) Used for checking if user redefined defaults
-#  parallelism_bypass_safety_check (bool) If true - skip K8s safety check
 # Outputs:
 #   Return number CPU logical cores, rounded to below integer
 #######################################################################
 function common::get_cpu_num {
   local -r parallelism_limit=$1
-  local -r parallelism_bypass_safety_check=$2
 
   local millicpu
 
@@ -190,17 +188,13 @@ function common::get_cpu_num {
 
     if [[ $millicpu -eq -1 ]]; then
       # K8s no limits or in DinD
-      if [[ $parallelism_bypass_safety_check == true ]]; then
-        return "$(nproc 2> /dev/null || echo 1)"
-      fi
-
       if [[ ! $parallelism_limit ]]; then
         common::colorify "yellow" "Unable to calculate available CPU cors.\n" \
           "You in K8s pod without limits or in DinD without limits propagation.\n" \
-          "To avoid possible harm, parallelism disabled.\n" \
-          "To reenable it, set limits or specify '--parallelism-limit' for hooks\n"
+          "To avoid possible harm, set '--parallelism-limit' for hooks"
       fi
-      return 1
+
+      return "$(nproc 2> /dev/null || echo 1)"
     fi
 
     return $((millicpu / 1000))
@@ -295,15 +289,11 @@ function common::per_dir_hook {
         # this flag will limit the number of parallel processes
         parallelism_limit="$value"
         ;;
-      --parallelism-bypass-safety-check)
-        # this flag will limit the number of parallel processes
-        parallelism_bypass_safety_check="$value"
-        ;;
     esac
   done
 
   set +e
-  common::get_cpu_num "$parallelism_limit" "$parallelism_bypass_safety_check"
+  common::get_cpu_num "$parallelism_limit"
   CPU=$?
   set -e
 

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -223,6 +223,7 @@ function common::per_dir_hook {
   # `nproc` - linux, `sysctl -n hw.ncpu` - macOS, `echo 1` - fallback
   local CPU
   CPU=$(nproc 2> /dev/null || sysctl -n hw.ncpu 2> /dev/null || echo 1)
+common::colorify "yellow" "CPU: $CPU"
   local parallelism_limit
   local parallelism_disabled=false
 

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -396,7 +396,7 @@ function common::colorify {
     COLOR=$RESET
   fi
 
-  echo -e "${COLOR}${TEXT}${RESET}"
+  echo -e "${COLOR}${TEXT}${RESET}" >&2
 }
 
 #######################################################################

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -180,6 +180,7 @@ function common::is_hook_run_on_whole_repo {
 #######################################################################
 function common::get_cpu_num {
   local -r parallelism_limit=$1
+  local -r parallelism_bypass_safety_check=$2
 
   local millicpu
 

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -305,7 +305,7 @@ function common::per_dir_hook {
 
   set +e
   common::get_cpu_num "$parallelism_ci_cpu_cores"
-  CPU=$?
+  local -r CPU=$?
   set -e
 
   # parallelism_limit can include reference to 'CPU' variable

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -226,6 +226,7 @@ function common::per_dir_hook {
   apt update
   apt install -y tree
   tree /sys/fs/cgroup/
+  more /sys/fs/cgroup/* | cat
 
   exit 1
 
@@ -239,7 +240,7 @@ function common::per_dir_hook {
     local millicpu
     millicpu=$(cut -d' ' -f1 /sys/fs/cgroup/cpu.max)
     echo "DBG:"
-    cut -/sys/fs/cgroup/cpu.max
+    cat /sys/fs/cgroup/cpu.max
     if [[ "$millicpu" == "max" ]]; then
       echo "DBG: CPU: max"
       CPU=$(nproc 2> /dev/null || echo 1)

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -226,7 +226,7 @@ function common::per_dir_hook {
   apt update
   apt install -y tree
   tree /sys/fs/cgroup/
-  more /sys/fs/cgroup/* | cat
+  more /sys/fs/cgroup/cpu* | cat
 
   exit 1
 

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -292,8 +292,11 @@ function common::per_dir_hook {
     esac
   done
 
+  set +e
   common::get_cpu_num "$parallelism_limit"
   CPU=$?
+  set -e
+
   # parallelism_limit can include reference to 'CPU' variable
   parallelism_limit=$((parallelism_limit))
   local parallelism_disabled=false

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -231,6 +231,7 @@ function common::per_dir_hook {
   echo cpuset-------------------------------------------
   more /sys/fs/cgroup/cpuset/* | cat
 
+  sleep 1000000000000000000000
   exit 1
 
   if [[ ! -f /sys/fs/cgroup/cpu.max ]]; then

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -225,19 +225,25 @@ function common::per_dir_hook {
 
   if [[ ! -f /sys/fs/cgroup/cpu.max ]]; then
     # On host machine
+    echo "DBG: On host machine"
     CPU=$(nproc 2> /dev/null || sysctl -n hw.ncpu 2> /dev/null || echo 1)
   else
     # Inside Linux container
+    echo "DBG: Inside Linux container"
     local millicpu
     millicpu=$(cut -d' ' -f1 /sys/fs/cgroup/cpu.max)
+    echo "DBG:"
+    cut -/sys/fs/cgroup/cpu.max
     if [[ "$millicpu" == "max" ]]; then
+      echo "DBG: CPU: max"
       CPU=$(nproc 2> /dev/null || echo 1)
     else
+      echo "DBG: CPU: $((millicpu / 1000))"
       CPU=$((millicpu / 1000))
     fi
   fi
 
-common::colorify "yellow" "CPU: $CPU"
+  common::colorify "yellow" "CPU: $CPU"
   local parallelism_limit
   local parallelism_disabled=false
 

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -219,45 +219,8 @@ function common::per_dir_hook {
 
   # Lookup hook-config for modifiers that impact common behavior
   local change_dir_in_unique_part=false
-  # Limit the number of parallel processes to the number of CPU cores -1
-  # `nproc` - linux, `sysctl -n hw.ncpu` - macOS, `echo 1` - fallback
-  local CPU
 
-  apt update
-  apt install -y tree
-  tree /sys/fs/cgroup/
-  more /sys/fs/cgroup/cpu/* | cat
-
-  echo cpuset-------------------------------------------
-  more /sys/fs/cgroup/cpuset/* | cat
-
-  sleep 1000000000000000000000
-  exit 1
-
-  if [[ ! -f /sys/fs/cgroup/cpu.max ]]; then
-    # On host machine
-    echo "DBG: On host machine"
-    CPU=$(nproc 2> /dev/null || sysctl -n hw.ncpu 2> /dev/null || echo 1)
-  else
-    # Inside Linux container
-    echo "DBG: Inside Linux container"
-    local millicpu
-    millicpu=$(cut -d' ' -f1 /sys/fs/cgroup/cpu.max)
-    echo "DBG:"
-    cat /sys/fs/cgroup/cpu.max
-    if [[ "$millicpu" == "max" ]]; then
-      echo "DBG: CPU: max"
-      CPU=$(nproc 2> /dev/null || echo 1)
-    else
-      echo "DBG: CPU: $((millicpu / 1000))"
-      CPU=$((millicpu / 1000))
-    fi
-  fi
-
-  common::colorify "yellow" "CPU: $CPU"
   local parallelism_limit
-  local parallelism_disabled=false
-
   IFS=";" read -r -a configs <<< "${HOOK_CONFIG[*]}"
   for c in "${configs[@]}"; do
     IFS="=" read -r -a config <<< "$c"
@@ -278,10 +241,68 @@ function common::per_dir_hook {
         ;;
       --parallelism-limit)
         # this flag will limit the number of parallel processes
-        parallelism_limit=$((value))
+        parallelism_limit="$value"
         ;;
     esac
   done
+
+  # Limit the number of parallel processes to the number of CPU cores -1
+  # `nproc` - linux, `sysctl -n hw.ncpu` - macOS, `echo 1` - fallback
+  local CPU millicpu
+
+  # apt update
+  # apt install -y tree
+  # tree /sys/fs/cgroup/
+  # more /sys/fs/cgroup/cpu/* | cat
+
+  # echo cpuset-------------------------------------------
+  # more /sys/fs/cgroup/cpuset/* | cat
+
+  # sleep 1000000000000000000000
+  # exit 1
+
+  if [[ -f /sys/fs/cgroup/cpu/cpu.cfs_quota_us ]]; then
+    # Inside K8s pod or DInD in K8s
+    millicpu=$(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us)
+    if [[ $millicpu -eq -1 ]]; then
+      # K8s no limits or in DinD
+      CPU=1
+
+      if [[ ! $parallelism_limit ]]; then
+        common::colorify "yellow" "Unable to calculate available CPU cors.\n" \
+          "You in K8s pod without limits or in DinD without limits propagation.\n" \
+          "To avoid possible harm, parallelism disabled.\n" \
+          "To reenable it, set limits or specify '--parallelism-limit' for hooks"
+      fi
+    else
+      CPU=$((millicpu / 1000))
+      echo "DBG: Inside K8s, CPU: $CPU"
+    fi
+  elif [[ -f /sys/fs/cgroup/cpu.max ]]; then
+    # Inside Linux container
+    echo "DBG: Inside Linux container"
+    local millicpu
+    millicpu=$(cut -d' ' -f1 /sys/fs/cgroup/cpu.max)
+    echo "DBG:"
+    cat /sys/fs/cgroup/cpu.max
+    if [[ "$millicpu" == "max" ]]; then
+      echo "DBG: CPU: max"
+      CPU=$(nproc 2> /dev/null || echo 1)
+    else
+      echo "DBG: CPU: $((millicpu / 1000))"
+      CPU=$((millicpu / 1000))
+    fi
+  else
+    # On host machine
+    echo "DBG: On host machine"
+    CPU=$(nproc 2> /dev/null || sysctl -n hw.ncpu 2> /dev/null || echo 1)
+  fi
+
+  common::colorify "yellow" "CPU: $CPU"
+  echo "DBG: parallelism_limit before: $parallelism_limit"
+
+  parallelism_limit=$((parallelism_limit))
+  local parallelism_disabled=false
 
   if [[ ! $parallelism_limit ]]; then
     parallelism_limit=$((CPU - 1))
@@ -289,6 +310,9 @@ function common::per_dir_hook {
     parallelism_limit=1
     parallelism_disabled=true
   fi
+
+  echo "DBG: parallelism_limit after: $parallelism_limit"
+  exit 1
 
   local final_exit_code=0
   local pids=()
@@ -353,7 +377,8 @@ function common::colorify {
 
   # Params start #
   local COLOR="${!1}"
-  local -r TEXT=$2
+  shift
+  local -r TEXT="$*"
   # Params end #
 
   if [ "$PRE_COMMIT_COLOR" = "never" ]; then

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -226,7 +226,7 @@ function common::per_dir_hook {
   apt update
   apt install -y tree
   tree /sys/fs/cgroup/
-  more /sys/fs/cgroup/cpu* | cat
+  more /sys/fs/cgroup/cpu/* | cat
 
   exit 1
 

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -176,7 +176,7 @@ function common::is_hook_run_on_whole_repo {
 #  parallelism_cpu_cores (string) Used in edge cases when number of
 #    CPU cores can't be derived automatically
 # Outputs:
-#   Return number CPU logical cores, rounded to below integer
+#   Returns number of CPU logical cores, rounded down to nearest integer
 #######################################################################
 function common::get_cpu_num {
   local -r parallelism_cpu_cores=$1

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -193,10 +193,10 @@ function common::get_cpu_num {
         common::colorify "yellow" "Unable to calculate available CPU cors.\n" \
           "You in K8s pod without limits or in DinD without limits propagation.\n" \
           "To avoid possible harm, parallelism disabled.\n" \
-          "If you'd like reenable it - set next for current hook:\n" \
+          "If you'd like reenable it - set corresponding limits, or set next for current hook:\n" \
           "  args:\n" \
           "    - --hook-config=--parallelism-ci-cpu-cores=N\n" \
-          "where N is the number of CPU cores available in your environment."
+          "where N is the number of CPU cores you providing to pre-commit."
 
         return 1
       fi

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -223,6 +223,10 @@ function common::per_dir_hook {
   # `nproc` - linux, `sysctl -n hw.ncpu` - macOS, `echo 1` - fallback
   local CPU
 
+  tree /sys/fs/cgroup/
+
+  exit 1
+
   if [[ ! -f /sys/fs/cgroup/cpu.max ]]; then
     # On host machine
     echo "DBG: On host machine"


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [x] This PR enhances existing functionality.

### Description of your changes

So, I found that `nproc` always shows how many CPUs available is. K8s "limits" and docker `--cpus` are throttling mechanisms, which do not hide the visibility of all cores.
There are a few workarounds, but  IMO, it is better to implement checks for that than do them

>Workaround for docker - set `--cpuset-cpus`
>Workaraund for K8s - somehow deal with [kubelet static CPU management policy](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#cpu-management-policies), as [recommend in Reddit](https://news.ycombinator.com/item?id=25224714)

* Send all "colorify" logs through stderr, as make able to add user-facing-logs in functions that also need to return same value to function-caller
