### PR TITLE
fix(`terraform_docs`): Restore multiply `--hook-config` args support. Regression from v1.95.0

### DIFF
--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -93,7 +93,10 @@ function terraform_docs {
   for c in "${configs[@]}"; do
 
     IFS="=" read -r -a config <<< "$c"
-    key=${config[0]}
+    # $hook_config receives string like '--foo=bar; --baz=4;' etc.
+    # It gets split by `;` into array, which we're parsing here ('--foo=bar' ' --baz=4')
+    # Next line removes leading spaces, to support >1 `--hook-config` args
+    key="${config[0]## }"
     value=${config[1]}
 
     case $key in


### PR DESCRIPTION
Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

We actually faced this issue in before [here](https://github.com/antonbabenko/pre-commit-terraform/pull/620/files#diff-a9db869be8201236cd6abaed19087fc571d29c10d679fc66bf945eba1a4ccd46R297-R300), but it was eliminated before it merged to `master` branch 

Because of how our parsing works, we get these empty spaces as "beginning of key name", and  because `" foo" != "foo"`, all hook-configs except first parsed effectively ignored. This PR removes that extra space.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123456":
-->

Fixes #721 
### How can we test changes

```yaml
repos:
  - repo: https://github.com/antonbabenko/pre-commit-terraform
    rev: 819893c726df778321faf4772ae429b186887a48
    hooks:
      - id: terraform_docs
        args:
          - --hook-config=--add-to-existing-file=true
          - --hook-config=--create-file-if-not-exist=true
```