### PR TITLE
fix(`terraform_docs`): Fix non-GNU sed issues, introduced in v1.93.0, as previous fix doesn't work correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,7 +599,7 @@ Unlike most other hooks, this hook triggers once if there are any changed files 
         - --hook-config=--use-standard-markers=true     # Boolean. Defaults to true (v1.93+), false (<v1.93). Set to true for compatibility with terraform-docs
     ```
 
-1. You can provide [any configuration available in `terraform-docs`](https://terraform-docs.io/user-guide/configuration/) as an argument to `terraform_doc` hook, for example:
+4. You can provide [any configuration available in `terraform-docs`](https://terraform-docs.io/user-guide/configuration/) as an argument to `terraform_doc` hook, for example:
 
     ```yaml
     - id: terraform_docs
@@ -610,7 +610,7 @@ Unlike most other hooks, this hook triggers once if there are any changed files 
     > **Warning**  
     > Avoid use `recursive.enabled: true` in config file, that can cause unexpected behavior.
 
-2. If you need some exotic settings, it can be done too. I.e. this one generates HCL files:
+5. If you need some exotic settings, it can be done too. I.e. this one generates HCL files:
 
     ```yaml
     - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -585,7 +585,7 @@ Unlike most other hooks, this hook triggers once if there are any changed files 
       To migrate everything to `terraform-docs` insertion markers, run in repo root:
 
       ```bash
-      if sed --version > /dev/null 2>&1; then SED_CMD=(sed -i''); else SED_CMD=(sed -i ''); fi
+      sed --version &> /dev/null && SED_CMD=(sed -i) || SED_CMD=(sed -i '')
       grep -rl --null 'BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK' . | xargs -0 "${SED_CMD[@]}" -e 's/BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK/BEGIN_TF_DOCS/'
       grep -rl --null 'END OF PRE-COMMIT-TERRAFORM DOCS HOOK' . | xargs -0 "${SED_CMD[@]}" -e 's/END OF PRE-COMMIT-TERRAFORM DOCS HOOK/END_TF_DOCS/'
       ```

--- a/README.md
+++ b/README.md
@@ -585,8 +585,9 @@ Unlike most other hooks, this hook triggers once if there are any changed files 
       To migrate everything to `terraform-docs` insertion markers, run in repo root:
 
       ```bash
-      grep -rl --null 'BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK' . | xargs -0 sed -i='' -e 's/BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK/BEGIN_TF_DOCS/'
-      grep -rl --null 'END OF PRE-COMMIT-TERRAFORM DOCS HOOK' . | xargs -0 sed -i='' -e 's/END OF PRE-COMMIT-TERRAFORM DOCS HOOK/END_TF_DOCS/'
+      SED_CMD=$(sed --version > /dev/null 2>&1 && echo "sed -i''" || echo "sed -i ''")
+      grep -rl --null 'BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK' . | xargs -0 $SED_CMD -e 's/BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK/BEGIN_TF_DOCS/'
+      grep -rl --null 'END OF PRE-COMMIT-TERRAFORM DOCS HOOK' . | xargs -0 $SED_CMD -e 's/END OF PRE-COMMIT-TERRAFORM DOCS HOOK/END_TF_DOCS/'
       ```
 
     ```yaml
@@ -598,7 +599,7 @@ Unlike most other hooks, this hook triggers once if there are any changed files 
         - --hook-config=--use-standard-markers=true     # Boolean. Defaults to true (v1.93+), false (<v1.93). Set to true for compatibility with terraform-docs
     ```
 
-4. You can provide [any configuration available in `terraform-docs`](https://terraform-docs.io/user-guide/configuration/) as an argument to `terraform_doc` hook, for example:
+1. You can provide [any configuration available in `terraform-docs`](https://terraform-docs.io/user-guide/configuration/) as an argument to `terraform_doc` hook, for example:
 
     ```yaml
     - id: terraform_docs
@@ -609,7 +610,7 @@ Unlike most other hooks, this hook triggers once if there are any changed files 
     > **Warning**  
     > Avoid use `recursive.enabled: true` in config file, that can cause unexpected behavior.
 
