### PR TITLE
fix(`terraform_docs`): Restore `--hook-config=--add-to-existing-file` default behavior. Regression from 1.94.0.

### DIFF
--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -264,11 +264,11 @@ function terraform_docs {
       #? TF 0.12+ and terraform-docs 0.12.0+
 
       #
-      # If `--add-to-existing-file=false` (default behavior), check is in file exist "hook markers",
-      # and if not skip execution to avoid addition of terraform-docs section -
-      # terraform-docs in 'inject' mode adds markers by default if they not present
+      # If `--add-to-existing-file=false` (default behavior), check if "hook markers" exist in file,
+      # and, if not, skip execution to avoid addition of terraform-docs section, as
+      # terraform-docs in 'inject' mode adds markers by default if they are not present
       #
-      if ! $add_to_existing; then
+      if [[ $add_to_existing == false ]]; then
         HAVE_MARKER=$(grep -o "$insertion_marker_begin" "$output_file" || exit 0)
         [[ ! $HAVE_MARKER ]] && continue
       fi
@@ -278,18 +278,18 @@ function terraform_docs {
     else
       #? TF 0.12+ and terraform-docs < 0.8
       #? Yes, we don't cover case of TF 0.12+ and terraform-docs 0.8-0.11
-      #? but I portably just drop this section in next release of the hook,
-      #? as there no sense to support hacks for tool versions which was released more than 3 years ago
+      #? but I probably just drop this section in next release of the hook,
+      #? as there's no sense to support hacks for tool versions which were released more than 3 years ago
 
       #
-      # If `--add-to-existing-file=true` set, check is in file exist "hook markers",
-      # and if not - append "hook markers" to the end of file.
+      # If `--add-to-existing-file=true` set, check if "hook markers" exist in file,
+      # and, if not, append "hook markers" to the end of the file.
       #
-      if $add_to_existing; then
+      if [[ $add_to_existing == true ]]; then
         HAVE_MARKER=$(grep -o "$insertion_marker_begin" "$output_file" || exit 0)
 
-        if [ ! "$HAVE_MARKER" ]; then
-          # Use of insertion markers, where addToExisting=true, with no markers in the existing file
+        if [[ ! $HAVE_MARKER ]]; then
+          # Use of insertion markers, when "add_to_existing=true" with no markers in the existing file
           echo "$insertion_marker_begin" >> "$output_file"
           echo "$insertion_marker_end" >> "$output_file"
         fi

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -264,17 +264,13 @@ function terraform_docs {
       #? TF 0.12+ and terraform-docs 0.12.0+
 
       #
-      # If `--add-to-existing-file=true` set, check is in file exist "hook markers",
-      # and if not - append "hook markers" to the end of file.
+      # If `--add-to-existing-file=false` (default behavior), check is in file exist "hook markers",
+      # and if not skip execution to avoid addition of terraform-docs section -
+      # terraform-docs in 'inject' mode adds markers by default if they not present
       #
-      if $add_to_existing; then
+      if ! $add_to_existing; then
         HAVE_MARKER=$(grep -o "$insertion_marker_begin" "$output_file" || exit 0)
-
-        if [ ! "$HAVE_MARKER" ]; then
-          # terraform-docs in 'inject; mode adds markers by default if they not present.
-          # So, we need need just skip execution to skip addition of terraform-docs section
-          continue
-        fi
+        [[ ! $HAVE_MARKER ]] && continue
       fi
       # shellcheck disable=SC2086
       terraform-docs --output-mode="$output_mode" --output-file="$output_file" $tf_docs_formatter $args ./ > /dev/null
@@ -285,6 +281,10 @@ function terraform_docs {
       #? but I portably just drop this section in next release of the hook,
       #? as there no sense to support hacks for tool versions which was released more than 3 years ago
 
+      #
+      # If `--add-to-existing-file=true` set, check is in file exist "hook markers",
+      # and if not - append "hook markers" to the end of file.
+      #
       if $add_to_existing; then
         HAVE_MARKER=$(grep -o "$insertion_marker_begin" "$output_file" || exit 0)
 

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -269,8 +269,8 @@ function terraform_docs {
       # terraform-docs in 'inject' mode adds markers by default if they are not present
       #
       if [[ $add_to_existing == false ]]; then
-        HAVE_MARKER=$(grep -o "$insertion_marker_begin" "$output_file") || true
-        [[ ! $HAVE_MARKER ]] && continue
+        have_marker=$(grep -o "$insertion_marker_begin" "$output_file") || unset have_marker
+        [[ ! $have_marker ]] && continue
       fi
       # shellcheck disable=SC2086
       terraform-docs --output-mode="$output_mode" --output-file="$output_file" $tf_docs_formatter $args ./ > /dev/null
@@ -286,9 +286,9 @@ function terraform_docs {
       # and, if not, append "hook markers" to the end of the file.
       #
       if [[ $add_to_existing == true ]]; then
-        HAVE_MARKER=$(grep -o "$insertion_marker_begin" "$output_file") || true
+        have_marker=$(grep -o "$insertion_marker_begin" "$output_file") || unset have_marker
 
-        if [[ ! $HAVE_MARKER ]]; then
+        if [[ ! $have_marker ]]; then
           # Use of insertion markers, when "add_to_existing=true" with no markers in the existing file
           echo "$insertion_marker_begin" >> "$output_file"
           echo "$insertion_marker_end" >> "$output_file"

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -260,24 +260,40 @@ function terraform_docs {
 
     replace_old_markers "$output_file"
 
-    #
-    # If `--add-to-existing-file=true` set, check is in file exist "hook markers",
-    # and if not - append "hook markers" to the end of file.
-    #
-    if $add_to_existing; then
-      HAVE_MARKER=$(grep -o "$insertion_marker_begin" "$output_file" || exit 0)
-
-      if [ ! "$HAVE_MARKER" ]; then
-        # Use of insertion markers, where addToExisting=true, with no markers in the existing file
-        echo "$insertion_marker_begin" >> "$output_file"
-        echo "$insertion_marker_end" >> "$output_file"
-      fi
-    fi
-
     if [[ "$terraform_docs_awk_file" == "0" ]]; then
+      #? TF 0.12+ and terraform-docs 0.12.0+
+
+      #
+      # If `--add-to-existing-file=true` set, check is in file exist "hook markers",
+      # and if not - append "hook markers" to the end of file.
+      #
+      if $add_to_existing; then
+        HAVE_MARKER=$(grep -o "$insertion_marker_begin" "$output_file" || exit 0)
+
+        if [ ! "$HAVE_MARKER" ]; then
+          # terraform-docs in 'inject; mode adds markers by default if they not present.
+          # So, we need need just skip execution to skip addition of terraform-docs section
+          continue
+        fi
+      fi
       # shellcheck disable=SC2086
       terraform-docs --output-mode="$output_mode" --output-file="$output_file" $tf_docs_formatter $args ./ > /dev/null
+
     else
+      #? TF 0.12+ and terraform-docs < 0.8
+      #? Yes, we don't cover case of TF 0.12+ and terraform-docs 0.8-0.11
+      #? but I portably just drop this section in next release of the hook,
+      #? as there no sense to support hacks for tool versions which was released more than 3 years ago
+
+      if $add_to_existing; then
+        HAVE_MARKER=$(grep -o "$insertion_marker_begin" "$output_file" || exit 0)
+
+        if [ ! "$HAVE_MARKER" ]; then
+          # Use of insertion markers, where addToExisting=true, with no markers in the existing file
+          echo "$insertion_marker_begin" >> "$output_file"
+          echo "$insertion_marker_end" >> "$output_file"
+        fi
+      fi
       # Can't append extension for mktemp, so renaming instead
       local tmp_file_docs
       tmp_file_docs=$(mktemp "${TMPDIR:-/tmp}/terraform-docs-XXXXXXXXXX")

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -269,7 +269,7 @@ function terraform_docs {
       # terraform-docs in 'inject' mode adds markers by default if they are not present
       #
       if [[ $add_to_existing == false ]]; then
-        HAVE_MARKER=$(grep -o "$insertion_marker_begin" "$output_file" || exit 0)
+        HAVE_MARKER=$(grep -o "$insertion_marker_begin" "$output_file") || true
         [[ ! $HAVE_MARKER ]] && continue
       fi
       # shellcheck disable=SC2086
@@ -286,7 +286,7 @@ function terraform_docs {
       # and, if not, append "hook markers" to the end of the file.
       #
       if [[ $add_to_existing == true ]]; then
-        HAVE_MARKER=$(grep -o "$insertion_marker_begin" "$output_file" || exit 0)
+        HAVE_MARKER=$(grep -o "$insertion_marker_begin" "$output_file") || true
 
         if [[ ! $HAVE_MARKER ]]; then
           # Use of insertion markers, when "add_to_existing=true" with no markers in the existing file


### PR DESCRIPTION
Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

Fixes #715

### How can we test changes

broken:
```
testdir=$(mktemp -d)
cd $testdir
touch main.tf README.md
echo "
repos:
  - repo: https://github.com/antonbabenko/pre-commit-terraform
    rev: v1.94.2 # issue introduced in 1.94.0
    hooks:
      - id: terraform_docs
" > .pre-commit-config.yaml
git init
git add -A
pre-commit run
```
fixed:

```bash
testdir=$(mktemp -d)
cd $testdir
touch main.tf README.md
echo "
repos:
  - repo: https://github.com/antonbabenko/pre-commit-terraform
    rev: c0b1f38bae3b34f3f223bc73a8b384e2e7a766d7
    hooks:
      - id: terraform_docs
" > .pre-commit-config.yaml
git init
git add -A
pre-commit run
```

```bash
testdir=$(mktemp -d)
cd $testdir
touch main.tf README.md
echo "
repos:
  - repo: https://github.com/antonbabenko/pre-commit-terraform
    rev: c0b1f38bae3b34f3f223bc73a8b384e2e7a766d7
    hooks:
      - id: terraform_docs
        args:
        - --hook-config=--add-to-existing-file=true
" > .pre-commit-config.yaml
git init
git add -A
pre-commit run
```