### PR TITLE
fix(`terraform_docs`): Suppress "terraform command not found" error message in case binary does not exist

### DIFF
--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -47,7 +47,7 @@ function terraform_docs_ {
   IFS=";" read -r -a configs <<< "$hook_config"
 
   local hack_terraform_docs
-  hack_terraform_docs=$(terraform version | sed -n 1p | grep -c 0.12) || true
+  hack_terraform_docs=$(terraform version 2> /dev/null | sed -n 1p | grep -c 0.12) || true
 
   if [[ ! $(command -v terraform-docs) ]]; then
     echo "ERROR: terraform-docs is required by terraform_docs pre-commit hook but is not installed or in the system's PATH."

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -47,7 +47,10 @@ function terraform_docs_ {
   IFS=";" read -r -a configs <<< "$hook_config"
 
   local hack_terraform_docs
-  hack_terraform_docs=$(terraform version 2> /dev/null | sed -n 1p | grep -c 0.12 || tofu version 2> /dev/null | echo 0) || true
+  local hack_terraform_docs=0
+  if [[ $(\command -V terraform 2> /dev/null) ]]; then
+    hack_terraform_docs=$(terraform version | sed -n 1p | grep -c 0.12) || true
+  fi
 
   if [[ ! $(command -v terraform-docs) ]]; then
     echo "ERROR: terraform-docs is required by terraform_docs pre-commit hook but is not installed or in the system's PATH."

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -47,7 +47,7 @@ function terraform_docs_ {
   IFS=";" read -r -a configs <<< "$hook_config"
 
   local hack_terraform_docs
-  hack_terraform_docs=$(terraform version 2> /dev/null | sed -n 1p | grep -c 0.12) || $(tofu version 2> /dev/null | echo 0) || true
+  hack_terraform_docs=$(terraform version 2> /dev/null | sed -n 1p | grep -c 0.12 || tofu version 2> /dev/null | echo 0) || true
 
   if [[ ! $(command -v terraform-docs) ]]; then
     echo "ERROR: terraform-docs is required by terraform_docs pre-commit hook but is not installed or in the system's PATH."

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -47,7 +47,7 @@ function terraform_docs_ {
   IFS=";" read -r -a configs <<< "$hook_config"
 
   local hack_terraform_docs
-  hack_terraform_docs=$(terraform version 2> /dev/null | sed -n 1p | grep -c 0.12) || true
+  hack_terraform_docs=$(terraform version 2> /dev/null | sed -n 1p | grep -c 0.12) || $(tofu version 2> /dev/null | echo 0) || true
 
   if [[ ! $(command -v terraform-docs) ]]; then
     echo "ERROR: terraform-docs is required by terraform_docs pre-commit hook but is not installed or in the system's PATH."


### PR DESCRIPTION
Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [X] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

If you are using OpenTofu and don't have Terraform binary installed, terraform_docs hook will display a `command not found` error. The error line checks if Terraform release is 0.12, so it's possible suppress this error message if Terraform binary doesn't exist.

<img width="877" alt="image" src="https://github.com/user-attachments/assets/b9210fee-ec52-4984-a79c-e1212918a82d">

### How can we test changes

Below are the steps to reproduce the error.

1) Install OpenTofu
2) Uninstall Terraform (or remove it from PATH)
3) Make any changes to variables.tf or outputs.tf
4) Run `pre-commit -a`

<img width="648" alt="image" src="https://github.com/user-attachments/assets/1aebeabd-c987-4faa-92f7-cf6e29486268">
