### PR TITLE
feat(`terraform-docs`): Add support for `replace` mode  for TF 0.12+; Use native saving to file for TF 0.12+. Both requires `terraform-docs` v0.12.0+ which released in 2021.

### DIFF
--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -200,6 +200,16 @@ function terraform_docs {
       text_file=$output_file
     fi
 
+    # Use `.terraform-docs.yml` `output.mode` if it set
+    local output_mode
+    output_mode=$(grep -A1000 -e '^output:$' "$config_file" | grep -E '^[[:space:]]+mode:' | tail -n 1) || true
+    if [[ $output_mode ]]; then
+      # Extract mode from `output.mode` line
+      output_mode=$(echo "$output_mode" | awk -F':' '{print $2}' | tr -d '[:space:]"' | tr -d "'")
+    else
+      output_mode="inject"
+    fi
+
     # Suppress terraform_docs color
     local config_file_no_color
     config_file_no_color="$config_file$(date +%s).yml"
@@ -265,7 +275,7 @@ function terraform_docs {
 
     if [[ "$terraform_docs_awk_file" == "0" ]]; then
       # shellcheck disable=SC2086
-      terraform-docs --output-mode inject $tf_docs_formatter $args --output-file="$text_file" ./ > /dev/null
+      terraform-docs --output-mode="$output_mode" --output-file="$text_file" $tf_docs_formatter $args ./ > /dev/null
     else
       # Can't append extension for mktemp, so renaming instead
       local tmp_file_docs

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -134,6 +134,7 @@ function terraform_docs {
   # Get hook settings
   #
   local text_file="README.md"
+  local output_mode="inject"
   local use_path_to_file=false
   local add_to_existing=false
   local create_if_not_exist=false
@@ -201,18 +202,12 @@ function terraform_docs {
     fi
 
     # Use `.terraform-docs.yml` `output.mode` if it set
-    local output_mode
-    output_mode=$(grep -A1000 -e '^output:$' "$config_file" | grep -E '^[[:space:]]+mode:' | tail -n 1) || true
-    echo "output_mode grep file: '$output_mode'"
-    if [[ $output_mode ]]; then
+    local config_output_mode
+    config_output_mode=$(grep -A1000 -e '^output:$' "$config_file" | grep -E '^[[:space:]]+mode:' | tail -n 1) || true
+    if [[ $config_output_mode ]]; then
       # Extract mode from `output.mode` line
-      output_mode=$(echo "$output_mode" | awk -F':' '{print $2}' | tr -d '[:space:]"' | tr -d "'")
-      echo "if output_mode file exist"
-    else
-      output_mode="inject"
-      echo "if output_mode defaults"
+      output_mode=$(echo "$config_output_mode" | awk -F':' '{print $2}' | tr -d '[:space:]"' | tr -d "'")
     fi
-    echo "output_mode after if: '$output_mode'"
 
     # Suppress terraform_docs color
     local config_file_no_color

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -265,7 +265,7 @@ function terraform_docs {
 
     if [[ "$terraform_docs_awk_file" == "0" ]]; then
       # shellcheck disable=SC2086
-      terraform-docs --output-mode inject $tf_docs_formatter $args --output-file="$text_file" ./
+      terraform-docs --output-mode inject $tf_docs_formatter $args --output-file="$text_file" ./ > /dev/null
     else
       # Can't append extension for mktemp, so renaming instead
       local tmp_file_docs

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -203,12 +203,16 @@ function terraform_docs {
     # Use `.terraform-docs.yml` `output.mode` if it set
     local output_mode
     output_mode=$(grep -A1000 -e '^output:$' "$config_file" | grep -E '^[[:space:]]+mode:' | tail -n 1) || true
+    echo "output_mode grep file: '$output_mode'"
     if [[ $output_mode ]]; then
       # Extract mode from `output.mode` line
       output_mode=$(echo "$output_mode" | awk -F':' '{print $2}' | tr -d '[:space:]"' | tr -d "'")
+      echo "if output_mode file exist"
     else
       output_mode="inject"
+      echo "if output_mode defaults"
     fi
+    echo "output_mode after if: '$output_mode'"
 
     # Suppress terraform_docs color
     local config_file_no_color


### PR DESCRIPTION
> [!IMPORTANT]
> Should be merged after #706

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [x] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123456":
-->

Closes #179 

### How can we test changes
`.terraform-docs.yml`:
```yaml
formatter: "md"
output:
  mode: replace
  template: |-
        {{ .Content }}
```

`.pre-commit-config.yaml`:
```yaml
repos:
  - repo: https://github.com/antonbabenko/pre-commit-terraform
    rev: ece0c17b91c17b29201aba379f99e79f59813438
    hooks:
      - id: terraform_docs
        args:
          - --args=--config=.terraform-docs.yml
          ## Also CLI options have precedence over YAML config
          ##  that's default behavior of major chunk of tools, so we just preserve it.
          #- --args=--output-mode=inject
