### PR TITLE
fix: Replace `mapfile` to support Bash 3.2.57 pre-installed in macOS 

### DIFF
--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -348,7 +348,9 @@ function common::per_dir_hook {
 
   local pids=()
 
-  mapfile -t dir_paths_unique < <(echo "${dir_paths[@]}" | tr ' ' '\n' | sort -u)
+  while IFS= read -r _line; do
+    dir_paths_unique+=("$_line")
+  done < <(printf '%s\n' "${dir_paths[@]}" | sort -u)
   local length=${#dir_paths_unique[@]}
   local last_index=$((${#dir_paths_unique[@]} - 1))
 

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -347,11 +347,10 @@ function common::per_dir_hook {
   fi
 
   local pids=()
-  local dir_paths_unique=()
 
-  while IFS= read -r _line; do
-    dir_paths_unique+=("$_line")
-  done < <(printf '%s\n' "${dir_paths[@]}" | sort -u)
+  # shellcheck disable=SC2207
+  local -a dir_paths_unique=("$(printf '%s\n' "${dir_paths[@]}" | sort -u)")
+
   local length=${#dir_paths_unique[@]}
   local last_index=$((${#dir_paths_unique[@]} - 1))
 

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -347,6 +347,7 @@ function common::per_dir_hook {
   fi
 
   local pids=()
+  local dir_paths_unique=()
 
   while IFS= read -r _line; do
     dir_paths_unique+=("$_line")

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -349,7 +349,7 @@ function common::per_dir_hook {
   local pids=()
 
   # shellcheck disable=SC2207
-  local -a dir_paths_unique=("$(printf '%s\n' "${dir_paths[@]}" | sort -u)")
+  local -a dir_paths_unique=($(printf '%s\n' "${dir_paths[@]}" | sort -u))
 
   local length=${#dir_paths_unique[@]}
   local last_index=$((${#dir_paths_unique[@]} - 1))


### PR DESCRIPTION
Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

`hooks/_common.sh`: Replace `mapfile` to support Bash v3