### PR TITLE
chore: Fix path to HTML coverage report during local `tox` run

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -94,7 +94,7 @@ commands_post =
       browse_cmd = shlex.join(("python3", "-Im", "webbrowser", html_url)); \
       serve_cmd = shlex.join((\
         "python3", "-Im", "http.server", \
-        "--directory", f"{cov_html_report_dir}", "0", \
+        "--directory", str(cov_html_report_dir), "0", \
       )); \
       print(f"\nTo open the HTML coverage report, run\n\n\
       \t\{browse_cmd !s\}\n");\

--- a/tox.ini
+++ b/tox.ini
@@ -94,7 +94,7 @@ commands_post =
       browse_cmd = shlex.join(("python3", "-Im", "webbrowser", html_url)); \
       serve_cmd = shlex.join((\
         "python3", "-Im", "http.server", \
-        "--directory", "cov_html_report_dir", "0", \
+        "--directory", f"{cov_html_report_dir}", "0", \
       )); \
       print(f"\nTo open the HTML coverage report, run\n\n\
       \t\{browse_cmd !s\}\n");\

--- a/tox.ini
+++ b/tox.ini
@@ -90,6 +90,7 @@ commands_post =
       cov_html_reports or sys.exit(); \
       cov_html_report_dir = pathlib.Path(cov_html_reports[-1]); \
       index_file = cov_html_report_dir / "index.html";\
+      index_file.exists() or sys.exit(); \
       html_url = f"file://\{index_file\}";\
       browse_cmd = shlex.join(("python3", "-Im", "webbrowser", html_url)); \
       serve_cmd = shlex.join((\


### PR DESCRIPTION
```bash
# Prev:
python3 -Im http.server --directory cov_html_report_dir 0

# Now:
python3 -Im http.server --directory /full/path/to/pre-commit-terraform/.tox/py/tmp/htmlcov 0
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Improved error handling for HTML coverage report generation.
	- Updated configuration for accurate referencing of coverage report directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->