### PR TITLE
fix: Parallelism CPU calculation inside Kubernetes and Docker with limits

### DIFF
--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -188,6 +188,11 @@ function common::is_hook_run_on_whole_repo {
 
 #######################################################################
 # Get the number of CPU logical cores available for pre-commit to use
+
+# CPU quota should be calculated as `cpu.cfs_quota_us / cpu.cfs_period_us`
+# For K8s see: https://docs.kernel.org/scheduler/sched-bwc.html
+# For Docker see: https://docs.docker.com/engine/containers/resource_constraints/#configure-the-default-cfs-scheduler
+#
 # Arguments:
 #  parallelism_ci_cpu_cores (string) Used in edge cases when number of
 #    CPU cores can't be derived automatically
@@ -197,12 +202,11 @@ function common::is_hook_run_on_whole_repo {
 function common::get_cpu_num {
   local -r parallelism_ci_cpu_cores=$1
 
+  local cpu_quota cpu_period cpu_num
+
   if [[ -f /sys/fs/cgroup/cpu/cpu.cfs_quota_us &&
     ! -f /proc/sys/fs/binfmt_misc/WSLInterop ]]; then # WSL have cfs_quota_us, but WSL should be checked as usual Linux host
     # Inside K8s pod or DinD in K8s
-    local cpu_quota cpu_period cpu_num
-    # CPU quota should be calculated as `cpu.cfs_quota_us / cpu.cfs_period_us`
-    # See: https://docs.kernel.org/scheduler/sched-bwc.html
     cpu_quota=$(< /sys/fs/cgroup/cpu/cpu.cfs_quota_us)
     cpu_period=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us 2> /dev/null || echo "$cpu_quota")
 
@@ -242,16 +246,17 @@ function common::get_cpu_num {
 
   if [[ -f /sys/fs/cgroup/cpu.max ]]; then
     # Inside Linux (Docker?) container
-    local millicpu
-    millicpu=$(cut -d' ' -f1 /sys/fs/cgroup/cpu.max)
+    cpu_quota=$(cut -d' ' -f1 /sys/fs/cgroup/cpu.max)
+    cpu_period=$(cut -d' ' -f2 /sys/fs/cgroup/cpu.max)
 
-    if [[ $millicpu == max ]]; then
+    if [[ $cpu_quota == max || $cpu_period -lt 1 ]]; then
       # No limits
       nproc 2> /dev/null || echo 1
       return
     fi
 
-    echo $((millicpu / 1000))
+    cpu_num=$((cpu_quota / cpu_period))
+    [[ $cpu_num -lt 1 ]] && echo 1 || echo $cpu_num
     return
   fi
 

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -197,12 +197,12 @@ function common::is_hook_run_on_whole_repo {
 function common::get_cpu_num {
   local -r parallelism_ci_cpu_cores=$1
 
-  local cpu_quota cpu_period cpu_num
-  local millicpu
-
   if [[ -f /sys/fs/cgroup/cpu/cpu.cfs_quota_us &&
     ! -f /proc/sys/fs/binfmt_misc/WSLInterop ]]; then # WSL have cfs_quota_us, but WSL should be checked as usual Linux host
     # Inside K8s pod or DinD in K8s
+    local cpu_quota cpu_period cpu_num
+    # CPU quota should be calculated as `cpu.cfs_quota_us / cpu.cfs_period_us`
+    # See: https://docs.kernel.org/scheduler/sched-bwc.html
     cpu_quota=$(< /sys/fs/cgroup/cpu/cpu.cfs_quota_us)
     cpu_period=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us 2> /dev/null || echo "$cpu_quota")
 
@@ -242,6 +242,7 @@ function common::get_cpu_num {
 
   if [[ -f /sys/fs/cgroup/cpu.max ]]; then
     # Inside Linux (Docker?) container
+    local millicpu
     millicpu=$(cut -d' ' -f1 /sys/fs/cgroup/cpu.max)
 
     if [[ $millicpu == max ]]; then

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -188,7 +188,7 @@ function common::is_hook_run_on_whole_repo {
 
 #######################################################################
 # Get the number of CPU logical cores available for pre-commit to use
-
+#
 # CPU quota should be calculated as `cpu.cfs_quota_us / cpu.cfs_period_us`
 # For K8s see: https://docs.kernel.org/scheduler/sched-bwc.html
 # For Docker see: https://docs.docker.com/engine/containers/resource_constraints/#configure-the-default-cfs-scheduler

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -204,7 +204,7 @@ function common::get_cpu_num {
     ! -f /proc/sys/fs/binfmt_misc/WSLInterop ]]; then # WSL have cfs_quota_us, but WSL should be checked as usual Linux host
     # Inside K8s pod or DinD in K8s
     cpu_quota=$(< /sys/fs/cgroup/cpu/cpu.cfs_quota_us)
-    cpu_period=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us || echo "$cpu_quota")
+    cpu_period=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us 2> /dev/null || echo "$cpu_quota")
 
     if [[ $cpu_quota -eq -1 || $cpu_period -lt 1 ]]; then
       # K8s no limits or in DinD

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -236,11 +236,7 @@ function common::get_cpu_num {
 
     cpu_period=$(< /sys/fs/cgroup/cpu/cpu.cfs_period_us)
     cpu_num=$((cpu_quota / cpu_period))
-    if ((cpu_num < 1)); then
-      echo 1
-    else
-      echo $cpu_num
-    fi
+    [[ $cpu_num -lt 1 ]] && echo 1 || echo $cpu_num
     return
   fi
 


### PR DESCRIPTION
The value of /sys/fs/cgroup/cpu/cpu.cfs_quota_us is not in milliseconds and cannot be simply divided by 1000 to determine the CPU limit. As per kernel documentation[^1], the cpu limit can be determined by dividing that value by /sys/fs/cgroup/cpu/cpu.cfs_period_us.

[^1]: https://docs.kernel.org/scheduler/sched-bwc.html

<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [X] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123456":
-->

Fixes the max CPU calculation when run inside kubernetes.

<!-- Fixes # -->

### How can we test changes

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

1. Run pre-commit inside kubernetes pod with CPU limit N.
2. Without specifying `--parallelism-limit`, confirm that pre-commit is only spawning N-1 concurrent processes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
    - Improved CPU core detection mechanism for more accurate resource allocation.
    - Enhanced compatibility with cgroup-based environments.
    - Updated logic for calculating CPU cores based on new variables for quota and period.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->