### PR TITLE
feat(`terraform_docs`): Add support for custom markers to better support other formats than Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,7 +610,7 @@ Unlike most other hooks, this hook triggers once if there are any changed files 
         - --hook-config=--use-standard-markers=true     # Boolean. Defaults to true (v1.93+), false (<v1.93). Set to true for compatibility with terraform-docs
           # The following two options "--custom-marker-begin" and "--custom-marker-end" are ignored if "--use-standard-markers" is set to false
         - --hook-config=--custom-marker-begin           # String. Defaults to "<!-- BEGIN_TF_DOCS -->" (v1.93+), "<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->" (<v1.93).
-                                                        # Set to use custom marker which helps you with using other formats like asciidoc. 
+                                                        # Set to use custom marker which helps you with using other formats like asciidoc.
                                                         # For Asciidoc this could be "--hook-config=--custom-marker-begin=// BEGIN_TF_DOCS"
         - --hook-config=--custom-marker-end             # String. Defaults to "<!-- END_TF_DOCS -->" (v1.93+), "<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->" (<v1.93).
                                                         # Set to use custom marker which helps you with using other formats like asciidoc.

--- a/README.md
+++ b/README.md
@@ -609,13 +609,13 @@ Unlike most other hooks, this hook triggers once if there are any changed files 
         - --hook-config=--create-file-if-not-exist=true # Boolean. true or false
         - --hook-config=--use-standard-markers=true     # Boolean. Defaults to true (v1.93+), false (<v1.93). Set to true for compatibility with terraform-docs
           # The following two options "--custom-marker-begin" and "--custom-marker-end" are ignored if "--use-standard-markers" is set to false
-        - --hook-config=--custom-marker-begin           # String. Defaults to "<!-- BEGIN_TF_DOCS -->" (v1.93+), "<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->" (<v1.93).
+        - --hook-config=--custom-marker-begin=<!-- BEGIN_TF_DOCS -->  # String.
                                                         # Set to use custom marker which helps you with using other formats like asciidoc.
                                                         # For Asciidoc this could be "--hook-config=--custom-marker-begin=// BEGIN_TF_DOCS"
-        - --hook-config=--custom-marker-end             # String. Defaults to "<!-- END_TF_DOCS -->" (v1.93+), "<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->" (<v1.93).
+        - --hook-config=--custom-marker-end=<!-- END_TF_DOCS -->  # String.
                                                         # Set to use custom marker which helps you with using other formats like asciidoc.
                                                         # For Asciidoc this could be "--hook-config=--custom-marker-end=// END_TF_DOCS"
-        - --hook-config=--custom-doc-header             # String. Defaults to "# "
+        - --hook-config=--custom-doc-header="# "        # String. Defaults to "# "
                                                         # Set to use custom marker which helps you with using other formats like asciidoc.
                                                         # For Asciidoc this could be "--hook-config=--custom-marker-end=\= "
     ```

--- a/README.md
+++ b/README.md
@@ -615,6 +615,9 @@ Unlike most other hooks, this hook triggers once if there are any changed files 
         - --hook-config=--custom-marker-end             # String. Defaults to "<!-- END_TF_DOCS -->" (v1.93+), "<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->" (<v1.93).
                                                         # Set to use custom marker which helps you with using other formats like asciidoc.
                                                         # For Asciidoc this could be "--hook-config=--custom-marker-end=// END_TF_DOCS"
+        - --hook-config=--custom-doc-header             # String. Defaults to "# "
+                                                        # Set to use custom marker which helps you with using other formats like asciidoc.
+                                                        # For Asciidoc this could be "--hook-config=--custom-marker-end=\= "
     ```
 
 4. If you want to use a terraform-docs config file, you must supply the path to the file, relative to the git repo root path:

--- a/README.md
+++ b/README.md
@@ -608,8 +608,13 @@ Unlike most other hooks, this hook triggers once if there are any changed files 
         - --hook-config=--add-to-existing-file=true     # Boolean. true or false
         - --hook-config=--create-file-if-not-exist=true # Boolean. true or false
         - --hook-config=--use-standard-markers=true     # Boolean. Defaults to true (v1.93+), false (<v1.93). Set to true for compatibility with terraform-docs