-5. If you need some exotic settings, it can be done too. I.e. this one generates HCL files:
+2. If you need some exotic settings, it can be done too. I.e. this one generates HCL files:
 
     ```yaml
     - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -585,9 +585,9 @@ Unlike most other hooks, this hook triggers once if there are any changed files 
       To migrate everything to `terraform-docs` insertion markers, run in repo root:
 
       ```bash
-      SED_CMD=$(sed --version > /dev/null 2>&1 && echo "sed -i''" || echo "sed -i ''")
-      grep -rl --null 'BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK' . | xargs -0 $SED_CMD -e 's/BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK/BEGIN_TF_DOCS/'
-      grep -rl --null 'END OF PRE-COMMIT-TERRAFORM DOCS HOOK' . | xargs -0 $SED_CMD -e 's/END OF PRE-COMMIT-TERRAFORM DOCS HOOK/END_TF_DOCS/'
+      if sed --version > /dev/null 2>&1; then SED_CMD=(sed -i''); else SED_CMD=(sed -i ''); fi
+      grep -rl --null 'BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK' . | xargs -0 ${SED_CMD[@]} -e 's/BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK/BEGIN_TF_DOCS/'
+      grep -rl --null 'END OF PRE-COMMIT-TERRAFORM DOCS HOOK' . | xargs -0 ${SED_CMD[@]} -e 's/END OF PRE-COMMIT-TERRAFORM DOCS HOOK/END_TF_DOCS/'
       ```
 
     ```yaml

--- a/README.md
+++ b/README.md
@@ -585,8 +585,8 @@ Unlike most other hooks, this hook triggers once if there are any changed files 
       To migrate everything to `terraform-docs` insertion markers, run in repo root:
 
       ```bash
-      grep -rl --null 'BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK' . | xargs -0 sed -i'' -e 's/BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK/BEGIN_TF_DOCS/'
-      grep -rl --null 'END OF PRE-COMMIT-TERRAFORM DOCS HOOK' . | xargs -0 sed -i'' -e 's/END OF PRE-COMMIT-TERRAFORM DOCS HOOK/END_TF_DOCS/'
+      grep -rl --null 'BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK' . | xargs -0 sed -i='' -e 's/BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK/BEGIN_TF_DOCS/'
+      grep -rl --null 'END OF PRE-COMMIT-TERRAFORM DOCS HOOK' . | xargs -0 sed -i='' -e 's/END OF PRE-COMMIT-TERRAFORM DOCS HOOK/END_TF_DOCS/'
       ```
 
     ```yaml

--- a/README.md
+++ b/README.md
@@ -586,8 +586,8 @@ Unlike most other hooks, this hook triggers once if there are any changed files 
 
       ```bash
       if sed --version > /dev/null 2>&1; then SED_CMD=(sed -i''); else SED_CMD=(sed -i ''); fi
