### PR TITLE
fix: Improve README and drop quotes from hook env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,12 @@ If for config above set up `export CONFIG_NAME=.tflint; export CONFIG_EXT=hcl` b
 
 You can specify environment variables that will be passed to the hook at runtime.
 
+> [!IMPORTANT]
+> Variable values are exported _verbatim_:
+> - No interpolation or expansion are applied
+> - The behavior is the same as if values would've been wrapped into single quotes
+> - The enclosing double quotes are removed if they are provided
+
 Config example:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -325,7 +325,6 @@ You can specify environment variables that will be passed to the hook at runtime
 > [!IMPORTANT]
 > Variable values are exported _verbatim_:
 > - No interpolation or expansion are applied
-> - The behavior is the same as if values would've been wrapped into single quotes
 > - The enclosing double quotes are removed if they are provided
 
 Config example:

--- a/README.md
+++ b/README.md
@@ -328,8 +328,7 @@ Config example:
 - id: terraform_validate
   args:
     - --env-vars=AWS_DEFAULT_REGION="us-west-2"
-    - --env-vars=AWS_ACCESS_KEY_ID="anaccesskey"
-    - --env-vars=AWS_SECRET_ACCESS_KEY="asecretkey"
+    - --env-vars=AWS_PROFILE="my-aws-cli-profile"
 ```
 
 ### All hooks: Disable color output

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -527,6 +527,11 @@ function common::export_provided_env_vars {
   for var in "${env_vars[@]}"; do
     var_name="${var%%=*}"
     var_value="${var#*=}"
+    # Drop enclosing double quotes
+    if [[ $var_value =~ ^\" && $var_value =~ \"$ ]]; then
+      var_value="${var_value#\"}"
+      var_value="${var_value%\"}"
+    fi
     # shellcheck disable=SC2086
     export $var_name="$var_value"
   done


### PR DESCRIPTION
Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [x] This PR enhances existing functionality.

### Description of your changes

Fixes https://github.com/antonbabenko/pre-commit-terraform/issues/650
* Improve `README` by replacing sensitive `AWS_` creds vars with `AWS_PROFILE`
* Drop enclosing double quote from hook env vars

Kudos to @ericfrederich for spotting and reporting that