### PR TITLE
chore(`yamllint`): Allow longer lines to avoid unneeded linter disabling

### DIFF
--- a/.github/.container-structure-test-config.yaml
+++ b/.github/.container-structure-test-config.yaml
@@ -137,7 +137,6 @@ commandTests:
 
 fileExistenceTests:
 - name: terrascan init
-  # yamllint disable-line rule:line-length
   path: >-
     /root/.terrascan/pkg/policies/opa/rego/github/github_repository/privateRepoEnabled.rego
   shouldExist: true

--- a/.github/workflows/build-image-test.yaml
+++ b/.github/workflows/build-image-test.yaml
@@ -40,7 +40,6 @@ jobs:
 
     - name: Get changed Docker related files
       id: changed-files-specific
-      # yamllint disable-line rule:line-length
       uses: tj-actions/changed-files@d6e91a2266cdb9d62096cebf1e8546899c6aa18f  # v45.0.6
       with:
         files: |
@@ -59,13 +58,11 @@ jobs:
         >> $GITHUB_ENV
 
     - name: Set up Docker Buildx
-      # yamllint disable-line rule:line-length
       uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5  # v3.8.0
       if: steps.changed-files-specific.outputs.any_changed == 'true'
 
     - name: Build if Dockerfile changed
       if: steps.changed-files-specific.outputs.any_changed == 'true'
-      # yamllint disable-line rule:line-length
       uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991  # v6.13.0
       with:
         context: .
@@ -105,7 +102,6 @@ jobs:
 
     - name: Dive - check image for waste files
       if: steps.changed-files-specific.outputs.any_changed == 'true'
-      # yamllint disable-line rule:line-length
       uses: MaxymVlasov/dive-action@b6a02b38f0f309e8817199658eab090d4f0f93ce  # v1.1.0
       with:
         image: ${{ env.IMAGE }}
@@ -118,7 +114,6 @@ jobs:
       if: >-
         steps.changed-files-specific.outputs.any_changed == 'true'
         && matrix.os == 'ubuntu-latest'
-      # yamllint disable-line rule:line-length
       uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991  # v6.13.0
       with:
         context: .

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -24,10 +24,8 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
     - name: Set up Docker Buildx
-      # yamllint disable-line rule:line-length
       uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5  # v3.8.0
     - name: Login to GitHub Container Registry
-      # yamllint disable-line rule:line-length
       uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567  # v3.3.0
       with:
         registry: ghcr.io
@@ -47,12 +45,10 @@ jobs:
       run: >-
         echo "IMAGE_REPO=ghcr.io/${GITHUB_REPOSITORY@L}" >> $GITHUB_ENV
     - name: Set up Docker Buildx
-      # yamllint disable-line rule:line-length
       uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5  # v3.8.0
 
     - name: Build and Push release
       if: github.event_name != 'schedule'
-      # yamllint disable-line rule:line-length
       uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991  # v6.13.0
       with:
         context: .
@@ -70,7 +66,6 @@ jobs:
 
     - name: Build and Push nightly
       if: github.event_name == 'schedule'
-      # yamllint disable-line rule:line-length
       uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991  # v6.13.0
       with:
         context: .

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -109,12 +109,10 @@ jobs:
 
     steps:
     - name: Switch to using Python 3.13 by default
-      # yamllint disable-line rule:line-length
       uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38  # v5.4.0
       with:
         python-version: 3.13
     - name: Check out src from Git
-      # yamllint disable-line rule:line-length
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       with:
         fetch-depth: 0
@@ -167,7 +165,6 @@ jobs:
         echo "dir=$(python -m pip cache dir)" >> "${GITHUB_OUTPUT}"
       shell: bash
     - name: Set up pip cache
-      # yamllint disable-line rule:line-length
       uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57  # v4.2.0
       with:
         path: ${{ steps.pip-cache-dir.outputs.dir }}
@@ -274,13 +271,11 @@ jobs:
 
     steps:
     - name: Switch to using Python 3.13
