### PR TITLE
feat: Hook terraform_wrapper_module_for_each should use versions.tf from the module if it exists

### DIFF
--- a/hooks/terraform_wrapper_module_for_each.sh
+++ b/hooks/terraform_wrapper_module_for_each.sh
@@ -393,7 +393,13 @@ EOF
       mv "$tmp_file_tf" "${output_dir}/main.tf"
 
       echo "$CONTENT_VARIABLES_TF" > "${output_dir}/variables.tf"
-      echo "$CONTENT_VERSIONS_TF" > "${output_dir}/versions.tf"
+
+      # If the root module has a versions.tf, use that; otherwise, create it
+      if [[ -f "${full_module_dir}/versions.tf" ]]; then
+        cp "${full_module_dir}/versions.tf" "${output_dir}/versions.tf"
+      else
+        echo "$CONTENT_VERSIONS_TF" > "${output_dir}/versions.tf"
+      fi
 
       echo "$CONTENT_OUTPUTS_TF" > "${output_dir}/outputs.tf"
       sed -i.bak "s|WRAPPER_OUTPUT_SENSITIVE|${wrapper_output_sensitive}|g" "${output_dir}/outputs.tf"


### PR DESCRIPTION
Put an `x` into the box if that apply:

- [x] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

Rather than having `hooks/terraform_wrapper_module_for_each.sh` always create `versions.tf` for us, if the module has `versions.tf`, use that instead.

We want to do this because if your module uses a non-Hashicorp provider and `versions.tf` doesn't have a the required `required_providers` config, then Terraform will try to download the provider from Hashicorp (i.e., for the [env0 provider](https://registry.terraform.io/providers/env0/env0/latest/docs), it would try to download `hashicorp/env0` which doesn't exist and NOT `env0/env0`)... We COULD set this in the deployment code; however, if you're using Terragrunt and you configure the provider with the `required_providers` config, then if you use a root module (with proper `versions.tf`) with the provider, then you get a conflict because you have `required_providers` configured in the module AND `required_providers` configured in the deployment code.

### How can we test changes

When you run pre-commit, `wrappers/versions.tf` should be copied from / the same as `/versions.tf`.