### PR TITLE
fix: Fix `grep: warning: stray \ before /` which pop-up in `grep 3.8`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,7 +5,7 @@
   language: script
   require_serial: true
   files: \.(tf(vars)?|hcl)$
-  exclude: \.terraform\/.*$
+  exclude: \.terraform/.*$
 
 - id: terraform_fmt
   name: Terraform fmt
@@ -13,7 +13,7 @@
   entry: hooks/terraform_fmt.sh
   language: script
   files: (\.tf|\.tfvars)$
-  exclude: \.terraform\/.*$
+  exclude: \.terraform/.*$
 
 - id: terraform_docs
   name: Terraform docs
@@ -22,7 +22,7 @@
   entry: hooks/terraform_docs.sh
   language: script
   files: (\.tf|\.terraform\.lock\.hcl)$
-  exclude: \.terraform\/.*$
+  exclude: \.terraform/.*$
 
 - id: terraform_docs_without_aggregate_type_defaults
   name: Terraform docs (without aggregate type defaults)
@@ -31,7 +31,7 @@
   entry: hooks/terraform_docs.sh
   language: script
   files: (\.tf)$
-  exclude: \.terraform\/.*$
+  exclude: \.terraform/.*$
 
 - id: terraform_docs_replace
   name: Terraform docs (overwrite README.md)
@@ -40,7 +40,7 @@
   entry: terraform_docs_replace
   language: python
   files: (\.tf)$
-  exclude: \.terraform\/.*$
+  exclude: \.terraform/.*$
 
 - id: terraform_validate
   name: Terraform validate
@@ -49,7 +49,7 @@
   entry: hooks/terraform_validate.sh
   language: script
   files: (\.tf|\.tfvars)$
-  exclude: \.terraform\/.*$
+  exclude: \.terraform/.*$
 
 - id: terraform_providers_lock
   name: Lock terraform provider versions
@@ -58,7 +58,7 @@
   entry: hooks/terraform_providers_lock.sh
   language: script
   files: (\.terraform\.lock\.hcl)$
-  exclude: \.terraform\/.*$
+  exclude: \.terraform/.*$
 
 - id: terraform_tflint
   name: Terraform validate with tflint
@@ -67,7 +67,7 @@
   entry: hooks/terraform_tflint.sh
   language: script
   files: (\.tf|\.tfvars)$
-  exclude: \.terraform\/.*$
+  exclude: \.terraform/.*$
 
 - id: terragrunt_fmt
   name: Terragrunt fmt
@@ -75,7 +75,7 @@
   entry: hooks/terragrunt_fmt.sh
   language: script
   files: (\.hcl)$
-  exclude: \.terraform\/.*$
+  exclude: \.terraform/.*$
 
 - id: terragrunt_validate
   name: Terragrunt validate
@@ -83,7 +83,7 @@
   entry: hooks/terragrunt_validate.sh
   language: script
   files: (\.hcl)$
-  exclude: \.terraform\/.*$
+  exclude: \.terraform/.*$
 
 - id: terraform_tfsec
   name: Terraform validate with tfsec (deprecated, use "terraform_trivy")
@@ -109,7 +109,7 @@
   pass_filenames: false
   always_run: false
   files: \.tf$
-  exclude: \.terraform\/.*$
+  exclude: \.terraform/.*$
   require_serial: true
 
 - id: terraform_checkov
@@ -119,7 +119,7 @@
   language: script
   always_run: false
   files: \.tf$
-  exclude: \.terraform\/.*$
+  exclude: \.terraform/.*$
   require_serial: true
 
 - id: terraform_wrapper_module_for_each
@@ -131,7 +131,7 @@
   always_run: false
   require_serial: true
   files: \.tf$
-  exclude: \.terraform\/.*$
+  exclude: \.terraform/.*$
 
 - id: terrascan
   name: terrascan
@@ -139,7 +139,7 @@
   language: script
   entry: hooks/terrascan.sh
   files: \.tf$
-  exclude: \.terraform\/.*$
+  exclude: \.terraform/.*$
   require_serial: true
 
 - id: tfupdate


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

Remove `\` before `\/` as grep 3.8 don't like it and `re.search` don't mind about it

Fix #618

### How can we test changes

These exclude patterns in pre-commit used by Python `re.search`, and it is okay with that change

https://regex101.com/
![image](https://github.com/antonbabenko/pre-commit-terraform/assets/11096782/ae6fff95-af33-40be-a710-bfa2287a4254)


```yaml
repos:
- repo: https://github.com/antonbabenko/pre-commit-terraform
  rev: 7e213b5c4202015ee5f5ee311cd6277b5ffd0775
 ...
```
