### PR TITLE
ci: Avoid reaching GH limits on MacOS runners

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,4 +3,6 @@
   extends: ["local>SpotOnInc/renovate-config"],
   // To make happy 'Validate PR title' GHA
   commitMessageLowerCase: "never",
+  // Disable auto-rebase on every commit to avoid reaching Github limits on macos runners
+  rebaseWhen: "conflicted",
 }


### PR DESCRIPTION
We are hit limits for how many runs on MacOS runners can be run, just by creation 10 renovate PRs and fix twise issues in half of them ~= 20 new PRs/commits for check

Each commit trigger 10 MacOS runs, which means that limit is aproximatly ~200 MacOS runs per hour.

I didn't find such limits in offical docs, btw
https://docs.github.com/en/actions/administering-github-actions/usage-limits-billing-and-administration#usage-limits