### PR TITLE
ci: Utilize native arm64 linux runners

### DIFF
--- a/.github/workflows/build-image-test.yaml
+++ b/.github/workflows/build-image-test.yaml
@@ -102,7 +102,7 @@ jobs:
     - name: Dive - check image for waste files
       if: steps.changed-files-specific.outputs.any_changed == 'true'
       # yamllint disable-line rule:line-length
-      uses: MaxymVlasov/dive-action@379af3fc636888ada5899c997e8b52db6ad45023  # v1.0.1
+      uses: MaxymVlasov/dive-action@fbf11e0550ed9c0b1e7ffdf86abf9dfabd2aca00  # v1.0.1+ ARM64 support
       with:
         image: ${{ env.IMAGE }}
         config-file: ${{ github.workspace }}/.github/.dive-ci.yaml

--- a/.github/workflows/build-image-test.yaml
+++ b/.github/workflows/build-image-test.yaml
@@ -83,6 +83,7 @@ jobs:
         env.CST_VERSION }}/container-structure-test-linux-${{ matrix.arch }}"
         > container-structure-test
         && chmod +x container-structure-test
+        && mkdir -p $HOME/bin/
         && mv container-structure-test $HOME/bin/
         && echo $HOME/bin/ >> $GITHUB_PATH
 

--- a/.github/workflows/build-image-test.yaml
+++ b/.github/workflows/build-image-test.yaml
@@ -87,16 +87,13 @@ jobs:
         && mv container-structure-test $HOME/bin/
         && echo $HOME/bin/ >> $GITHUB_PATH
 
-    - name: Check file existence and list directory
-      run: ls -al ${{ github.workspace }}/.github
-
-
     - name: Run structure tests
       if: steps.changed-files-specific.outputs.any_changed == 'true'
       run: >-
         container-structure-test test
-        -c ${{ github.workspace }}/.github/.spacelift-runners-container-structure-test-config.yaml
-        -i ${{ env.IMAGE }}
+        --config ${{ github.workspace
+        }}/.github/.container-structure-test-config.yaml
+        --image ${{ env.IMAGE }}
 
     - name: Dive - check image for waste files
       if: steps.changed-files-specific.outputs.any_changed == 'true'

--- a/.github/workflows/build-image-test.yaml
+++ b/.github/workflows/build-image-test.yaml
@@ -77,12 +77,11 @@ jobs:
         # yamllint disable-line rule:line-length
         # renovate: datasource=github-releases depName=container-structure-test lookupName=GoogleContainerTools/container-structure-test
         CST_VERSION: 1.19.3
-      run: >-
-        curl -L "
-        https://github.com/GoogleContainerTools/container-structure-test/
-        releases/download/v${CST_VERSION}/
-        container-structure-test-linux-${{ matrix.arch }}
-        " > container-structure-test
+        CST_REPO: github.com/GoogleContainerTools/container-structure-test
+      run: |
+        curl -L "https://${{ env.CST_REPO }}/releases/download/v${{
+        env.CST_VERSION }}/container-structure-test-linux-${{ matrix.arch }}"
+        > container-structure-test
         && chmod +x container-structure-test
         && mv container-structure-test /usr/bin/
 

--- a/.github/workflows/build-image-test.yaml
+++ b/.github/workflows/build-image-test.yaml
@@ -11,11 +11,19 @@ jobs:
   build:
     strategy:
       matrix:
-        os:
-        - ubuntu-latest
-        - ubuntu-24.04-arm
+        arch:
+        - amd64
+        - arm64
+        include:
+        - os-name: Ubuntu x64
+          os: ubuntu-latest
+          arch: amd64
 
+        - os-name: Ubuntu ARM
+          os: ubuntu-24.04-arm
+          arch: arm64
 
