### PR TITLE
fix(`terraform_docs`): Fix non-GNU `sed` issues, introduced in v1.93.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,8 +585,8 @@ Unlike most other hooks, this hook triggers once if there are any changed files 
       To migrate everything to `terraform-docs` insertion markers, run in repo root:
 
       ```bash
-      grep -rl 'BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK' . | xargs sed -i 's/BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK/BEGIN_TF_DOCS/g'
-      grep -rl 'END OF PRE-COMMIT-TERRAFORM DOCS HOOK' . | xargs sed -i 's/END OF PRE-COMMIT-TERRAFORM DOCS HOOK/END_TF_DOCS/g'
+      grep -rl 'BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK' . | xargs sed -i'' 's/BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK/BEGIN_TF_DOCS/g'
+      grep -rl 'END OF PRE-COMMIT-TERRAFORM DOCS HOOK' . | xargs sed -i'' 's/END OF PRE-COMMIT-TERRAFORM DOCS HOOK/END_TF_DOCS/g'
       ```
 
     ```yaml

--- a/README.md
+++ b/README.md
@@ -585,8 +585,8 @@ Unlike most other hooks, this hook triggers once if there are any changed files 
       To migrate everything to `terraform-docs` insertion markers, run in repo root:
 
       ```bash
-      grep -rl 'BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK' . | xargs sed -i'' 's/BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK/BEGIN_TF_DOCS/g'
-      grep -rl 'END OF PRE-COMMIT-TERRAFORM DOCS HOOK' . | xargs sed -i'' 's/END OF PRE-COMMIT-TERRAFORM DOCS HOOK/END_TF_DOCS/g'
+      grep -rl --null 'BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK' . | xargs -0 sed -i'' -e 's/BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK/BEGIN_TF_DOCS/'
+      grep -rl --null 'END OF PRE-COMMIT-TERRAFORM DOCS HOOK' . | xargs -0 sed -i'' -e 's/END OF PRE-COMMIT-TERRAFORM DOCS HOOK/END_TF_DOCS/'
       ```
 
     ```yaml

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -40,8 +40,8 @@ function main {
 function replace_old_markers {
   local -r file=$1
 
-  sed -i'' "s/^${old_insertion_marker_begin}$/${insertion_marker_begin}/" "$file"
-  sed -i''  "s/^${old_insertion_marker_end}$/${insertion_marker_end}/" "$file"
+  sed -i'' -e "s/^${old_insertion_marker_begin}$/${insertion_marker_begin}/" "$file"
+  sed -i'' -e "s/^${old_insertion_marker_end}$/${insertion_marker_end}/" "$file"
 }
 
 #######################################################################

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -40,8 +40,8 @@ function main {
 function replace_old_markers {
   local -r file=$1
 
-  sed -i "s/^${old_insertion_marker_begin}$/${insertion_marker_begin}/" "$file"
-  sed -i "s/^${old_insertion_marker_end}$/${insertion_marker_end}/" "$file"
+  sed -i'' "s/^${old_insertion_marker_begin}$/${insertion_marker_begin}/" "$file"
+  sed -i''  "s/^${old_insertion_marker_end}$/${insertion_marker_end}/" "$file"
 }
 
 #######################################################################


### PR DESCRIPTION
Ensure compatibility of `terraform_docs` hook on MacOS and Linux by using GNU sed.

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

In PR #701, the usage of `sed` was introduced to the `terraform_docs` for in-file changes, resulting in #703

MacOS requires an extension for the `-i` parameter, unlike GNU sed.
As a result the hook fails on MacOS know with the following error:

```shell
Terraform docs..........................................................................Failed
- hook id: terraform_docs
- exit code: 1

sed: 1: "README.md": invalid command code R
```

I see two potential solutions for this issue.

1) Always pass a extension to the `-i` parameter, as this is compatible with GNU sed, too. As a result, a backup file would be created for each sed commands operation and needs to be deleted again.

2) Ensure we always use GNU sed. GNU sed is available via brew and can easily be installed on MacOS systems. Using GNU sed on both MacOS and Linux ensures consistent behaviour across operating systems.

I'm happy to change it to option 1, but wanted to show both options I see to fix the issue. Also I'm not 100% sure about Windows support for this hooks, but it seems like ( #648 ) they only work on Linux and MacOS.