-      # yamllint disable-line rule:line-length
       uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38  # v5.4.0
       with:
         python-version: 3.13
 
     - name: Grab the source from Git
-      # yamllint disable-line rule:line-length
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       with:
         fetch-depth: 0
@@ -309,7 +304,6 @@ jobs:
       run: >-
         echo "dir=$(python -m pip cache dir)" >> "${GITHUB_OUTPUT}"
     - name: Set up pip cache
-      # yamllint disable-line rule:line-length
       uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57  # v4.2.0
       with:
         path: ${{ steps.pip-cache-dir.outputs.dir }}
@@ -375,7 +369,6 @@ jobs:
         >> "${GITHUB_OUTPUT}"
       working-directory: dist
     - name: Store the distribution packages
-      # yamllint disable-line rule:line-length
       uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
       with:
         name: >-
@@ -522,7 +515,6 @@ jobs:
 
     steps:
     - name: Decide whether the needed jobs succeeded or failed
-      # yamllint disable-line rule:line-length
       uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # v1.2.2
       with:
         jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,7 +47,6 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      # yamllint disable-line rule:line-length
       uses: github/codeql-action/init@dd746615b3b9d728a6a37ca2045b68ca76d4841a  # v3.28.8
       with:
         languages: ${{ matrix.language }}
@@ -60,7 +59,6 @@ jobs:
     # If this step fails, then you should remove it and run the build
     # manually (see below)
     - name: Autobuild
-      # yamllint disable-line rule:line-length
       uses: github/codeql-action/autobuild@dd746615b3b9d728a6a37ca2045b68ca76d4841a  # v3.28.8
 
     # ℹ️ Command-line programs to run using the OS shell.
@@ -76,7 +74,6 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      # yamllint disable-line rule:line-length
       uses: github/codeql-action/analyze@dd746615b3b9d728a6a37ca2045b68ca76d4841a  # v3.28.8
       with:
         category: /language:${{matrix.language}}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,8 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
-      # yamllint disable-line rule:line-length
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
     - name: Dependency Review
-      # yamllint disable-line rule:line-length
       uses: actions/dependency-review-action@3b139cfc5fae8b618d3eae3675e383bb1769c019  # v4.5.0

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -25,7 +25,6 @@ jobs:
     steps:
     # Please look up the latest version from
     # https://github.com/amannn/action-semantic-pull-request/releases
-    # yamllint disable-line rule:line-length
     - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017  # v5.5.3
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -55,7 +55,6 @@ jobs:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
     # Skip terraform_tflint which interferes to commit pre-commit auto-fixes
-    # yamllint disable-line rule:line-length
     - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38  # v5.4.0
       with:
         python-version: '3.9'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,6 @@ jobs:
         fetch-depth: 0
 
     - name: Release
-      # yamllint disable-line rule:line-length
       uses: cycjimmy/semantic-release-action@b1b432f13acb7768e0c8efdec416d363a57546f2  # v4.1.1
       with:
         semantic_version: 18.0.0

--- a/.github/workflows/reusable-tox.yml
+++ b/.github/workflows/reusable-tox.yml
@@ -158,7 +158,6 @@ jobs:
         Switch to using Python v${{ inputs.python-version }}
         by default
       id: python-install
-      # yamllint disable-line rule:line-length
       uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38  # v5.4.0
       with:
         python-version: ${{ inputs.python-version }}
@@ -169,14 +168,12 @@ jobs:
     - name: Grab the source from Git
       if: >-
         contains(fromJSON('["pre-commit", "spellcheck-docs"]'), inputs.toxenv)
-      # yamllint disable-line rule:line-length
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       with:
         ref: ${{ github.event.inputs.release-committish }}
     - name: Retrieve the project source from an sdist inside the GHA artifact
       if: >-
         !contains(fromJSON('["pre-commit", "spellcheck-docs"]'), inputs.toxenv)
