### PR TITLE
chore: Rename 'py' to 'pytest' in GHA to avoid confusion

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -452,7 +452,7 @@ jobs:
         - macos-13
         - windows-2025
         toxenv:
-        - py
+        - pytest
         xfail:
         - false
 

--- a/.github/workflows/reusable-tox.yml
+++ b/.github/workflows/reusable-tox.yml
@@ -262,7 +262,7 @@ jobs:
       shell: bash
     - name: Download all the dists
       if: >-
-        contains(fromJSON('["metadata-validation", "py"]'), inputs.toxenv)
+        contains(fromJSON('["metadata-validation", "pytest"]'), inputs.toxenv)
       uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.dists-artifact-name }}

--- a/tox.ini
+++ b/tox.ini
@@ -104,6 +104,9 @@ set_env =
   COVERAGE_PROCESS_START = {toxinidir}{/}.coveragerc
 wheel_build_env = .pkg
 
+# Duplicate default 'py' env to 'pytest' to be able run pytest with 'tox run -e pytest'
+[testenv:pytest]
+
 
 [testenv:cleanup-dists]
 description =


### PR DESCRIPTION
### Description of your changes

When you see `py` in tests it not clear what exactly going on. Until now I thought that it represents "python", but actually this part run `pytest`
![image](https://github.com/user-attachments/assets/a7f5aeef-a4ab-4d18-a793-834f0b3c5ce9)

So, for avoiding confusion and add ability to explicitly specify `tox r -e pytest`, this PR was made

### How can we test changes

Wait till tests pass on this PR