### PR TITLE
chore: Suppress insufficient coverage `pytest` warning

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ commands =
     {[python-cli-options]byte-errors} \
     {[python-cli-options]max-isolation} \
     {[python-cli-options]warnings-to-errors} \
+    -W 'ignore:Coverage failure::pytest_cov.plugin' \
     -m pytest \
       {tty:--color=yes} \
       {posargs:--cov-report=html:{envtmpdir}{/}htmlcov{/}}


### PR DESCRIPTION
This is emitted by `pytest-cov` [[1]] and is turned into an error by the default `-Werror` passed to Python, not the `filterwarnings` setting within the `pytest`.

The patch selectively suppresses the warning so there's nothing to turn into an error in the first place. Insufficient coverage still marks the test session as failed as it's supposed to.

[1]: https://github.com/pytest-dev/pytest-cov/issues/675

### Description of your changes

$sbj. This is a workaround for a `pytest-cov` imperfection.


### How can we test changes

`tox -qq -- tests/pytest/_cli_test.py::test_app_exit -qq` should not show a traceback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated test configuration to suppress specific coverage-related warnings during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->