### PR TITLE
feat: Include .tfbackend files in hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -13,7 +13,7 @@
     Rewrites all Terraform configuration files to a canonical format.
   entry: hooks/terraform_fmt.sh
   language: script
-  files: (\.tf|\.tfvars)$
+  files: (\.tf|\.tfbackend|\.tfvars)$
   exclude: \.terraform/.*$
 
 - id: terraform_docs

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
   entry: hooks/infracost_breakdown.sh
   language: script
   require_serial: true
-  files: \.(tf(vars)?|hcl)$
+  files: \.(tf(backend|vars)?|hcl)$
   exclude: \.terraform/.*$
 
 - id: terraform_fmt
@@ -53,7 +53,7 @@
   require_serial: true
   entry: hooks/terraform_validate.sh
   language: script
-  files: \.(tf(vars)?|terraform\.lock\.hcl)$
+  files: \.(tf(backend|vars)?|terraform\.lock\.hcl)$
   exclude: \.terraform/.*$
 
 - id: terraform_providers_lock
@@ -71,7 +71,7 @@
   require_serial: true
   entry: hooks/terraform_tflint.sh
   language: script
-  files: (\.tf|\.tfvars)$
+  files: \.tf(backend|vars)?$
   exclude: \.terraform/.*$
 
 - id: terragrunt_fmt
@@ -114,7 +114,7 @@
     Static analysis of Terraform templates to spot potential security issues.
   require_serial: true
   entry: hooks/terraform_tfsec.sh
-  files: \.tf(vars)?$
+  files: \.tf(backend|vars)?$
   language: script
 
 - id: terraform_trivy
@@ -123,7 +123,7 @@
     Static analysis of Terraform templates to spot potential security issues.
   require_serial: true
   entry: hooks/terraform_trivy.sh
-  files: \.tf(vars)?$
+  files: \.tf(backend|vars)?$
   language: script
 
 - id: checkov

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -13,7 +13,7 @@
     Rewrites all Terraform configuration files to a canonical format.
   entry: hooks/terraform_fmt.sh
   language: script
-  files: (\.tf|\.tfbackend|\.tfvars)$
+  files: \.tf(backend|vars)?$
   exclude: \.terraform/.*$
 
 - id: terraform_docs

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -13,7 +13,7 @@
     Rewrites all Terraform configuration files to a canonical format.
   entry: hooks/terraform_fmt.sh
   language: script
-  files: \.tf(backend|vars)?$
+  files: \.tf(vars)?$
   exclude: \.terraform/.*$
 
 - id: terraform_docs


### PR DESCRIPTION
Blocked as there Upstream FR / bug: https://github.com/hashicorp/terraform/issues/36564

---

<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [x] This PR enhances existing functionality.

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123456":
-->

<!-- Fixes # -->

As per the official docs https://developer.hashicorp.com/terraform/language/backend#file:

> A backend configuration file has the contents of the backend block as top-level attributes, without the need to wrap it in another terraform or backend block:
>
> ```
> address = "demo.consul.io"
> path    = "example_app/terraform_state"
> scheme  = "https"
> ```
>
> *.backendname.tfbackend (e.g. config.consul.tfbackend) is the recommended naming pattern. Terraform will not prevent you from using other names but following this convention will help your editor understand the content and likely provide better editing experience as a result.

### How can we test changes

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Add `foo.tfbackend` (a simple HCL file, without blocks, similar to `.tfvars`), run e.g. `pre-commit run --all-files terraform_fmt`.