### PR TITLE
fix(`terraform_providers_lock`): Require `terraform init` (and `terraform_validate` hook) run when only lockfile changed

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -48,7 +48,7 @@
   require_serial: true
   entry: hooks/terraform_validate.sh
   language: script
-  files: (\.tf|\.tfvars|\.terraform\.lock\.hcl)$
+  files: \.(tf(vars)?|terraform\.lock\.hcl)$
   exclude: \.terraform/.*$
 
 - id: terraform_providers_lock

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -48,7 +48,7 @@
   require_serial: true
   entry: hooks/terraform_validate.sh
   language: script
-  files: (\.tf|\.tfvars)$
+  files: (\.tf|\.tfvars|\.terraform\.lock\.hcl)$
   exclude: \.terraform/.*$
 
 - id: terraform_providers_lock


### PR DESCRIPTION
Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

![image](https://github.com/antonbabenko/pre-commit-terraform/assets/11096782/50022937-7360-4c3b-8919-a488730c493a)

When the terraform root module contains any child module it requires `terraform init` to run to be able to successfully run the provider lock operation.

Previously, `terraform init` was in `terraform_providers_lock` hook too, but moved out to be only in `terraform_validate`, because there was little sense to try to lock anything that was code invalid. 
If we return `terraform init` back to  `terraform_providers_lock` - major changes in providers that remove resources etc. can be successfully written to lockfile without any checks, as such checks done in `terraform_validate`

## Workaround till the release of that stuff

Add `files: (\.tf|\.tfvars|\.terraform\.lock\.hcl)$` to `terraform_validate` hook call