### PR TITLE
ci: Disable checks unrunable @ pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,3 @@
----
-
 ci:
   autoupdate_schedule: quarterly
   skip:
@@ -68,5 +66,3 @@ repos:
   - id: prettier
     # https://prettier.io/docs/en/options.html#parser
     files: '.json5$'
-
-...

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,12 @@
+---
+
+ci:
+  autoupdate_schedule: quarterly
+  skip:
+    - shfmt
+    - shellcheck
+    - hadolint
+
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v5.0.0
@@ -59,3 +68,5 @@ repos:
   - id: prettier
     # https://prettier.io/docs/en/options.html#parser
     files: '.json5$'
+
+...


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.
- [x] This is a contributor/maintainer facing change that in no way affects the end-users

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123456":
-->
Enabling faster feedback loop for new contributors by enabling https://pre-commit.ci in this repo. 

The only visible effect of this is when said app is installed and the service is running the checks, it would skip the checks that rely on the external executables that might be missing in runtime. It's necessary since that testing environment is controlled by someone else.

<!-- Fixes # -->

### How can we test changes

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
@antonbabenko  go to https://github.com/apps/pre-commit-ci/installations/select_target, install the app into this repo and then merge the PR.