### PR TITLE
ci: Fix edge case with Nightly builds right after new release

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -334,6 +334,15 @@ jobs:
         --skip-missing-interpreters false
         --notest
 
+    - name: Drop Git tags from HEAD for non-tag-create events
+      if: >-
+        !fromJSON(needs.pre-setup.outputs.release-requested)
+      run: >-
+        git tag --points-at HEAD
+        |
+        xargs git tag --delete
+      shell: bash
+
     - name: Set static timestamp for dist build reproducibility
       # ... from the last Git commit since it's immutable
       run: >-

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -335,8 +335,6 @@ jobs:
         --notest
 
     - name: Drop Git tags from HEAD for non-tag-create events
-      if: >-
-        !fromJSON(needs.pre-setup.outputs.release-requested)
       run: >-
         git tag --points-at HEAD
         |


### PR DESCRIPTION
### Description of your changes

Each failed nightly build occurs right when new tag released and tag point to latest commit.

To avoid that, we need to drop tag to HEAD in CI
![image](https://github.com/user-attachments/assets/a7cd3f26-771f-4846-8dc1-b102d68a1380)
![image](https://github.com/user-attachments/assets/60b7038b-f5cd-4089-ae6d-ebe7c04ee09d)



### How can we test changes

1. Fork repo with all branches
2. Create PR from this branch and merge to fork `master`
3. Manually make new release
4. Go to Actions -> Enable :hourglass:  action
5. Trigger :hourglass: action manually
https://github.com/MaxymVlasov/pre-commit-terraform-PR776/actions/runs/12916272093
