### PR TITLE
chore(packaging): Enable support for versioning Git archives

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,3 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true)$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst

--- a/hatch.toml
+++ b/hatch.toml
@@ -14,7 +14,9 @@ packages = [
 ]
 
 [metadata.hooks.vcs.urls]
-'Source Archive' = 'https://github.com/antonbabenko/pre-commit-terraform/archive/{commit_hash}.tar.gz'
+# FIXME: Uncomment 'Source Archive' as soon as
+# FIXME: https://github.com/ofek/hatch-vcs/issues/80 is fixed.
+# 'Source Archive' = 'https://github.com/antonbabenko/pre-commit-terraform/archive/{commit_hash}.tar.gz'
 'GitHub: repo' = 'https://github.com/antonbabenko/pre-commit-terraform'
 
 [version]


### PR DESCRIPTION
It's a follow-up to #735 that lacks this property. It's also an internal change.

It essentially allows one to
```
$ pip install https://github.com/antonbabenko/pre-commit-terraform/archive/a7155a7.tar.gz
```
and get a correctly computed version in the installed metadata.

[1]: https://setuptools-scm.rtfd.io/en/latest/usage/#git-archives

<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.
- [x] This PR is an internal change that the end-users won't notice.

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123456":
-->
See above.
<!-- Fixes # -->

### How can we test changes

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
```
$ pip install https://github.com/antonbabenko/pre-commit-terraform/archive/a7155a7.tar.gz
```