### PR TITLE
chore: Add OSSF badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Github tag](https://img.shields.io/github/tag/antonbabenko/pre-commit-terraform.svg)](https://github.com/antonbabenko/pre-commit-terraform/releases) ![maintenance status](https://img.shields.io/maintenance/yes/2025.svg) [![Help Contribute to Open Source](https://www.codetriage.com/antonbabenko/pre-commit-terraform/badges/users.svg)](https://www.codetriage.com/antonbabenko/pre-commit-terraform)
 [![CI/CD Badge]][CI/CD]
 [![Codecov Badge]][Codecov]
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/antonbabenko/pre-commit-terraform/badge)](https://scorecard.dev/viewer/?uri=github.com/antonbabenko/pre-commit-terraform)
 
 [CI/CD Badge]:
 https://github.com/antonbabenko/pre-commit-terraform/actions/workflows/ci-cd.yml/badge.svg?branch=master


### PR DESCRIPTION
This badge include automatic checks which, when click on it, show repo security state, similar to `Security` tab in Github repo.

It less strict than #785, where part of checks should be filled manually


Relates #712

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added OpenSSF Scorecard badge to README to showcase project's security assessment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->