### PR TITLE
chore(linters): Add yamlfmt

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,8 +4,8 @@ codecov:
     wait_for_ci: false
 
   require_ci_to_pass: false
-
-  token: >-  # notsecret  # repo-scoped, upload-only, stability in fork PRs
+  # notsecret  # repo-scoped, upload-only, stability in fork PRs
+  token: >-
     7316089b-55fe-4646-b640-78d84b79d109
 
 comment:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -37,7 +37,8 @@ env:
   PYTHONIOENCODING: utf-8
   PYTHONUTF8: 1
   TOX_PARALLEL_NO_SPINNER: 1  # Disable tox's parallel run spinner animation
-  TOX_TESTENV_PASSENV: >-  # Make tox-wrapped tools see color requests
+  # Make tox-wrapped tools see color requests
+  TOX_TESTENV_PASSENV: >-
     FORCE_COLOR
     MYPY_FORCE_COLOR
     NO_COLOR
@@ -396,7 +397,8 @@ jobs:
         # `no-commit-to-branch` is skipped because it does not make sense
         # in the CI, only locally.
         # Ref: https://github.com/pre-commit/pre-commit-hooks/issues/1124
-        - >-  # only affects pre-commit, set for all for simplicity:
+        # only affects pre-commit, set for all for simplicity:
+        - >-
           SKIP=
           hadolint,
           no-commit-to-branch,
@@ -448,7 +450,8 @@ jobs:
         # NOTE: important results first.
         - 3.13
         - 3.9
-        - >-  # str
+        # str
+        - >-
           3.10
         - 3.12
         - 3.11

--- a/.github/workflows/reusable-tox.yml
+++ b/.github/workflows/reusable-tox.yml
@@ -85,7 +85,8 @@ permissions:
   contents: read
 
 env:
-  COLOR: >-  # Supposedly, pytest or coveragepy use this
+  # Supposedly, pytest or coveragepy use this
+  COLOR: >-
     yes
   FORCE_COLOR: 1  # Request colored output from CLI tools supporting it
   MYPY_FORCE_COLOR: 1  # MyPy's color enforcement
@@ -97,7 +98,8 @@ env:
   PYTHONIOENCODING: utf-8
   PYTHONUTF8: 1
   TOX_PARALLEL_NO_SPINNER: 1
-  TOX_TESTENV_PASSENV: >-  # Make tox-wrapped tools see color requests
+  # Make tox-wrapped tools see color requests
+  TOX_TESTENV_PASSENV: >-
     COLOR
     FORCE_COLOR
     MYPY_FORCE_COLOR
@@ -356,7 +358,8 @@ jobs:
         !cancelled()
         && failure()
         && inputs.tox-rerun-posargs != ''
-      run: >-  # `exit 1` makes sure that the job remains red with flaky runs
+      # `exit 1` makes sure that the job remains red with flaky runs
+      run: >-
         python -Im
         tox
         --parallel auto

--- a/.github/workflows/stale-actions.yaml
+++ b/.github/workflows/stale-actions.yaml
@@ -22,11 +22,8 @@ jobs:
         stale-pr-label: stale
         stale-issue-message: >
           This issue has been automatically marked as stale because it has been
-          open 30 days
-
-
-          with no activity. Remove stale label or comment or this issue will be
-          closed in 10 days
+          open 30 days with no activity. Remove stale label or comment or this
+          issue will be closed in 10 days
         stale-pr-message: >
           This PR has been automatically marked as stale because it has been
           open 30 days

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,20 @@ repos:
   hooks:
   - id: gitleaks
 
+#
+# YAML Linters
+#
+- repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
+  rev: 0.2.3
+  hooks:
+  - id: yamlfmt
+    args:
+    - --mapping=2
+    - --sequence=2
+    - --offset=0
+    - --width=75
+    - --implicit_start
+
 - repo: https://github.com/adrienverge/yamllint.git
   rev: v1.35.1
   hooks:

--- a/.yamllint
+++ b/.yamllint
@@ -16,5 +16,6 @@ rules:
       false
     - >-
       true
-    - >-  # Allow "on" key name in GHA CI/CD workflow definitions
+    # Allow "on" key name in GHA CI/CD workflow definitions
+    - >-
       on


### PR DESCRIPTION
`yamlfmt` does not support inline comments in `key: >-  # comment` construction - it removes such comments.

That's only one incontinence which I see for that linter, so it's good enough to force its use