### PR TITLE
chore(refactoring): Introduce a Python CLI app layout

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -37,7 +37,7 @@
   name: Terraform docs (overwrite README.md)
   description: Overwrite content of README.md with terraform-docs.
   require_serial: true
-  entry: terraform_docs_replace
+  entry: python -Im pre_commit_terraform replace-docs
   language: python
   files: (\.tf)$
   exclude: \.terraform/.*$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,3 @@ email = 'yz@yz.kiev.ua'
 [project.readme]
 file = 'README.md'
 content-type = 'text/markdown'
-
-[project.scripts]
-terraform_docs_replace = 'pre_commit_terraform.terraform_docs_replace:main'

--- a/src/pre_commit_terraform/README.md
+++ b/src/pre_commit_terraform/README.md
@@ -7,13 +7,13 @@ that ends up being installed into `site-packages/` of virtualenvs.
 
 When the Git repository is `pip install`ed, this [import package] becomes
 available for use within respective Python interpreter instance. It can be
-imported and sub-modules can be imported through the dot-syntax.
-Additionally, the modules within are able to import the neighboring ones
-using relative imports that have a leading dot in them.
+imported and sub-modules can be imported through the dot-syntax. Additionally,
+the modules within can import the neighboring ones using relative imports that
+have a leading dot in them.
 
 It additionally implements a [runpy interface], meaning that its name can
-be passed to `python -m` in order to invoke the CLI. This is the primary method
-of integration with the [`pre-commit` framework] and local development/testing.
+be passed to `python -m` to invoke the CLI. This is the primary method of
+integration with the [`pre-commit` framework] and local development/testing.
 
 The layout allows for having several Python modules wrapping third-party tools,
 each having an argument parser and being a subcommand for the main CLI
@@ -32,12 +32,11 @@ subcommand modules.
 2. Within that module, define two functions —
    `invoke_cli_app(parsed_cli_args: Namespace) -> ReturnCodeType | int` and
    `populate_argument_parser(subcommand_parser: ArgumentParser) -> None`.
-3. Edit [`_cli_parsing.py`], importing `populate_argument_parser` from
-   `subcommand_x` and adding it into `PARSER_MAP` with `subcommand-x` as
-   a key.
-5. Edit [`_cli_subcommands.py`] `invoke_cli_app` from `subcommand_x` and
-   adding it into `SUBCOMMAND_MAP` with `subcommand-x` as a key.
-6. Edit [`.pre-commit-hooks.yaml`], adding a new hook that invokes
+   Additionally, define a module-level constant
+   `CLI_SUBCOMMAND_NAME: Final[str] = 'subcommand-x'`.
+3. Edit [`_cli_subcommands.py`], importing `subcommand_x` as a relative module
+   and add it into the `SUBCOMMAND_MODULES` list.
+4. Edit [`.pre-commit-hooks.yaml`], adding a new hook that invokes
    `python -m pre_commit_terraform subcommand-x`.
 
 ## Manual testing
@@ -53,7 +52,7 @@ POSIX-inspired CLI app.
 
 ## DX/UX considerations
 
-Since it's an app that can be executed outside of the [`pre-commit` framework],
+Since it's an app that can be executed outside the [`pre-commit` framework],
 it is useful to check out and follow these [CLI guidelines][clig].
 
 [`.pre-commit-hooks.yaml`]: ../../.pre-commit-hooks.yaml

--- a/src/pre_commit_terraform/README.md
+++ b/src/pre_commit_terraform/README.md
@@ -55,9 +55,37 @@ POSIX-inspired CLI app.
 Since it's an app that can be executed outside the [`pre-commit` framework],
 it is useful to check out and follow these [CLI guidelines][clig].
 
