### PR TITLE
feat: Expand environment variables in `--args=` which contains lowercase symbols, like `${TF_VAR_lowercase}` 

### DIFF
--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -128,7 +128,7 @@ function common::parse_and_export_env_vars {
     while true; do
       # Check if at least 1 env var exists in `$arg`
       # shellcheck disable=SC2016 # '${' should not be expanded
-      if [[ "$arg" =~ '${'[A-Z_][A-Z0-9_]*'}' ]]; then
+      if [[ "$arg" =~ '${'[A-Z_][A-Za-z0-9_]*'}' ]]; then
         # Get `ENV_VAR` from `.*${ENV_VAR}.*`
         local env_var_name=${arg#*$\{}
         env_var_name=${env_var_name%%\}*}


### PR DESCRIPTION
Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [x] This PR enhances existing functionality.

### Description of your changes
Improves https://github.com/antonbabenko/pre-commit-terraform?tab=readme-ov-file#all-hooks-usage-of-environment-variables-in---args
Found in https://github.com/antonbabenko/pre-commit-terraform/issues/718#issuecomment-2347102202

Support of [this option](https://developer.hashicorp.com/terraform/language/values/variables#environment-variables) probably will not be needed in any observed use cases, but it is cheap to implement, so here we are