### PR TITLE
fix(`terraform_docs`): Allow having whitespaces in path to `.terraform-docs.yaml` config file

### DIFF
--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -145,8 +145,13 @@ function terraform_docs {
     had_config_flag=true
     local config_file=${args#*--config}
     config_file=${config_file#*=}
-    config_file=${config_file% --*}
-    args=${args/--config=$config_file/}
+    # If there are more parameters after config path, trim until --
+    if [[ $config_file == *" --"* ]]; then
+      config_file=${config_file%% --*}
+    fi
+    # Trim trailing whitespace but preserve internal spaces
+
+    config_file="${config_file%"${config_file##*[![:space:]]}"}" args=${args/--config=$config_file/}
 
     # Prioritize `.terraform-docs.yml` `output.file` over
     # `--hook-config=--path-to-file=` if it set
@@ -234,7 +239,7 @@ function terraform_docs {
     fi
     local config_options=""
     if [[ $had_config_flag == true ]]; then
-        config_options="--config=$config_file"
+      config_options="--config=$config_file"
     fi
     # shellcheck disable=SC2086
     terraform-docs --output-mode="$output_mode" --output-file="$output_file" $tf_docs_formatter "$config_options" $args ./ > /dev/null

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -87,7 +87,7 @@ function terraform_docs {
   local add_to_existing=false
   local create_if_not_exist=false
   local use_standard_markers=true
-  local had_config_flag=false
+  local have_config_flag=false
 
   IFS=";" read -r -a configs <<< "$hook_config"
 
@@ -142,7 +142,7 @@ function terraform_docs {
     local tf_docs_formatter="md"
 
   else
-    had_config_flag=true
+    have_config_flag=true
     local config_file=${args#*--config}
     config_file=${config_file#*=}
     # If there are more parameters after config path, trim until --
@@ -238,7 +238,7 @@ function terraform_docs {
       [[ ! $have_marker ]] && popd > /dev/null && continue
     fi
     local config_options=""
-    if [[ $had_config_flag == true ]]; then
+    if [[ $have_config_flag == true ]]; then
       config_options="--config=$config_file"
     fi
     # shellcheck disable=SC2086

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -eo pipefail
-
 # globals variables
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 readonly SCRIPT_DIR
@@ -233,13 +232,12 @@ function terraform_docs {
       have_marker=$(grep -o "$insertion_marker_begin" "$output_file") || unset have_marker
       [[ ! $have_marker ]] && popd > /dev/null && continue
     fi
+    local config_options=""
     if [[ $had_config_flag == true ]]; then
-    # shellcheck disable=SC2086
-    terraform-docs --output-mode="$output_mode" --output-file="$output_file" $tf_docs_formatter --config="$config_file" $args ./ > /dev/null
-    else
-    # shellcheck disable=SC2086
-    terraform-docs --output-mode="$output_mode" --output-file="$output_file" $tf_docs_formatter $config_arg $args ./ > /dev/null
+        config_options="--config=$config_file"
     fi
+    # shellcheck disable=SC2086
+    terraform-docs --output-mode="$output_mode" --output-file="$output_file" $tf_docs_formatter "$config_options" $args ./ > /dev/null
 
     popd > /dev/null
   done

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail
+
 # globals variables
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 readonly SCRIPT_DIR
@@ -143,15 +144,17 @@ function terraform_docs {
 
   else
     have_config_flag=true
-    local config_file=${args#*--config}
-    config_file=${config_file#*=}
-    # If there are more parameters after config path, trim until --
-    if [[ $config_file == *" --"* ]]; then
-      config_file=${config_file%% --*}
-    fi
-    # Trim trailing whitespace but preserve internal spaces
-
-    config_file="${config_file%"${config_file##*[![:space:]]}"}" args=${args/--config=$config_file/}
+    # Enable extended pattern matching operators
+    shopt -qp extglob || EXTGLOB_IS_NOT_SET=true && shopt -s extglob
+    # Trim any args before the `--config` arg value
+    local config_file=${args##*--config@(+([[:space:]])|=)}
+    # Trim any trailing spaces and args (if any)
+    config_file="${config_file%%+([[:space:]])?(--*)}"
+    # Trim `--config` arg and its value from original args as we will
+    # pass `--config` separately to allow whitespaces in its value
+    args=${args/--config@(+([[:space:]])|=)$config_file*([[:space:]])/}
+    # Restore state of `extglob` if we changed it
+    [[ $EXTGLOB_IS_NOT_SET ]] && shopt -u extglob
 
     # Prioritize `.terraform-docs.yml` `output.file` over
     # `--hook-config=--path-to-file=` if it set
@@ -237,10 +240,8 @@ function terraform_docs {
       have_marker=$(grep -o "$insertion_marker_begin" "$output_file") || unset have_marker
       [[ ! $have_marker ]] && popd > /dev/null && continue
     fi
-    local config_options=""
-    if [[ $have_config_flag == true ]]; then
-      config_options="--config=$config_file"
-    fi
+    local config_options
+    [[ $have_config_flag == true ]] && config_options="--config=$config_file"
     # shellcheck disable=SC2086
     terraform-docs --output-mode="$output_mode" --output-file="$output_file" $tf_docs_formatter "$config_options" $args ./ > /dev/null
 


### PR DESCRIPTION
Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

This resolves an issue if the path to the config file for terraform-docs has multiple paths.

### How can we test changes

```
terraform_docs.sh --hook-config="--custom-marker-begin=// BEGIN_TF_DOCS" --hook-config="--custom-marker-end=// END_TF_DOCS" --args=--config="path with spaces/.terraform-docs.yml" ./deployment/main.tf
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
	- Enhanced configuration handling for Terraform documentation generation.
	- Improved flexibility in managing Terraform documentation command execution.
	- Refined logic for processing configuration flags and arguments, allowing for whitespace in values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->