### PR TITLE
ci: Disable `no-commit-to-branch` @ GHA

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -387,8 +387,14 @@ jobs:
         - pre-commit
         - metadata-validation
         environment-variables:
+        # `no-commit-to-branch` is skipped because it does not make sense
+        # in the CI, only locally.
+        # Ref: https://github.com/pre-commit/pre-commit-hooks/issues/1124
         - >-  # only affects pre-commit, set for all for simplicity:
-          SKIP=hadolint,shfmt
+          SKIP=
+          hadolint,
+          no-commit-to-branch,
+          shfmt,
         tox-run-posargs:
         - ''
         xfail:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -392,9 +392,9 @@ jobs:
         # Ref: https://github.com/pre-commit/pre-commit-hooks/issues/1124
         - >-  # only affects pre-commit, set for all for simplicity:
           SKIP=
-          hadolint,
-          no-commit-to-branch,
-          shfmt,
+            hadolint,
+            no-commit-to-branch,
+            shfmt,
         tox-run-posargs:
         - ''
         xfail:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -392,9 +392,9 @@ jobs:
         # Ref: https://github.com/pre-commit/pre-commit-hooks/issues/1124
         - >-  # only affects pre-commit, set for all for simplicity:
           SKIP=
-            hadolint,
-            no-commit-to-branch,
-            shfmt,
+          hadolint,
+          no-commit-to-branch,
+          shfmt,
         tox-run-posargs:
         - ''
         xfail:


### PR DESCRIPTION
This turns off the "is push to master" in GitHub Actions CI/CD as it does not make sense in this environment, being local-only [[1]].

[1]: https://github.com/pre-commit/pre-commit-hooks/issues/1124

<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.
- [x] Internal maintenance, no effect on end-users or contributors.

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123456":
-->
This is a follow-up for #742. One of its jobs runs `pre-commit` and doesn't filter out this hook. The hook itself would only fail on pushes to `master` which is not a condition that can happen in PR workflow runs.
<!-- Fixes # -->

### How can we test changes

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
You can't. This will only be visible on `master`.