+    name: ${{ matrix.os-name }}
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
@@ -35,6 +43,7 @@ jobs:
           tools/*.sh
 
     - name: Set IMAGE environment variable
+      if: steps.changed-files-specific.outputs.any_changed == 'true'
       # Lowercase the org/repo name to allow for workflow to run in forks,
       # which owners have uppercase letters in username
       run: >-
@@ -44,6 +53,7 @@ jobs:
     - name: Set up Docker Buildx
       # yamllint disable-line rule:line-length
       uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5  # v3.8.0
+      if: steps.changed-files-specific.outputs.any_changed == 'true'
 
     - name: Build if Dockerfile changed
       if: steps.changed-files-specific.outputs.any_changed == 'true'
@@ -61,13 +71,27 @@ jobs:
         secrets: |
           "github_token=${{ secrets.GITHUB_TOKEN }}"
 
+    - name: Setup Container Structure Tests
+      if: steps.changed-files-specific.outputs.any_changed == 'true'
+      env:
+        # yamllint disable-line rule:line-length
+        # renovate: datasource=github-releases depName=container-structure-test lookupName=GoogleContainerTools/container-structure-test
+        CST_VERSION: 1.19.3
+      run: >-
+        curl -L "
+        https://github.com/GoogleContainerTools/container-structure-test/
+        releases/download/v${CST_VERSION}/
+        container-structure-test-linux-${{ matrix.arch }}
+        " > container-structure-test
+        && chmod +x container-structure-test
+        && mv container-structure-test /usr/bin/
+
     - name: Run structure tests
       if: steps.changed-files-specific.outputs.any_changed == 'true'
-      # yamllint disable-line rule:line-length
-      uses: plexsystems/container-structure-test-action@c0a028aa96e8e82ae35be556040340cbb3e280ca  # v0.3.0
-      with:
-        image: ${{ env.IMAGE }}
-        config: .github/.container-structure-test-config.yaml
+      run: >-
+        container-structure-test test
+        -c .github/.spacelift-runners-container-structure-test-config.yaml
+        -i ${{ env.IMAGE }}
 
     - name: Dive - check image for waste files
       if: steps.changed-files-specific.outputs.any_changed == 'true'

--- a/.github/workflows/build-image-test.yaml
+++ b/.github/workflows/build-image-test.yaml
@@ -46,9 +46,6 @@ jobs:
         context: .
         build-args: |
           INSTALL_ALL=true
-        # yamllint disable-line rule:line-length
-        platforms: >-  # Only one allowed here, see https://github.com/docker/buildx/issues/59#issuecomment-1433097926
-          linux/${{ matrix.arch }}
         push: false
         load: true
         tags: |

--- a/.github/workflows/build-image-test.yaml
+++ b/.github/workflows/build-image-test.yaml
@@ -83,7 +83,9 @@ jobs:
         env.CST_VERSION }}/container-structure-test-linux-${{ matrix.arch }}"
         > container-structure-test
         && chmod +x container-structure-test
-        && mv container-structure-test /usr/bin/
+        && mv container-structure-test $HOME/bin/
+        && echo $HOME/bin/ >> $GITHUB_PATH
+
 
     - name: Run structure tests
       if: steps.changed-files-specific.outputs.any_changed == 'true'

--- a/.github/workflows/build-image-test.yaml
+++ b/.github/workflows/build-image-test.yaml
@@ -78,10 +78,10 @@ jobs:
         # renovate: datasource=github-releases depName=container-structure-test lookupName=GoogleContainerTools/container-structure-test
         CST_VERSION: 1.19.3
         CST_REPO: github.com/GoogleContainerTools/container-structure-test
-      run: |
+      run: >-
         curl -L "https://${{ env.CST_REPO }}/releases/download/v${{
-        env.CST_VERSION }}/container-structure-test-linux-${{ matrix.arch
-        }}" > container-structure-test
+        env.CST_VERSION }}/container-structure-test-linux-${{ matrix.arch }}"
+        > container-structure-test
         && chmod +x container-structure-test
         && mv container-structure-test /usr/bin/
 

--- a/.github/workflows/build-image-test.yaml
+++ b/.github/workflows/build-image-test.yaml
@@ -106,7 +106,7 @@ jobs:
     - name: Dive - check image for waste files
       if: steps.changed-files-specific.outputs.any_changed == 'true'
       # yamllint disable-line rule:line-length
-      uses: MaxymVlasov/dive-action@e49d301dc06c52fe877e90df531adc174925c06d  # v1.0.1+ ARM64 support
+      uses: MaxymVlasov/dive-action@4c86ec8e41e935c9a3df9ebcf45ca6fa637c05f8  # v1.0.1+ ARM64 support
       with:
         image: ${{ env.IMAGE }}
         config-file: ${{ github.workspace }}/.github/.dive-ci.yaml

--- a/.github/workflows/build-image-test.yaml
+++ b/.github/workflows/build-image-test.yaml
@@ -11,8 +11,10 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        arch: [amd64, arm64]
+        os:
+        - ubuntu-latest
+        - ubuntu-24.04-arm
+
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -31,13 +33,6 @@ jobs:
           tools/entrypoint.sh
           .github/workflows/build-image-test.yaml
           tools/*.sh
-
-    - name: Set up QEMU
-      if: matrix.os != 'ubuntu-latest' || matrix.arch != 'amd64'
-      # yamllint disable-line rule:line-length
-      uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a  # v3.3.0
-      with:
-        platforms: arm64
 
     - name: Set up Docker Buildx
       # yamllint disable-line rule:line-length
@@ -86,7 +81,6 @@ jobs:
       if: >-
         steps.changed-files-specific.outputs.any_changed == 'true'
         && matrix.os == 'ubuntu-latest'
-        && matrix.arch == 'amd64'
       # yamllint disable-line rule:line-length
       uses: docker/build-push-action@67a2d409c0a876cbe6b11854e3e25193efe4e62d  # v6.12.0
       with:

--- a/.github/workflows/build-image-test.yaml
+++ b/.github/workflows/build-image-test.yaml
@@ -87,6 +87,9 @@ jobs:
         && mv container-structure-test $HOME/bin/
         && echo $HOME/bin/ >> $GITHUB_PATH
 
+    - name: Check file existence and list directory
+      run: ls -al ${{ github.workspace }}/.github
+
 
     - name: Run structure tests
       if: steps.changed-files-specific.outputs.any_changed == 'true'

--- a/.github/workflows/build-image-test.yaml
+++ b/.github/workflows/build-image-test.yaml
@@ -13,6 +13,10 @@ env:
 
 jobs:
   build:
+    permissions:
+      # for MaxymVlasov/dive-action to write comments to PRs
+      pull-requests: write
+
     strategy:
       matrix:
         arch:

--- a/.github/workflows/build-image-test.yaml
+++ b/.github/workflows/build-image-test.yaml
@@ -92,7 +92,7 @@ jobs:
       if: steps.changed-files-specific.outputs.any_changed == 'true'
       run: >-
         container-structure-test test
-        -c .github/.spacelift-runners-container-structure-test-config.yaml
+        -c ${{ github.workspace }}/.github/.spacelift-runners-container-structure-test-config.yaml
         -i ${{ env.IMAGE }}
 
     - name: Dive - check image for waste files

--- a/.github/workflows/build-image-test.yaml
+++ b/.github/workflows/build-image-test.yaml
@@ -102,7 +102,7 @@ jobs:
     - name: Dive - check image for waste files
       if: steps.changed-files-specific.outputs.any_changed == 'true'
       # yamllint disable-line rule:line-length
-      uses: MaxymVlasov/dive-action@fbf11e0550ed9c0b1e7ffdf86abf9dfabd2aca00  # v1.0.1+ ARM64 support
+      uses: MaxymVlasov/dive-action@3fd368cb761ec0110e89b9600616e8b64b0e4c6c  # v1.0.1+ ARM64 support
       with:
         image: ${{ env.IMAGE }}
         config-file: ${{ github.workspace }}/.github/.dive-ci.yaml

--- a/.github/workflows/build-image-test.yaml
+++ b/.github/workflows/build-image-test.yaml
@@ -106,7 +106,7 @@ jobs:
     - name: Dive - check image for waste files
       if: steps.changed-files-specific.outputs.any_changed == 'true'
       # yamllint disable-line rule:line-length
-      uses: MaxymVlasov/dive-action@4c86ec8e41e935c9a3df9ebcf45ca6fa637c05f8  # v1.0.1+ ARM64 support
+      uses: MaxymVlasov/dive-action@b6a02b38f0f309e8817199658eab090d4f0f93ce  # v1.1.0
       with:
         image: ${{ env.IMAGE }}
         config-file: ${{ github.workspace }}/.github/.dive-ci.yaml

--- a/.github/workflows/build-image-test.yaml
+++ b/.github/workflows/build-image-test.yaml
@@ -80,8 +80,8 @@ jobs:
         CST_REPO: github.com/GoogleContainerTools/container-structure-test
       run: |
         curl -L "https://${{ env.CST_REPO }}/releases/download/v${{
-        env.CST_VERSION }}/container-structure-test-linux-${{ matrix.arch }}"
-        > container-structure-test
+        env.CST_VERSION }}/container-structure-test-linux-${{ matrix.arch
+        }}" > container-structure-test
         && chmod +x container-structure-test
         && mv container-structure-test /usr/bin/
 

--- a/.github/workflows/build-image-test.yaml
+++ b/.github/workflows/build-image-test.yaml
@@ -102,7 +102,7 @@ jobs:
     - name: Dive - check image for waste files
       if: steps.changed-files-specific.outputs.any_changed == 'true'
       # yamllint disable-line rule:line-length
-      uses: MaxymVlasov/dive-action@3fd368cb761ec0110e89b9600616e8b64b0e4c6c  # v1.0.1+ ARM64 support
+      uses: MaxymVlasov/dive-action@e49d301dc06c52fe877e90df531adc174925c06d  # v1.0.1+ ARM64 support
       with:
         image: ${{ env.IMAGE }}
         config-file: ${{ github.workspace }}/.github/.dive-ci.yaml

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -16,9 +16,6 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-    - name: Set up QEMU
-      # yamllint disable-line rule:line-length
-      uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a  # v3.3.0
     - name: Set up Docker Buildx
       # yamllint disable-line rule:line-length
       uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5  # v3.8.0


### PR DESCRIPTION
### Description of your changes

This should speed up docker image build process during tests and wipe out one of dependencies