### PR TITLE
fix(docker image security): Improve dependency pinning and disable ability to build image from different than specified in dockefile tag

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -185,7 +185,7 @@ jobs:
         python -m
         pip install
         --user
-        setuptools-scm
+        setuptools-scm~=8.2
       shell: bash
     - name: Set the current dist version from Git
       id: scm-version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-ARG TAG=3.12.0-alpine3.17@sha256:fc34b07ec97a4f288bc17083d288374a803dd59800399c76b977016c9fe5b8f2
-FROM python:${TAG} as builder
+FROM python:3.12.0-alpine3.17@sha256:fc34b07ec97a4f288bc17083d288374a803dd59800399c76b977016c9fe5b8f2 AS python_base
+
+FROM python_base AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -11,8 +12,8 @@ RUN apk add --no-cache \
     curl=~8 && \
     # Upgrade packages for be able get latest Checkov
     python3 -m pip install --no-cache-dir --upgrade \
-        pip \
-        setuptools
+        pip~=25.0 \
+        setuptools~=75.8
 
 COPY tools/install/ /install/
 
@@ -100,7 +101,7 @@ RUN . /.env && \
 
 
 
-FROM python:${TAG}
+FROM python_base
 
 RUN apk add --no-cache \
     # pre-commit deps


### PR DESCRIPTION
Relates #712 
Based on https://github.com/ossf/scorecard/issues/3684#issuecomment-2683942964

I am not sure that pining python deps to major version will make any difference for OSSF, but at least we will specify what major versions we currently rely on