### PR TITLE
fix(non-linux): Bash environment variables in arguments not expanded

### DIFF
--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -1,8 +1,24 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-[[ $PCT_LOG == trace ]] && set -x # Enable Trace logs
+if [[ $PCT_LOG == trace ]]; then
 
+  # FUNC_TRACE="${FUNCNAME[*]:1}" # Get functions in trace. Skip first two functions that used for logging
+  # func_trace=${FUNC_TRACE// / <- } # Replace ' ' to ' <- '.
+  echo "BASH path: '$BASH'"
+  echo "BASH_VERSION: $BASH_VERSION"
+  echo "BASHOPTS: $BASHOPTS"
+  echo "OSTYPE: $OSTYPE"
+
+  # ${FUNCNAME[*]} - reverse functions trace. Each new function call append to start
+  # ${BASH_SOURCE##*/} - get filename
+  # $LINENO - get line number
+  export PS4='\e[2m
+trace: ${FUNCNAME[*]}
+       ${BASH_SOURCE##*/}:$LINENO: \e[0m'
+
+  set -x
+fi
 # Hook ID, based on hook filename.
 # Hook filename MUST BE same with `- id` in .pre-commit-hooks.yaml file
 # shellcheck disable=SC2034 # Unused var.

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -127,7 +127,8 @@ function common::parse_and_export_env_vars {
     # Repeat until all env vars will be expanded
     while true; do
       # Check if at least 1 env var exists in `$arg`
-      if [[ "$arg" =~ \${[A-Z_][A-Z0-9_]+} ]]; then
+      # shellcheck disable=SC2016 # '${' should not be expanded
+      if [[ "$arg" =~ '${'[A-Z_][A-Z0-9_]+'}' ]]; then
         # Get `ENV_VAR` from `.*${ENV_VAR}.*`
         local env_var_name=${arg#*$\{}
         env_var_name=${env_var_name%%\}*}

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
+[[ $PCT_LOG == trace ]] && set -x # Enable Trace logs
+
 # Hook ID, based on hook filename.
 # Hook filename MUST BE same with `- id` in .pre-commit-hooks.yaml file
 # shellcheck disable=SC2034 # Unused var.

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -127,8 +127,7 @@ function common::parse_and_export_env_vars {
     # Repeat until all env vars will be expanded
     while true; do
       # Check if at least 1 env var exists in `$arg`
-      # shellcheck disable=SC2016 # '${' should not be expanded
-      if [[ "$arg" =~ .*'${'[A-Z_][A-Z0-9_]+?'}'.* ]]; then
+      if [[ "$arg" =~ \${[A-Z_][A-Z0-9_]+} ]]; then
         # Get `ENV_VAR` from `.*${ENV_VAR}.*`
         local env_var_name=${arg#*$\{}
         env_var_name=${env_var_name%%\}*}

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -128,7 +128,7 @@ function common::parse_and_export_env_vars {
     while true; do
       # Check if at least 1 env var exists in `$arg`
       # shellcheck disable=SC2016 # '${' should not be expanded
-      if [[ "$arg" =~ '${'[A-Z_][A-Z0-9_]+'}' ]]; then
+      if [[ "$arg" =~ '${'[A-Z_][A-Z0-9_]*'}' ]]; then
         # Get `ENV_VAR` from `.*${ENV_VAR}.*`
         local env_var_name=${arg#*$\{}
         env_var_name=${env_var_name%%\}*}

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -3,8 +3,6 @@ set -eo pipefail
 
 if [[ $PCT_LOG == trace ]]; then
 
-  # FUNC_TRACE="${FUNCNAME[*]:1}" # Get functions in trace. Skip first two functions that used for logging
-  # func_trace=${FUNC_TRACE// / <- } # Replace ' ' to ' <- '.
   echo "BASH path: '$BASH'"
   echo "BASH_VERSION: $BASH_VERSION"
   echo "BASHOPTS: $BASHOPTS"


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

* `?` is not supported in bash regex outside Linux.

* Add trace log level for very problematic cases (relates to #562) 


Fixes #638 

### How can we test changes

```yaml
repos:
- repo: https://github.com/antonbabenko/pre-commit-terraform
  rev: e76ffce8e949b9269edfd9101b72526a307401c3
  hooks:
    - id: terraform_trivy
      args:
        - --args=--config-policy="/Users/${USER}/PATH_TO_CUSTOM_POLICY/"
      verbose: true
```

and run 

* `pre-commit run -a`
* `PCT_LOG=trace  pre-commit run -a`

