### PR TITLE
fix: Replace `mapfile` to support Bash 3.2.57 pre-installed in macOS

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_local_install.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_local_install.md
@@ -91,7 +91,6 @@ echo -n "tfsec " && tfsec --version       2>/dev/null || echo "SKIPPED"
 echo -n "trivy " && trivy --version       2>/dev/null || echo "SKIPPED"
 echo -n "tfupdate " && tfupdate --version 2>/dev/null || echo "SKIPPED"
 echo -n "hcledit " && hcledit version     2>/dev/null || echo "SKIPPED"
-echo -n "flock " && flock --version       2>/dev/null || echo "SKIPPED"
 EOF
 
 -->

--- a/Dockerfile
+++ b/Dockerfile
@@ -173,7 +173,6 @@ RUN . /.env && \
 RUN . /.env && \
     F=tools_versions_info && \
     pre-commit --version >> $F && \
-    echo "flock $(flock 2>&1 | head -n 1)" >> $F && \
     ./terraform --version | head -n 1 >> $F && \
     (if [ "$CHECKOV_VERSION"        != "false" ]; then echo "checkov $(checkov --version)" >> $F;     else echo "checkov SKIPPED" >> $F        ; fi) && \
     (if [ "$INFRACOST_VERSION"      != "false" ]; then echo "$(./infracost --version)" >> $F;         else echo "infracost SKIPPED" >> $F      ; fi) && \


### PR DESCRIPTION
Follow-up release fix for
https://github.com/antonbabenko/pre-commit-terraform/pull/627