-        - --hook-config=--custom-marker-begin     # String. Defaults to "<!-- BEGIN_TF_DOCS -->" (v1.93+), "<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->" (<v1.93). Set to use custom marker which helps you with using other formats like asciidoc
-        - --hook-config=--custom-marker-end     # String. Defaults to "<!-- END_TF_DOCS -->" (v1.93+), "<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->" (<v1.93). Set to use custom marker which helps you with using other formats like asciidoc
+          # The following two options "--custom-marker-begin" and "--custom-marker-end" are ignored if "--use-standard-markers" is set to false
+        - --hook-config=--custom-marker-begin           # String. Defaults to "<!-- BEGIN_TF_DOCS -->" (v1.93+), "<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->" (<v1.93).
+                                                        # Set to use custom marker which helps you with using other formats like asciidoc. 
+                                                        # For Asciidoc this could be "--hook-config=--custom-marker-begin=// BEGIN_TF_DOCS"
+        - --hook-config=--custom-marker-end             # String. Defaults to "<!-- END_TF_DOCS -->" (v1.93+), "<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->" (<v1.93).
+                                                        # Set to use custom marker which helps you with using other formats like asciidoc.
+                                                        # For Asciidoc this could be "--hook-config=--custom-marker-end=// END_TF_DOCS"
     ```
 
 4. If you want to use a terraform-docs config file, you must supply the path to the file, relative to the git repo root path:

--- a/README.md
+++ b/README.md
@@ -608,6 +608,8 @@ Unlike most other hooks, this hook triggers once if there are any changed files 
         - --hook-config=--add-to-existing-file=true     # Boolean. true or false
         - --hook-config=--create-file-if-not-exist=true # Boolean. true or false
         - --hook-config=--use-standard-markers=true     # Boolean. Defaults to true (v1.93+), false (<v1.93). Set to true for compatibility with terraform-docs
+        - --hook-config=--custom-marker-begin     # String. Defaults to "<!-- BEGIN_TF_DOCS -->" (v1.93+), "<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->" (<v1.93). Set to use custom marker which helps you with using other formats like asciidoc
+        - --hook-config=--custom-marker-end     # String. Defaults to "<!-- END_TF_DOCS -->" (v1.93+), "<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->" (<v1.93). Set to use custom marker which helps you with using other formats like asciidoc
     ```
 
 4. If you want to use a terraform-docs config file, you must supply the path to the file, relative to the git repo root path:

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -42,8 +42,8 @@ function replace_old_markers {
 
   # Determine the appropriate sed command based on the operating system (GNU sed or BSD sed)
   sed --version &> /dev/null && SED_CMD=(sed -i) || SED_CMD=(sed -i '')
-  "${SED_CMD[@]}" -e "s|^${old_insertion_marker_begin}$|${insertion_marker_begin}|" "$file"
-  "${SED_CMD[@]}" -e "s|^${old_insertion_marker_end}$|${insertion_marker_end}|" "$file"
+  "${SED_CMD[@]}" -e "s/^${old_insertion_marker_begin}$/${insertion_marker_begin//\//\\/}/" "$file"
+  "${SED_CMD[@]}" -e "s/^${old_insertion_marker_end}$/${insertion_marker_begin//\//\\/}/" "$file"
 }
 
 #######################################################################
@@ -115,11 +115,13 @@ function terraform_docs {
         common::colorify "yellow" "WARNING: --use-standard-markers is deprecated and will be removed in the future."
         common::colorify "yellow" "         All needed changes already done by the hook, feel free to remove --use-standard-markers setting from your pre-commit config"
         ;;
-        --custom-marker-begin)
+      --custom-marker-begin)
         insertion_marker_begin=$value
+        common::colorify "yellow" "INFO: --custom-marker-begin is used and the marker is set to \"$value\"."
         ;;
-        --custom-marker-end)
+      --custom-marker-end)
         insertion_marker_end=$value
+        common::colorify "yellow" "INFO: --custom-marker-end is used and the marker is set to \"$value\"."
         ;;
     esac
   done

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -42,8 +42,8 @@ function replace_old_markers {
 
   # Determine the appropriate sed command based on the operating system (GNU sed or BSD sed)
   sed --version &> /dev/null && SED_CMD=(sed -i) || SED_CMD=(sed -i '')
-  "${SED_CMD[@]}" -e "s/^${old_insertion_marker_begin}$/${insertion_marker_begin}/" "$file"
-  "${SED_CMD[@]}" -e "s/^${old_insertion_marker_end}$/${insertion_marker_end}/" "$file"
+  "${SED_CMD[@]}" -e "s|^${old_insertion_marker_begin}$|${insertion_marker_begin}|" "$file"
+  "${SED_CMD[@]}" -e "s|^${old_insertion_marker_end}$|${insertion_marker_end}|" "$file"
 }
 
 #######################################################################
