### PR TITLE
fix(`terraform_docs`): Fix issue with processing multiply files without `terraform-docs` markers. Issue introduced in v1.95.0

### DIFF
--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -213,7 +213,7 @@ function terraform_docs {
     #
     if [[ $add_to_existing == false ]]; then
       have_marker=$(grep -o "$insertion_marker_begin" "$output_file") || unset have_marker
-      [[ ! $have_marker ]] && continue
+      [[ ! $have_marker ]] && popd > /dev/null && continue
     fi
     # shellcheck disable=SC2086
     terraform-docs --output-mode="$output_mode" --output-file="$output_file" $tf_docs_formatter $args ./ > /dev/null


### PR DESCRIPTION




<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

A bug in the terraform-docs hook was introduced in #717.  [In that PR, a `continue` statement was added that is not preceded by a `popd` command](https://github.com/antonbabenko/pre-commit-terraform/blob/869a106a4c8c48f34f58318a830436142e31e10a/hooks/terraform_docs.sh#L216).  The bug is only triggered when the hook is processing multiple files where one (or more) of the files does not contain the terraform-docs marker statements.  The hook fails to process the remaining files because the working directory is not reset to the root of the repository.  I ran into this bug on version 1.96.0 of the hooks and pre-commit version 3.8.0. 

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123456":
-->

<!-- Fixes # -->

### How can we test changes

Here is a script to reproduce the issue.  It creates a repository containing multiple modules.  The `pre-commit run -a` command will print an error similar to `~/.cache/pre-commit/reporqzucglw/hooks/terraform_docs.sh: line 178: pushd: modules/c: No such file or directory` and module C's README won't be updated by terraform-docs.

```shell

cat <<EOF> .pre-commit-config.yaml
---
repos:
  - repo: https://github.com/antonbabenko/pre-commit-terraform
    rev: v1.96.0
    hooks:
      - id: terraform_docs
        files: '.*'
        verbose: true
        types_or:
          - markdown
          - terraform
EOF

git init
pre-commit install --install-hooks
mkdir -p modules/{a,b,c}

cat <<EOF> modules/a/README.md
# I'm module A

<!-- BEGIN_TF_DOCS -->
<!-- END_TF_DOCS -->

EOF

cat <<EOF> modules/b/README.md
# I'm module B

I break things

EOF

cat <<EOF> modules/c/README.md
# I'm module C

<!-- BEGIN_TF_DOCS -->
<!-- END_TF_DOCS -->

EOF

git add .
pre-commit run -a

```
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
