### PR TITLE
chore(packaging): Fix computing SCM-based version @ the dists

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -10,3 +10,10 @@ exclude = [
 packages = [
   'hooks/',
 ]
+
+[metadata.hooks.vcs.urls]
+'Source Archive' = 'https://github.com/antonbabenko/pre-commit-terraform/archive/{commit_hash}.tar.gz'
+'GitHub: repo' = 'https://github.com/antonbabenko/pre-commit-terraform'
+
+[version]
+source = 'vcs'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,12 @@
 [build-system]
 requires = [
   'hatchling',
+  'hatch-vcs',  # setuptools-scm
 ]
 build-backend = 'hatchling.build'
 
 [project]
 name = 'pre-commit-terraform'
-version = '0.0.0'
-# version_format = '{tag}+{gitsha}'
 classifiers = [
   'License :: OSI Approved :: MIT License',
   'Programming Language :: Python :: 2',
@@ -19,16 +18,15 @@ classifiers = [
   'Programming Language :: Python :: Implementation :: PyPy',
 ]
 description = 'Pre-commit hooks for terraform_docs_replace'
-dependencies = [
-  'setuptools-git-version',
+dependencies = []
+dynamic = [
+  'urls',
+  'version',
 ]
 
 [[project.authors]]
 name = 'Contributors'  # FIXME
 # email = 'степан@криївка.укр'
-
-[project.urls]
-'GitHub: repo' = 'https://github.com/antonbabenko/pre-commit-terraform'
 
 [project.readme]
 file = 'README.md'


### PR DESCRIPTION
The previously existing attempt to use `setuptools-git-version` never worked as it wasn't integrated correctly — it was added as a runtime dependency while it's meant to be a build dependency. This resulted in 0.0.0 being used all the time.

This patch adds a hatchling plugin that implements the original idea in a way that actually works.

<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123456":
-->
$sbj.
<!-- Fixes # -->

### How can we test changes

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
`python -Im build`