-      # yamllint disable-line rule:line-length
       uses: re-actors/checkout-python-sdist@187f55296b0f54d88259aaaf99af32ad3647d3bc  # v2.0.0
       with:
         source-tarball-name: ${{ inputs.source-tarball-name }}
@@ -184,7 +181,6 @@ jobs:
 
     - name: Cache pre-commit.com virtualenvs
       if: inputs.toxenv == 'pre-commit'
-      # yamllint disable-line rule:line-length
       uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57  # v4.2.0
       with:
         path: ~/.cache/pre-commit
@@ -243,7 +239,6 @@ jobs:
       shell: bash
     - name: Set up pip cache
       if: fromJSON(steps.py-abi.outputs.is-stable-abi)
-      # yamllint disable-line rule:line-length
       uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57  # v4.2.0
       with:
         path: ${{ steps.pip-cache-dir.outputs.dir }}
@@ -271,7 +266,6 @@ jobs:
     - name: Download all the dists
       if: >-
         contains(fromJSON('["metadata-validation", "pytest"]'), inputs.toxenv)
-      # yamllint disable-line rule:line-length
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: ${{ inputs.dists-artifact-name }}
@@ -325,7 +319,6 @@ jobs:
       if: >-
         !cancelled()
         && steps.tox-run.outputs.test-result-files != ''
-      # yamllint disable-line rule:line-length
       uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4
       with:
         paths: >-
@@ -343,7 +336,6 @@ jobs:
         && steps.tox-run.outputs.cov-report-files != ''
         && steps.tox-run.outputs.test-result-files == ''
         && steps.tox-run.outputs.codecov-flags != 'MyPy'
-      # yamllint disable-line rule:line-length
       uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95  # v1.3.0
       with:
         badge: true
@@ -382,7 +374,6 @@ jobs:
       if: >-
         !cancelled()
         && steps.tox-run.outputs.cov-report-files != ''
-      # yamllint disable-line rule:line-length
       uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3  # v5.3.1
       with:
         disable_search: true
@@ -407,7 +398,6 @@ jobs:
       if: >-
         !cancelled()
         && steps.tox-run.outputs.test-result-files != ''
-      # yamllint disable-line rule:line-length
       uses: codecov/test-results-action@4e79e65778be1cecd5df25e14af1eafb6df80ea9  # v1.0.2
       with:
         disable_search: true

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -38,13 +38,11 @@ jobs:
 
     steps:
     - name: Checkout code
-      # yamllint disable-line rule:line-length
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       with:
         persist-credentials: false
 
     - name: Run analysis
-      # yamllint disable-line rule:line-length
       uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46  # v2.4.0
       with:
         results_file: results.sarif
@@ -69,7 +67,6 @@ jobs:
     # Upload the results as artifacts (optional). Commenting out will disable
     # uploads of run results in SARIF format to the repository Actions tab.
     - name: Upload artifact
-      # yamllint disable-line rule:line-length
       uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
       with:
         name: SARIF file
@@ -78,7 +75,6 @@ jobs:
 
     # Upload the results to GitHub's code scanning dashboard.
     - name: Upload to code-scanning
-      # yamllint disable-line rule:line-length
       uses: github/codeql-action/upload-sarif@dd746615b3b9d728a6a37ca2045b68ca76d4841a  # v3.28.8
       with:
         sarif_file: results.sarif

--- a/.yamllint
+++ b/.yamllint
@@ -8,6 +8,8 @@ rules:
     indent-sequences: false
   quoted-strings:
     required: only-when-needed
+  line-length:
+    max: 100
   truthy:
     allowed-values:
     - >-


### PR DESCRIPTION
Formatter which will be introduced later, will enforce stricter rules when it is possible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Introduced a new SSH command test that verifies version output.
- **Chores**
  - Optimized build, release, and CI workflows with updated actions and enhanced caching mechanisms.
- **Style**
  - Removed redundant linting comments and introduced a new YAML line-length rule to ensure configuration consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->