+## Subcommand development
+
+`populate_argument_parser()` accepts a regular instance of
+[`argparse.ArgumentParser`]. Call its methods to extend the CLI arguments that
+would be specific for the subcommand you are creating. Those arguments will be
+available later, as an argument to the `invoke_cli_app()` function — through an
+instance of [`argparse.Namespace`]. For the `CLI_SUBCOMMAND_NAME` constant,
+choose `kebab-space-sub-command-style`, it does not need to be `snake_case`.
+
+Make sure to return a `ReturnCode` instance or an integer from
+`invoke_cli_app()`. Returning a non-zero value will result in the CLI app
+exiting with a return code typically interpreted as an error while zero means
+success. You can `import errno` to use typical POSIX error codes through their
+human-readable identifiers.
+
+Another way to interrupt the CLI app control flow is by raising an instance of
+one of the in-app errors. `raise PreCommitTerraformExit` for a successful exit,
+but it can be turned into an error outcome via
+`raise PreCommitTerraformExit(1)`.
+`raise PreCommitTerraformRuntimeError('The world is broken')` to indicate
+problems within the runtime. The framework will intercept any exceptions
+inheriting `PreCommitTerraformBaseError`, so they won't be presented to the
+end-users.
+
 [`.pre-commit-hooks.yaml`]: ../../.pre-commit-hooks.yaml
 [`_cli_parsing.py`]: ./_cli_parsing.py
 [`_cli_subcommands.py`]: ./_cli_subcommands.py
+[`argparse.ArgumentParser`]:
+https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser
+[`argparse.Namespace`]:
+https://docs.python.org/3/library/argparse.html#argparse.Namespace
 [clig]: https://clig.dev
 [importable package]: https://docs.python.org/3/tutorial/modules.html#packages
 [import package]: https://packaging.python.org/en/latest/glossary/#term-Import-Package

--- a/src/pre_commit_terraform/__main__.py
+++ b/src/pre_commit_terraform/__main__.py
@@ -1,0 +1,10 @@
+"""A runpy-style CLI entry-point module."""
+
+from sys import argv, exit as exit_with_return_code
+
+from ._cli import invoke_cli_app
+
+
+if __name__ == '__main__':
+    return_code = invoke_cli_app(argv[1:])
+    exit_with_return_code(return_code)

--- a/src/pre_commit_terraform/__main__.py
+++ b/src/pre_commit_terraform/__main__.py
@@ -5,6 +5,5 @@ from sys import argv, exit as exit_with_return_code
 from ._cli import invoke_cli_app
 
 
-if __name__ == '__main__':
-    return_code = invoke_cli_app(argv[1:])
-    exit_with_return_code(return_code)
+return_code = invoke_cli_app(argv[1:])
+exit_with_return_code(return_code)

--- a/src/pre_commit_terraform/_cli.py
+++ b/src/pre_commit_terraform/_cli.py
@@ -1,0 +1,56 @@
+"""Outer CLI layer of the app interface."""
+
+from sys import stderr
+
+from ._cli_subcommands import choose_cli_app
+from ._cli_parsing import initialize_argument_parser
+from ._errors import (
+    PreCommitTerraformBaseError,
+    PreCommitTerraformExit,
+    PreCommitTerraformRuntimeError,
+)
+from ._structs import ReturnCode
+from ._types import ReturnCodeType
+
+
+def invoke_cli_app(cli_args: list[str]) -> ReturnCodeType:
+    """Run the entry-point of the CLI app.
+
+    Includes initializing parsers of all the sub-apps and
+    choosing what to execute.
+    """
+    root_cli_parser = initialize_argument_parser()
+    parsed_cli_args = root_cli_parser.parse_args(cli_args)
+    try:
+        invoke_chosen_app = choose_cli_app(parsed_cli_args.check_name)
+    except LookupError as lookup_err:
+        print(f'Sourcing subcommand failed: {lookup_err !s}', file=stderr)
+        return ReturnCode.ERROR
+
+    try:
+        return invoke_chosen_app(parsed_cli_args)
+    except PreCommitTerraformExit as exit_err:
+        print(f'App exiting: {exit_err !s}', file=stderr)
+        raise
+    except PreCommitTerraformRuntimeError as unhandled_exc:
+        print(
+            f'App execution took an unexpected turn: {unhandled_exc !s}. '
+            'Exiting...',
+            file=stderr,
+        )
+        return ReturnCode.ERROR
+    except PreCommitTerraformBaseError as unhandled_exc:
+        print(
+            f'A surprising exception happened: {unhandled_exc !s}. Exiting...',
+            file=stderr,
+        )
+        return ReturnCode.ERROR
+    except KeyboardInterrupt as ctrl_c_exc:
+        print(
+            f'User-initiated interrupt: {ctrl_c_exc !s}. Exiting...',
+            file=stderr,
+        )
+        return ReturnCode.ERROR
+
+
+__all__ = ('invoke_cli_app',)

