### PR TITLE
chore: Pin action tag

### DIFF
--- a/.github/workflows/reusable-tox.yml
+++ b/.github/workflows/reusable-tox.yml
@@ -407,6 +407,7 @@ jobs:
       if: >-
         !cancelled()
         && steps.tox-run.outputs.test-result-files != ''
+      # yamllint disable-line rule:line-length
       uses: codecov/test-results-action@4e79e65778be1cecd5df25e14af1eafb6df80ea9  # v1.0.2
       with:
         disable_search: true

--- a/.github/workflows/reusable-tox.yml
+++ b/.github/workflows/reusable-tox.yml
@@ -407,10 +407,7 @@ jobs:
       if: >-
         !cancelled()
         && steps.tox-run.outputs.test-result-files != ''
-      # FIXME: revert to v1 once Codecov releases v1.0.2 of their action.
-      # Ref: https://github.com/codecov/test-results-action/issues/108.
-      # uses: codecov/test-results-action@v1
-      uses: codecov/test-results-action@4e79e65778be1cecd5df25e14af1eafb6df80ea9
+      uses: codecov/test-results-action@4e79e65778be1cecd5df25e14af1eafb6df80ea9  # v1.0.2
       with:
         disable_search: true
         fail_ci_if_error: >-


### PR DESCRIPTION
Tag was realeased

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow to use version 1.0.2 of the Codecov test results action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->