### PR TITLE
chore: Make codecov badge green in README

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -14,7 +14,7 @@ comment:
   require_changes: true
 
 coverage:
-  range: 100..100
+  range: 96..100
   status:
     patch:
       default:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -14,7 +14,7 @@ comment:
   require_changes: true
 
 coverage:
-  range: 96..100
+  range: 100..100
   status:
     patch:
       default:

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ https://github.com/antonbabenko/pre-commit-terraform/actions/workflows/ci-cd.yml
 https://github.com/antonbabenko/pre-commit-terraform/actions/workflows/ci-cd.yml
 
 [Codecov Badge]:
-https://codecov.io/gh/antonbabenko/pre-commit-terraform/branch/master/graph/badge.svg?flags[]=pytest
-[Codecov]: https://app.codecov.io/gh/antonbabenko/pre-commit-terraform?flags[]=pytest
+https://codecov.io/gh/antonbabenko/pre-commit-terraform/branch/master/graph/badge.svg?flag=pytest
+[Codecov]: https://app.codecov.io/gh/antonbabenko/pre-commit-terraform?flag=pytest
 
 [![SWUbanner](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/banner-direct.svg)](https://github.com/vshymanskyy/StandWithUkraine/blob/main/docs/README.md)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ https://github.com/antonbabenko/pre-commit-terraform/actions/workflows/ci-cd.yml
 
 [Codecov Badge]:
 https://codecov.io/gh/antonbabenko/pre-commit-terraform/branch/master/graph/badge.svg?flag=pytest
-[Codecov]: https://app.codecov.io/gh/antonbabenko/pre-commit-terraform?flag=pytest
+[Codecov]: https://app.codecov.io/gh/antonbabenko/pre-commit-terraform?flags[]=pytest
 
 [![SWUbanner](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/banner-direct.svg)](https://github.com/vshymanskyy/StandWithUkraine/blob/main/docs/README.md)
 


### PR DESCRIPTION
### Description of your changes

We already know that there will be no 100% because of how it interprets MyPy checks, even if they're 100% actually.
Also, I found that there was an attempt to set up badge only for `pytest`, but the option was specified wrong, so I fixed that.
https://docs.codecov.com/docs/status-badges

![image](https://github.com/user-attachments/assets/f49bd70c-d752-47a2-b384-ba6d82f35603)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Codecov badge and reference URLs in README
  - Modified URL parameter from `flags[]` to `flag` for Codecov links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->