### PR TITLE
fix(`terraform_docs`): Fix bug introduced in `v1.97.2`

### DIFF
--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -52,7 +52,9 @@ function common::initialize {
 function common::parse_cmdline {
   # common global arrays.
   # Populated via `common::parse_cmdline` and can be used inside hooks' functions
-  ARGS=() HOOK_CONFIG=() FILES=()
+  ARGS=()
+  HOOK_CONFIG=()
+  FILES=()
   # Used inside `common::terraform_init` function
   TF_INIT_ARGS=()
   # Used inside `common::export_provided_env_vars` function

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -160,7 +160,7 @@ function terraform_docs {
     # `--hook-config=--path-to-file=` if it set
     local config_output_file
     # Get latest non-commented `output.file` from `.terraform-docs.yml`
-    config_output_file=$(grep -A1000 -e '^output:$' "$config_file" | grep -E '^[[:space:]]+file:' | tail -n 1) || true
+    config_output_file=$(grep -A1000 -e '^output:$' "$config_file" 2> /dev/null | grep -E '^[[:space:]]+file:' | tail -n 1) || true
 
     if [[ $config_output_file ]]; then
       # Extract filename from `output.file` line
@@ -176,7 +176,7 @@ function terraform_docs {
 
     # Use `.terraform-docs.yml` `output.mode` if it set
     local config_output_mode
-    config_output_mode=$(grep -A1000 -e '^output:$' "$config_file" | grep -E '^[[:space:]]+mode:' | tail -n 1) || true
+    config_output_mode=$(grep -A1000 -e '^output:$' "$config_file" 2> /dev/null | grep -E '^[[:space:]]+mode:' | tail -n 1) || true
     if [[ $config_output_mode ]]; then
       # Extract mode from `output.mode` line
       output_mode=$(echo "$config_output_mode" | awk -F':' '{print $2}' | tr -d '[:space:]"' | tr -d "'")
@@ -240,10 +240,19 @@ function terraform_docs {
       have_marker=$(grep -o "$insertion_marker_begin" "$output_file") || unset have_marker
       [[ ! $have_marker ]] && popd > /dev/null && continue
     fi
-    local config_options
-    [[ $have_config_flag == true ]] && config_options="--config=$config_file"
-    # shellcheck disable=SC2086
-    terraform-docs --output-mode="$output_mode" --output-file="$output_file" $tf_docs_formatter "$config_options" $args ./ > /dev/null
+
+    local tfdocs_cmd=(
+      terraform-docs
+        --output-mode="$output_mode"
+        --output-file="$output_file"
+        $tf_docs_formatter
+        $args
+    )
+    if [[ $have_config_flag == true ]]; then
+      ${tfdocs_cmd[@]} "--config=$config_file" ./ > /dev/null
+    else
+      ${tfdocs_cmd[@]} ./ > /dev/null
+    fi
 
     popd > /dev/null
   done

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -241,6 +241,8 @@ function terraform_docs {
       [[ ! $have_marker ]] && popd > /dev/null && continue
     fi
 
+    # shellcheck disable=SC2206
+    # Need to pass $tf_docs_formatter and $args as separate arguments, not as single string
     local tfdocs_cmd=(
       terraform-docs
         --output-mode="$output_mode"
@@ -249,9 +251,9 @@ function terraform_docs {
         $args
     )
     if [[ $have_config_flag == true ]]; then
-      ${tfdocs_cmd[@]} "--config=$config_file" ./ > /dev/null
+      "${tfdocs_cmd[@]}" "--config=$config_file" ./ > /dev/null
     else
-      ${tfdocs_cmd[@]} ./ > /dev/null
+      "${tfdocs_cmd[@]}" ./ > /dev/null
     fi
 
     popd > /dev/null

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -245,10 +245,10 @@ function terraform_docs {
     # Need to pass $tf_docs_formatter and $args as separate arguments, not as single string
     local tfdocs_cmd=(
       terraform-docs
-        --output-mode="$output_mode"
-        --output-file="$output_file"
-        $tf_docs_formatter
-        $args
+      --output-mode="$output_mode"
+      --output-file="$output_file"
+      $tf_docs_formatter
+      $args
     )
     if [[ $have_config_flag == true ]]; then
       "${tfdocs_cmd[@]}" "--config=$config_file" ./ > /dev/null


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [x] This PR enhances existing functionality.

### Description of your changes

* Fix bug introduced via #796 by passing config file only when it is defined
* While here make array declarations in `common::parse_cmdline` in `hooks/_common.sh` compliant with Bash v3
* While here suppress error outputs from `grep` for non-existing config file in `hooks/terraform_docs.sh` where error output makes no sense

Fixes #796

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved global variable initialization for enhanced readability.
	- Enhanced error suppression and restructured command execution, leading to cleaner script output and more maintainable execution logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->