### PR TITLE
ci(StepSecurity): Harden GHA token permissions 

### DIFF
--- a/.github/workflows/build-image-test.yaml
+++ b/.github/workflows/build-image-test.yaml
@@ -2,7 +2,10 @@
 
 name: Build Dockerfile if changed and run smoke tests
 
-on: [pull_request]
+on:
+  pull_request:
+
+permissions: {}
 
 env:
   IMAGE_TAG: pr-test

--- a/.github/workflows/build-image-test.yaml
+++ b/.github/workflows/build-image-test.yaml
@@ -5,7 +5,8 @@ name: Build Dockerfile if changed and run smoke tests
 on:
   pull_request:
 
-permissions: {}
+permissions:
+  contents: read
 
 env:
   IMAGE_TAG: pr-test

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -15,6 +15,10 @@ permissions:
 
 jobs:
   docker:
+    permissions:
+      # for docker/build-push-action to publish docker image
+      packages: write
+
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -10,6 +10,9 @@ on:
   schedule:
   - cron: 00 00 * * *
 
+permissions:
+  contents: read
+
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -15,6 +15,9 @@ on:
   pull_request:
   workflow_call:  # a way to embed the main tests
 
+permissions:
+  contents: read
+
 concurrency:
   group: >-
     ${{

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -9,8 +9,14 @@ on:
     - edited
     - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   main:
+    permissions:
+      pull-requests: read  # for amannn/action-semantic-pull-request to analyze PRs
+      statuses: write  # for amannn/action-semantic-pull-request to mark status of analyzed PR
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -15,8 +15,11 @@ permissions:
 jobs:
   main:
     permissions:
-      pull-requests: read  # for amannn/action-semantic-pull-request to analyze PRs
-      statuses: write  # for amannn/action-semantic-pull-request to mark status of analyzed PR
+      # for amannn/action-semantic-pull-request to analyze PRs
+      pull-requests: read
+      # for amannn/action-semantic-pull-request to mark status of analyzed PR
+      statuses: write
+
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -2,7 +2,8 @@
 
 name: Common issues check
 
-on: [pull_request]
+on:
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -4,8 +4,13 @@ name: Common issues check
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
+    permissions:
+      contents: write  # for pre-commit/action to push back fixes to PR branch
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ on:
     - .pre-commit-hooks.yaml
     # Ignore paths
     - '!tests/**'
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,4 +46,7 @@ jobs:
           @semantic-release/changelog@6.0.0
           @semantic-release/git@10.0.0
       env:
+        # Custom token for triggering Docker image build GH Workflow on release
+        # created by cycjimmy/semantic-release-action. Events created by
+        # workflows with default GITHUB_TOKEN not trigger other GH Workflow.
         GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,18 @@ on:
     - .pre-commit-hooks.yaml
     # Ignore paths
     - '!tests/**'
+
 permissions:
   contents: read
 
 jobs:
   release:
+    permissions:
+      # for cycjimmy/semantic-release-action to create a release
+      contents: write
+      # for cycjimmy/semantic-release-action to write comments to issues
+      issues: write
+
     name: Release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
       contents: write
       # for cycjimmy/semantic-release-action to write comments to issues
       issues: write
+      # for cycjimmy/semantic-release-action to write comments to PRs
+      pull-requests: write
 
     name: Release
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-tox.yml
+++ b/.github/workflows/reusable-tox.yml
@@ -83,6 +83,9 @@ on:
         description: Mandatory token for uploading to Codecov
         required: true
 
+permissions:
+  contents: read
+
 env:
   COLOR: >-  # Supposedly, pytest or coveragepy use this
     yes

--- a/.github/workflows/scheduled-runs.yml
+++ b/.github/workflows/scheduled-runs.yml
@@ -10,6 +10,9 @@ on:
   - cron: 3 5 * * *  # run daily at 5:03 UTC
   workflow_dispatch:  # manual trigger
 
+permissions:
+  contents: read
+
 run-name: >-
   🌃
   Nightly run of

--- a/.github/workflows/stale-actions.yaml
+++ b/.github/workflows/stale-actions.yaml
@@ -5,8 +5,14 @@ on:
   schedule:
   - cron: 0 0 * * *
 
+permissions:
+  contents: read
+
 jobs:
   stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
     - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639  # v9.1.0


### PR DESCRIPTION
### Description of your changes

Changes in this pull request is provided by [StepSecurity](https://app.stepsecurity.io/securerepo) 

## Security Fixes

### Least Privileged GitHub Actions Token Permissions

The GITHUB_TOKEN is an automatically generated secret to make authenticated calls to the GitHub API. GitHub recommends setting minimum token permissions for the GITHUB_TOKEN.

- [GitHub Security Guide](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)
- [The Open Source Security Foundation (OpenSSF) Security Guide](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions)


Relates: #712


