### PR TITLE
fix(`terraform_docs`): Fix issue and prioritize `output.file` setting from `.terraform-docs.yml` config over `--hook-config=--path-to-file=`

### DIFF
--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -168,10 +168,12 @@ function terraform_docs {
     # Prioritize `.terraform-docs.yml` `output.file` over
     # `--hook-config=--path-to-file=` if it set
     local output_file
-    output_file=$(grep -A1000 -e '^output:$' "$config_file" | grep ' file:' |
-      awk -F':' '{print $2}' | tr -d '[:space:]"' | tr -d "'")
+    # Get latest non-commented `output.file` from `.terraform-docs.yml`
+    output_file=$(grep -A1000 -e '^output:$' "$config_file" | grep ' file:' | grep -v '#' || true)
+
     if [ "$output_file" ]; then
-      text_file=$output_file
+      # Extract filename from `output.file` line
+      text_file=$(echo "$output_file" | awk -F':' '{print $2}' | tr -d '[:space:]"' | tr -d "'")
     fi
 
     # Suppress terraform_docs color

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -159,13 +159,22 @@ function terraform_docs {
   if [[ "$args" != *"--config"* ]]; then
     local tf_docs_formatter="md"
 
-  # Suppress terraform_docs color
   else
 
     local config_file=${args#*--config}
     config_file=${config_file#*=}
     config_file=${config_file% *}
 
+    # Prioritize `.terraform-docs.yml` `output.file` over
+    # `--hook-config=--path-to-file=` if it set
+    local output_file
+    output_file=$(grep -A1000 -e '^output:$' "$config_file" | grep ' file:' |
+      awk -F':' '{print $2}' | tr -d '[:space:]"' | tr -d "'")
+    if [ "$output_file" ]; then
+      text_file=$output_file
+    fi
+
+    # Suppress terraform_docs color
     local config_file_no_color
     config_file_no_color="$config_file$(date +%s).yml"
 

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -228,7 +228,7 @@ function terraform_docs {
 
     if [[ "$terraform_docs_awk_file" == "0" ]]; then
       # shellcheck disable=SC2086
-      terraform-docs $tf_docs_formatter $args ./ > "$tmp_file"
+      terraform-docs --output-file="" $tf_docs_formatter $args ./ > "$tmp_file"
     else
       # Can't append extension for mktemp, so renaming instead
       local tmp_file_docs
@@ -239,7 +239,7 @@ function terraform_docs {
 
       awk -f "$terraform_docs_awk_file" ./*.tf > "$tmp_file_docs_tf"
       # shellcheck disable=SC2086
-      terraform-docs $tf_docs_formatter $args "$tmp_file_docs_tf" > "$tmp_file"
+      terraform-docs --output-file="" $tf_docs_formatter $args "$tmp_file_docs_tf" > "$tmp_file"
       rm -f "$tmp_file_docs_tf"
     fi
 

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -169,7 +169,7 @@ function terraform_docs {
     # `--hook-config=--path-to-file=` if it set
     local output_file
     # Get latest non-commented `output.file` from `.terraform-docs.yml`
-    output_file=$(grep -A1000 -e '^output:$' "$config_file" | grep ' file:' | grep -v '#' || true)
+    output_file=$(grep -A1000 -e '^output:$' "$config_file" | grep ' file:' | grep -v '#' | tail -n 1 || true)
 
     if [ "$output_file" ]; then
       # Extract filename from `output.file` line


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123456":
-->

This PR explicitly overrides any output files configured in `.terraform-docs.yml` to ensure the rendered documentation is written to stdout (which the hook pipes to a file and then injects into the appropriate destination file).

Fixes #697

### How can we test changes

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

setup as per the steps to reproduce in #697 and run the hook.