--- a/src/pre_commit_terraform/_cli.py
+++ b/src/pre_commit_terraform/_cli.py
@@ -2,7 +2,6 @@
 
 from sys import stderr
 
-from ._cli_subcommands import choose_cli_app
 from ._cli_parsing import initialize_argument_parser
 from ._errors import (
     PreCommitTerraformBaseError,
@@ -21,14 +20,9 @@ def invoke_cli_app(cli_args: list[str]) -> ReturnCodeType:
     """
     root_cli_parser = initialize_argument_parser()
     parsed_cli_args = root_cli_parser.parse_args(cli_args)
-    try:
-        invoke_chosen_app = choose_cli_app(parsed_cli_args.check_name)
-    except LookupError as lookup_err:
-        print(f'Sourcing subcommand failed: {lookup_err !s}', file=stderr)
-        return ReturnCode.ERROR
 
     try:
-        return invoke_chosen_app(parsed_cli_args)
+        return parsed_cli_args.invoke_cli_app(parsed_cli_args)
     except PreCommitTerraformExit as exit_err:
         print(f'App exiting: {exit_err !s}', file=stderr)
         raise

--- a/src/pre_commit_terraform/_cli_parsing.py
+++ b/src/pre_commit_terraform/_cli_parsing.py
@@ -22,11 +22,11 @@ def attach_subcommand_parsers_to(root_cli_parser: ArgumentParser, /) -> None:
         required=True,
     )
     for subcommand_module in SUBCOMMAND_MODULES:
-        replace_docs_parser = subcommand_parsers.add_parser(subcommand_module.CLI_SUBCOMMAND_NAME)
-        replace_docs_parser.set_defaults(
+        subcommand_parser = subcommand_parsers.add_parser(subcommand_module.CLI_SUBCOMMAND_NAME)
+        subcommand_parser.set_defaults(
             invoke_cli_app=subcommand_module.invoke_cli_app,
         )
-        subcommand_module.populate_argument_parser(replace_docs_parser)
+        subcommand_module.populate_argument_parser(subcommand_parser)
 
 
 def initialize_argument_parser() -> ArgumentParser:

--- a/src/pre_commit_terraform/_cli_parsing.py
+++ b/src/pre_commit_terraform/_cli_parsing.py
@@ -1,0 +1,43 @@
+"""Argument parser initialization logic.
+
+This defines helpers for setting up both the root parser and the parsers
+of all the sub-commands.
+"""
+
+from argparse import ArgumentParser
+
+from .terraform_docs_replace import (
+    populate_argument_parser as populate_replace_docs_argument_parser,
+)
+
+
+PARSER_MAP = {
+    'replace-docs': populate_replace_docs_argument_parser,
+}
+
+
+def attach_subcommand_parsers_to(root_cli_parser: ArgumentParser, /) -> None:
+    """Connect all sub-command parsers to the given one.
+
+    This functions iterates over a mapping of subcommands to their
+    respective population functions, executing them to augment the
+    main parser.
+    """
+    subcommand_parsers = root_cli_parser.add_subparsers(
+        dest='check_name',
+        help='A check to be performed.',
+        required=True,
+    )
+    for subcommand_name, initialize_subcommand_parser in PARSER_MAP.items():
+        replace_docs_parser = subcommand_parsers.add_parser(subcommand_name)
+        initialize_subcommand_parser(replace_docs_parser)
+
+
+def initialize_argument_parser() -> ArgumentParser:
+    """Return the root argument parser with sub-commands."""
+    root_cli_parser = ArgumentParser(prog=f'python -m {__package__ !s}')
+    attach_subcommand_parsers_to(root_cli_parser)
+    return root_cli_parser
+
+
+__all__ = ('initialize_argument_parser',)

--- a/src/pre_commit_terraform/_cli_parsing.py
+++ b/src/pre_commit_terraform/_cli_parsing.py
@@ -6,14 +6,7 @@ of all the sub-commands.
 
 from argparse import ArgumentParser
 
-from .terraform_docs_replace import (
-    populate_argument_parser as populate_replace_docs_argument_parser,
-)
-
-
-PARSER_MAP = {
-    'replace-docs': populate_replace_docs_argument_parser,
-}
+from ._cli_subcommands import SUBCOMMAND_MODULES
 
 
 def attach_subcommand_parsers_to(root_cli_parser: ArgumentParser, /) -> None:
@@ -28,9 +21,12 @@ def attach_subcommand_parsers_to(root_cli_parser: ArgumentParser, /) -> None:
         help='A check to be performed.',
         required=True,
     )
-    for subcommand_name, initialize_subcommand_parser in PARSER_MAP.items():
-        replace_docs_parser = subcommand_parsers.add_parser(subcommand_name)
-        initialize_subcommand_parser(replace_docs_parser)
+    for subcommand_module in SUBCOMMAND_MODULES:
+        replace_docs_parser = subcommand_parsers.add_parser(subcommand_module.CLI_SUBCOMMAND_NAME)
+        replace_docs_parser.set_defaults(
+            invoke_cli_app=subcommand_module.invoke_cli_app,
+        )
+        subcommand_module.populate_argument_parser(replace_docs_parser)
 
 
 def initialize_argument_parser() -> ArgumentParser:

--- a/src/pre_commit_terraform/_cli_subcommands.py
+++ b/src/pre_commit_terraform/_cli_subcommands.py
@@ -1,0 +1,31 @@
+"""A CLI sub-commands organization module."""
+
+from argparse import Namespace
+from typing import Callable
+
+from ._structs import ReturnCode
+from .terraform_docs_replace import (
+    invoke_cli_app as invoke_replace_docs_cli_app,
+)
+
+
+SUBCOMMAND_MAP = {
+    'replace-docs': invoke_replace_docs_cli_app,
+}
+
+
+def choose_cli_app(
+        check_name: str,
+        /,
+) -> Callable[[Namespace], ReturnCode | int]:
+    """Return a subcommand callable by CLI argument name."""
+    try:
+        return SUBCOMMAND_MAP[check_name]
+    except KeyError as key_err:
+        raise LookupError(
+            f'{key_err !s}: Unable to find a callable for '
+            f'the `{check_name !s}` subcommand',
+        ) from key_err
+
+
+__all__ = ('choose_cli_app',)

--- a/src/pre_commit_terraform/_cli_subcommands.py
+++ b/src/pre_commit_terraform/_cli_subcommands.py
@@ -1,31 +1,12 @@
 """A CLI sub-commands organization module."""
 
-from argparse import Namespace
-from typing import Callable
-
-from ._structs import ReturnCode
-from .terraform_docs_replace import (
-    invoke_cli_app as invoke_replace_docs_cli_app,
-)
+from . import terraform_docs_replace
+from ._types import CLISubcommandModuleProtocol
 
 
-SUBCOMMAND_MAP = {
-    'replace-docs': invoke_replace_docs_cli_app,
-}
+SUBCOMMAND_MODULES: list[CLISubcommandModuleProtocol] = [
+    terraform_docs_replace,
+]
 
 
-def choose_cli_app(
-        check_name: str,
-        /,
-) -> Callable[[Namespace], ReturnCode | int]:
-    """Return a subcommand callable by CLI argument name."""
-    try:
-        return SUBCOMMAND_MAP[check_name]
-    except KeyError as key_err:
-        raise LookupError(
-            f'{key_err !s}: Unable to find a callable for '
-            f'the `{check_name !s}` subcommand',
-        ) from key_err
-
-
-__all__ = ('choose_cli_app',)
+__all__ = ('SUBCOMMAND_MODULES',)

--- a/src/pre_commit_terraform/_errors.py
+++ b/src/pre_commit_terraform/_errors.py
@@ -1,0 +1,16 @@
+"""App-specific exceptions."""
+
+
+class PreCommitTerraformBaseError(Exception):
+    """Base exception for all the in-app errors."""
+
+
+class PreCommitTerraformRuntimeError(
+        PreCommitTerraformBaseError,
+        RuntimeError,
+):
+    """An exception representing a runtime error condition."""
+
+
+class PreCommitTerraformExit(PreCommitTerraformBaseError, SystemExit):
+    """An exception for terminating execution from deep app layers."""

--- a/src/pre_commit_terraform/_structs.py
+++ b/src/pre_commit_terraform/_structs.py
@@ -1,0 +1,16 @@
+"""Data structures to be reused across the app."""
+
+from enum import IntEnum
+
+
+class ReturnCode(IntEnum):
+    """POSIX-style return code values.
+
+    To be used in check callable implementations.
+    """
+
+    OK = 0
+    ERROR = 1
+
+
+__all__ = ('ReturnCode',)

--- a/src/pre_commit_terraform/_types.py
+++ b/src/pre_commit_terraform/_types.py
@@ -1,6 +1,30 @@
 """Composite types for annotating in-project code."""
 
+from argparse import ArgumentParser, Namespace
+from typing import Final, Protocol
+
 from ._structs import ReturnCode
 
 
 ReturnCodeType = ReturnCode | int
+
+
+class CLISubcommandModuleProtocol(Protocol):
+    """A protocol for the subcommand-implementing module shape."""
+
+    CLI_SUBCOMMAND_NAME: Final[str]
+    """This constant contains a CLI."""
+
+    def populate_argument_parser(
+            self, subcommand_parser: ArgumentParser,
+    ) -> None:
+        """Run a module hook for populating the subcommand parser."""
+
+    def invoke_cli_app(
+            self, parsed_cli_args: Namespace,
+    ) -> ReturnCodeType | int:
+        """Run a module hook implementing the subcommand logic."""
+        ...  # pylint: disable=unnecessary-ellipsis
+
+
+__all__ = ('CLISubcommandModuleProtocol', 'ReturnCodeType')

--- a/src/pre_commit_terraform/_types.py
+++ b/src/pre_commit_terraform/_types.py
@@ -1,0 +1,6 @@
+"""Composite types for annotating in-project code."""
+
+from ._structs import ReturnCode
+
+
+ReturnCodeType = ReturnCode | int

--- a/src/pre_commit_terraform/terraform_docs_replace.py
+++ b/src/pre_commit_terraform/terraform_docs_replace.py
@@ -1,33 +1,42 @@
-import argparse
 import os
 import subprocess
-import sys
 import warnings
+from argparse import ArgumentParser, Namespace
+
+from ._structs import ReturnCode
+from ._types import ReturnCodeType
 
 
-def main(argv=None):
-    parser = argparse.ArgumentParser(
-        description="""Run terraform-docs on a set of files. Follows the standard convention of
-                       pulling the documentation from main.tf in order to replace the entire
-                       README.md file each time."""
+def populate_argument_parser(subcommand_parser: ArgumentParser) -> None:
+    subcommand_parser.description = (
+        'Run terraform-docs on a set of files. Follows the standard '
+        'convention of pulling the documentation from main.tf in order to '
+        'replace the entire README.md file each time.'
     )
-    parser.add_argument(
+    subcommand_parser.add_argument(
         '--dest', dest='dest', default='README.md',
     )
-    parser.add_argument(
+    subcommand_parser.add_argument(
         '--sort-inputs-by-required', dest='sort', action='store_true',
         help='[deprecated] use --sort-by-required instead',
     )
-    parser.add_argument(
+    subcommand_parser.add_argument(
         '--sort-by-required', dest='sort', action='store_true',
     )
-    parser.add_argument(
-        '--with-aggregate-type-defaults', dest='aggregate', action='store_true',
+    subcommand_parser.add_argument(
+        '--with-aggregate-type-defaults',
+        dest='aggregate',
+        action='store_true',
         help='[deprecated]',
     )
-    parser.add_argument('filenames', nargs='*', help='Filenames to check.')
-    args = parser.parse_args(argv)
+    subcommand_parser.add_argument(
+        'filenames',
+        nargs='*',
+        help='Filenames to check.',
+    )
 
+
+def invoke_cli_app(parsed_cli_args: Namespace) -> ReturnCodeType:
     warnings.warn(
         '`terraform_docs_replace` hook is DEPRECATED.'
         'For migration instructions see '
@@ -37,29 +46,28 @@ def main(argv=None):
     )
 
     dirs = []
-    for filename in args.filenames:
+    for filename in parsed_cli_args.filenames:
         if (os.path.realpath(filename) not in dirs and
                 (filename.endswith(".tf") or filename.endswith(".tfvars"))):
             dirs.append(os.path.dirname(filename))
 
-    retval = 0
+    retval = ReturnCode.OK
 
     for dir in dirs:
         try:
             procArgs = []
             procArgs.append('terraform-docs')
-            if args.sort:
+            if parsed_cli_args.sort:
                 procArgs.append('--sort-by-required')
             procArgs.append('md')
             procArgs.append("./{dir}".format(dir=dir))
             procArgs.append('>')
-            procArgs.append("./{dir}/{dest}".format(dir=dir, dest=args.dest))
+            procArgs.append(
+                './{dir}/{dest}'.
+                format(dir=dir, dest=parsed_cli_args.dest),
+            )
             subprocess.check_call(" ".join(procArgs), shell=True)
         except subprocess.CalledProcessError as e:
             print(e)
-            retval = 1
+            retval = ReturnCode.ERROR
     return retval
-
-
-if __name__ == '__main__':
-    sys.exit(main())

--- a/src/pre_commit_terraform/terraform_docs_replace.py
+++ b/src/pre_commit_terraform/terraform_docs_replace.py
@@ -2,9 +2,13 @@ import os
 import subprocess
 import warnings
 from argparse import ArgumentParser, Namespace
+from typing import Final
 
 from ._structs import ReturnCode
 from ._types import ReturnCodeType
+
+
+CLI_SUBCOMMAND_NAME: Final[str] = 'replace-docs'
 
 
 def populate_argument_parser(subcommand_parser: ArgumentParser) -> None:


### PR DESCRIPTION
This includes a structure with purpose-based modules and a standard mechanism for adding more subcommands.

When adding a new subcommand, one has to define the `invoke_cli_app()` and `populate_argument_parser()` hooks in their new module together with a `CLI_SUBCOMMAND_NAME` string constant. I can then be wired into the framework via `_cli_subcommands.py`. This is the only integration point necessary.

`populate_argument_parser()` accepts a subparser instance of `argparse.ArgumentParser()` that a new subcommand would need to attach new arguments into. It does not need to return anything. And the `invoke_cli_app()` hook is called with an instance of `argparse.Namespace()` with all the arguments parsed and pre-processed. This function is supposed to have the main check logic and return an instance of `._structs.ReturnCode()` or `int`.
`CLI_SUBCOMMAND_NAME` needs to be annotated as a `Final[str]`.

`pre-commit` integration is done through the runpy interface: `python -m pre_commit_terraform <subcommand>`.

The import package folder also contains a more detailed maintenance manual: https://github.com/antonbabenko/pre-commit-terraform/tree/8e77580805322e5d264a2667b4f4cba53e8bf94c/src/pre_commit_terraform#readme.

<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.
- [x] This PR is an internal restructuring change.

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123456":
-->
I think the most important details are in the commit messages. Everything that is unlikely to change much over time is in "_private" modules.
<!-- Fixes # -->

### How can we test changes

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Something like `python -Im pip install -e . && python -Im pre_commit_terraform replace-docs`. Or invoke it via pre-commit.