@@ -114,6 +114,12 @@ function terraform_docs {
         use_standard_markers=$value
         common::colorify "yellow" "WARNING: --use-standard-markers is deprecated and will be removed in the future."
         common::colorify "yellow" "         All needed changes already done by the hook, feel free to remove --use-standard-markers setting from your pre-commit config"
+        ;;
+        --custom-marker-begin)
+        insertion_marker_begin=$value
+        ;;
+        --custom-marker-end)
+        insertion_marker_end=$value
         ;;
     esac
   done

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -9,6 +9,7 @@ readonly SCRIPT_DIR
 
 insertion_marker_begin="<!-- BEGIN_TF_DOCS -->"
 insertion_marker_end="<!-- END_TF_DOCS -->"
+doc_header="# "
 
 # Old markers used by the hook before the introduction of the terraform-docs markers
 readonly old_insertion_marker_begin="<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->"
@@ -123,6 +124,10 @@ function terraform_docs {
         insertion_marker_end=$value
         common::colorify "yellow" "INFO: --custom-marker-end is used and the marker is set to \"$value\"."
         ;;
+      --custom-doc-header)
+        doc_header=$value
+        common::colorify "yellow" "INFO: --custom-doc-header is used and the marker is set to \"$value\"."
+        ;;
     esac
   done
 
@@ -206,7 +211,7 @@ function terraform_docs {
 
       # Use of insertion markers, where there is no existing README file
       {
-        echo -e "# ${PWD##*/}\n"
+        echo -e "${doc_header}${PWD##*/}\n"
         echo "$insertion_marker_begin"
         echo "$insertion_marker_end"
       } >> "$output_file"

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -43,7 +43,7 @@ function replace_old_markers {
   # Determine the appropriate sed command based on the operating system (GNU sed or BSD sed)
   sed --version &> /dev/null && SED_CMD=(sed -i) || SED_CMD=(sed -i '')
   "${SED_CMD[@]}" -e "s/^${old_insertion_marker_begin}$/${insertion_marker_begin//\//\\/}/" "$file"
-  "${SED_CMD[@]}" -e "s/^${old_insertion_marker_end}$/${insertion_marker_begin//\//\\/}/" "$file"
+  "${SED_CMD[@]}" -e "s/^${old_insertion_marker_end}$/${insertion_marker_end//\//\\/}/" "$file"
 }
 
 #######################################################################

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -118,15 +118,15 @@ function terraform_docs {
         ;;
       --custom-marker-begin)
         insertion_marker_begin=$value
-        common::colorify "yellow" "INFO: --custom-marker-begin is used and the marker is set to \"$value\"."
+        common::colorify "green" "INFO: --custom-marker-begin is used and the marker is set to \"$value\"."
         ;;
       --custom-marker-end)
         insertion_marker_end=$value
-        common::colorify "yellow" "INFO: --custom-marker-end is used and the marker is set to \"$value\"."
+        common::colorify "green" "INFO: --custom-marker-end is used and the marker is set to \"$value\"."
         ;;
       --custom-doc-header)
         doc_header=$value
-        common::colorify "yellow" "INFO: --custom-doc-header is used and the marker is set to \"$value\"."
+        common::colorify "green" "INFO: --custom-doc-header is used and the doc header is set to \"$value\"."
         ;;
     esac
   done


### PR DESCRIPTION

<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [x] This PR adds new functionality.
- [x] This PR enhances existing functionality.

### Description of your changes

This adds support to pass custom markers.
This helps to improve support for other formats like asciidoc which you can use if you use a config for terraform-doc.

### How can we test changes

Add your custom marker to a README and run the hook with the options. You may also want to change the template used by terraform-doc

```
terraform_docs.sh --hook-config=--path-to-file=README.adoc --hook-config="--custom-marker-begin=// BEGIN_TF_DOCS" --hook-config="--custom-marker-end=// END_TF_DOCS" --args=--config=.terraform-docs.yml ./path/to/file.tf
```