-      grep -rl --null 'BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK' . | xargs -0 ${SED_CMD[@]} -e 's/BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK/BEGIN_TF_DOCS/'
-      grep -rl --null 'END OF PRE-COMMIT-TERRAFORM DOCS HOOK' . | xargs -0 ${SED_CMD[@]} -e 's/END OF PRE-COMMIT-TERRAFORM DOCS HOOK/END_TF_DOCS/'
+      grep -rl --null 'BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK' . | xargs -0 "${SED_CMD[@]}" -e 's/BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK/BEGIN_TF_DOCS/'
+      grep -rl --null 'END OF PRE-COMMIT-TERRAFORM DOCS HOOK' . | xargs -0 "${SED_CMD[@]}" -e 's/END OF PRE-COMMIT-TERRAFORM DOCS HOOK/END_TF_DOCS/'
       ```
 
     ```yaml

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -41,11 +41,7 @@ function replace_old_markers {
   local -r file=$1
 
   # Determine the appropriate sed command based on the operating system (GNU sed or BSD sed)
-  if sed --version > /dev/null 2>&1; then
-    SED_CMD=(sed -i'')
-  else
-    SED_CMD=(sed -i '')
-  fi
+  sed --version &> /dev/null && SED_CMD=(sed -i) || SED_CMD=(sed -i '')
   "${SED_CMD[@]}" -e "s/^${old_insertion_marker_begin}$/${insertion_marker_begin}/" "$file"
   "${SED_CMD[@]}" -e "s/^${old_insertion_marker_end}$/${insertion_marker_end}/" "$file"
 }

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -46,10 +46,8 @@ function replace_old_markers {
   else
     SED_CMD=(sed -i '')
   fi
-  # shellcheck disable=SC2068
-  ${SED_CMD[@]} -e "s/^${old_insertion_marker_begin}$/${insertion_marker_begin}/" "$file"
-  # shellcheck disable=SC2068
-  ${SED_CMD[@]} -e "s/^${old_insertion_marker_end}$/${insertion_marker_end}/" "$file"
+  "${SED_CMD[@]}" -e "s/^${old_insertion_marker_begin}$/${insertion_marker_begin}/" "$file"
+  "${SED_CMD[@]}" -e "s/^${old_insertion_marker_end}$/${insertion_marker_end}/" "$file"
 }
 
 #######################################################################

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -42,15 +42,14 @@ function replace_old_markers {
 
   # Determine the appropriate sed command based on the operating system (GNU sed or BSD sed)
   if sed --version > /dev/null 2>&1; then
-    SED_CMD="sed -i''"
+    SED_CMD=(sed -i'')
   else
-    # shellcheck disable=SC2089
-    SED_CMD="sed -i ''"
+    SED_CMD=(sed -i '')
   fi
-  # shellcheck disable=SC2090
-  $SED_CMD -e "s/^${old_insertion_marker_begin}$/${insertion_marker_begin}/" "$file"
-  # shellcheck disable=SC2090
-  $SED_CMD -e "s/^${old_insertion_marker_end}$/${insertion_marker_end}/" "$file"
+  # shellcheck disable=SC2068
+  ${SED_CMD[@]} -e "s/^${old_insertion_marker_begin}$/${insertion_marker_begin}/" "$file"
+  # shellcheck disable=SC2068
+  ${SED_CMD[@]} -e "s/^${old_insertion_marker_end}$/${insertion_marker_end}/" "$file"
 }
 
 #######################################################################

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -40,8 +40,8 @@ function main {
 function replace_old_markers {
   local -r file=$1
 
-  sed -i'' -e "s/^${old_insertion_marker_begin}$/${insertion_marker_begin}/" "$file"
-  sed -i'' -e "s/^${old_insertion_marker_end}$/${insertion_marker_end}/" "$file"
+  sed -i='' -e "s/^${old_insertion_marker_begin}$/${insertion_marker_begin}/" "$file"
+  sed -i='' -e "s/^${old_insertion_marker_end}$/${insertion_marker_end}/" "$file"
 }
 
 #######################################################################

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -41,8 +41,15 @@ function replace_old_markers {
   local -r file=$1
 
   # Determine the appropriate sed command based on the operating system (GNU sed or BSD sed)
-  SED_CMD=$(sed --version > /dev/null 2>&1 && echo "sed -i''" || echo "sed -i ''")
+  if sed --version > /dev/null 2>&1; then
+    SED_CMD="sed -i''"
+  else
+    # shellcheck disable=SC2089
+    SED_CMD="sed -i ''"
+  fi
+  # shellcheck disable=SC2090
   $SED_CMD -e "s/^${old_insertion_marker_begin}$/${insertion_marker_begin}/" "$file"
+  # shellcheck disable=SC2090
   $SED_CMD -e "s/^${old_insertion_marker_end}$/${insertion_marker_end}/" "$file"
 }
 

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -40,8 +40,10 @@ function main {
 function replace_old_markers {
   local -r file=$1
 
-  sed -i='' -e "s/^${old_insertion_marker_begin}$/${insertion_marker_begin}/" "$file"
-  sed -i='' -e "s/^${old_insertion_marker_end}$/${insertion_marker_end}/" "$file"
+  # Determine the appropriate sed command based on the operating system (GNU sed or BSD sed)
+  SED_CMD=$(sed --version > /dev/null 2>&1 && echo "sed -i''" || echo "sed -i ''")
+  $SED_CMD -e "s/^${old_insertion_marker_begin}$/${insertion_marker_begin}/" "$file"
+  $SED_CMD -e "s/^${old_insertion_marker_end}$/${insertion_marker_end}/" "$file"
 }
 
 #######################################################################


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

Fixes #707

### How can we test changes

```yaml
repos:
  - repo: https://github.com/antonbabenko/pre-commit-terraform
    rev: 70670818f5d14ba13c268dd366ecfa8374e88f42
    hooks:
      - id: terraform_docs
``` 
