### PR TITLE
chore: Fix shellcheck v0.10.0 linters rules

### DIFF
--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -139,7 +139,7 @@ function common::parse_and_export_env_vars {
         # `$arg` will be checked in `if` conditional, `$ARGS` will be used in the next functions.
         # shellcheck disable=SC2016 # '${' should not be expanded
         arg=${arg/'${'$env_var_name'}'/$env_var_value}
-        ARGS[$arg_idx]=$arg
+        ARGS[arg_idx]=$arg
         # shellcheck disable=SC2016 # '${' should not be expanded
         common::colorify "green" 'After ${'"$env_var_name"'} expansion: '"'$arg'\n"
         continue


### PR DESCRIPTION
### Description of your changes

Should not change anything, as it just make happy shellcheck v0.10.0 about this particular line

```bash
In hooks/_common.sh line 142:
        ARGS[$arg_idx]=$arg
             ^------^ SC2004 (style): $/${} is unnecessary on arithmetic variables.

For more information:
  https://www.shellcheck.net/wiki/SC2004 -- $/${} is unnecessary on arithmeti...

```

found in [Linters check for unrelated PR](https://github.com/antonbabenko/pre-commit-terraform/actions/runs/12758739930/job/35561336508?pr=737#step:17:46) https://github.com/antonbabenko/pre-commit-terraform/pull/737, as it uses ubutntu24.04, and no matter that `shellcheck` recommend install itself by `apt`, it contains outdated version for most OSes, IE, ubuntu22.04 uses 0.8.0, when latest one is 0.10.0

Actually, we can do it as PATCH release, but I am not sure is it worst it.