### PR TITLE
chore(linters): Reorder linters, make hadolint ignores more specific

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,9 @@
+ignored:
+- DL3007  # Using latest
+- DL3013  # Pin versions in pip
+- DL3027  # Do not use apt
+- DL3059  # Docker `RUN`s shouldn't be consolidated here
+- DL4006  # Not related to alpine
+- SC1091  # Useless check
+- SC2015  # Useless check
+- SC3037  # Not related to alpine

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,9 +1,0 @@
-ignored:
-- DL3007  # Using latest
-- DL3013  # Pin versions in pip
-- DL3027  # Do not use apt
-- DL3059  # Docker `RUN`s shouldn't be consolidated here
-- DL4006  # Not related to alpine
-- SC1091  # Useless check
-- SC2015  # Useless check
-- SC3037  # Not related to alpine

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,9 +47,13 @@ repos:
   hooks:
   - id: gitleaks
 
-#
-# YAML Linters
-#
+# Dockerfile
+- repo: https://github.com/hadolint/hadolint
+  rev: v2.12.1-beta
+  hooks:
+  - id: hadolint
+
+# YAML
 - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
   rev: 0.2.3
   hooks:
@@ -71,7 +75,7 @@ repos:
     args:
     - --strict
 
-# JSON5 Linter
+# JSON5
 - repo: https://github.com/pre-commit/mirrors-prettier
   rev: v3.1.0
   hooks:
@@ -79,6 +83,21 @@ repos:
     # https://prettier.io/docs/en/options.html#parser
     files: .json5$
 
+# Bash
+- repo: https://github.com/jumanjihouse/pre-commit-hooks
+  rev: 3.0.0
+  hooks:
+  - id: shfmt
+    args:
+    - -l
+    - -i
+    - '2'
+    - -ci
+    - -sr
+    - -w
+  - id: shellcheck
+
+# Python
 - repo: https://github.com/pre-commit/mirrors-mypy.git
   rev: v1.15.0
   hooks:
@@ -133,31 +152,3 @@ repos:
     - --lineprecision-report=.tox/.tmp/.test-results/mypy--py-3.9
     - --txt-report=.tox/.tmp/.test-results/mypy--py-3.9
     pass_filenames: false
-
-- repo: https://github.com/jumanjihouse/pre-commit-hooks
-  rev: 3.0.0
-  hooks:
-  - id: shfmt
-    args:
-    - -l
-    - -i
-    - '2'
-    - -ci
-    - -sr
-    - -w
-  - id: shellcheck
-
-# Dockerfile linter
-- repo: https://github.com/hadolint/hadolint
-  rev: v2.12.1-beta
-  hooks:
-  - id: hadolint
-    args:
-    - --ignore=DL3007  # Using latest
-    - --ignore=DL3013  # Pin versions in pip
-    - --ignore=DL3027  # Do not use apt
-    - --ignore=DL3059  # Docker `RUN`s shouldn't be consolidated here
-    - --ignore=DL4006  # Not related to alpine
-    - --ignore=SC1091  # Useless check
-    - --ignore=SC2015  # Useless check
-    - --ignore=SC3037  # Not related to alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,14 +84,14 @@ RUN /install/trivy.sh
 
 # Checking binaries versions and write it to debug file
 
-# SC3037 - We do not use `echo` flags here, so it's false-positive
-# hadolint ignore=SC3037
+# SC2086 - We do not need to quote "$F" variable, because it's not contain spaces
+# DL4006 - Not Applicable for for /bin/sh in alpine images. Disable, as recommended by check itself
+# hadolint ignore=SC2086,DL4006
 RUN . /.env && \
     F=tools_versions_info && \
     pre-commit --version >> $F && \
     (if [ "$OPENTOFU_VERSION"       != "false" ]; then ./tofu --version | head -n 1 >> $F;            else echo "opentofu SKIPPED" >> $F       ; fi) && \
     (if [ "$TERRAFORM_VERSION"      != "false" ]; then ./terraform --version | head -n 1 >> $F;       else echo "terraform SKIPPED" >> $F      ; fi) && \
-
     \
     (if [ "$CHECKOV_VERSION"        != "false" ]; then echo "checkov $(checkov --version)" >> $F;     else echo "checkov SKIPPED" >> $F        ; fi) && \
     (if [ "$HCLEDIT_VERSION"        != "false" ]; then echo "hcledit $(./hcledit version)" >> $F;     else echo "hcledit SKIPPED" >> $F        ; fi) && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,7 @@ RUN /install/trivy.sh
 # Checking binaries versions and write it to debug file
 
 # SC2086 - We do not need to quote "$F" variable, because it's not contain spaces
-# DL4006 - Not Applicable for for /bin/sh in alpine images. Disable, as recommended by check itself
+# DL4006 - Not Applicable for /bin/sh in alpine images. Disable, as recommended by check itself
 # hadolint ignore=SC2086,DL4006
 RUN . /.env && \
     F=tools_versions_info && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,8 +85,7 @@ RUN /install/trivy.sh
 # Checking binaries versions and write it to debug file
 
 # SC3037 - We do not use `echo` flags here, so it's false-positive
-# DL4006 - Not Applicable for for /bin/sh in alpine images. Disable, as recommended by check itself
-# hadolint ignore=SC3037,DL4006
+# hadolint ignore=SC3037
 RUN . /.env && \
     F=tools_versions_info && \
     pre-commit --version >> $F && \
@@ -104,7 +103,7 @@ RUN . /.env && \
     (if [ "$TFSEC_VERSION"          != "false" ]; then echo "tfsec $(./tfsec --version)" >> $F;       else echo "tfsec SKIPPED" >> $F          ; fi) && \
     (if [ "$TFUPDATE_VERSION"       != "false" ]; then echo "tfupdate $(./tfupdate --version)" >> $F; else echo "tfupdate SKIPPED" >> $F       ; fi) && \
     (if [ "$TRIVY_VERSION"          != "false" ]; then echo "trivy $(./trivy --version)" >> $F;       else echo "trivy SKIPPED" >> $F          ; fi) && \
-    echo -e "\n\n" && cat $F && echo -e "\n\n"
+    printf "\n\n\n" && cat $F && printf "\n\n\n"
 
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,8 +84,9 @@ RUN /install/trivy.sh
 
 # Checking binaries versions and write it to debug file
 
-# We do not use `echo` flags here, so it's false-positive
-# hadolint ignore=SC3037
+# SC3037 - We do not use `echo` flags here, so it's false-positive
+# DL4006 - Not Applicable for for /bin/sh in alpine images. Disable, as recommended by check itself
+# hadolint ignore=SC3037,DL4006
 RUN . /.env && \
     F=tools_versions_info && \
     pre-commit --version >> $F && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,8 @@ RUN if [ "$INSTALL_ALL" != "false" ]; then \
         echo "TRIVY_VERSION=latest"          >> /.env \
     ; fi
 
+# Docker `RUN`s shouldn't be consolidated here
+# hadolint global ignore=DL3059
 RUN /install/opentofu.sh
 RUN /install/terraform.sh
 
@@ -81,6 +83,9 @@ RUN /install/trivy.sh
 
 
 # Checking binaries versions and write it to debug file
+
+# We do not use `echo` flags here, so it's false-positive
+# hadolint ignore=SC3037
 RUN . /.env && \
     F=tools_versions_info && \
     pre-commit --version >> $F && \

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,11 +1,9 @@
+# We use `latest` tag for tests proposes
+# hadolint ignore=DL3007
 FROM pre-commit-terraform:latest
 
-RUN apt update && \
-    apt install -y \
-        datamash \
-        time && \
-    # Cleanup
-    rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache \
+    datamash=~1.8
 
 WORKDIR /pct
 ENTRYPOINT [ "/pct/tests/hooks_performance_test.sh" ]


### PR DESCRIPTION
Split from https://github.com/antonbabenko/pre-commit-terraform/pull/831

Hadolint supports its own config file, and that make able 3rd-party tools that utilize hadolint also known about specified config options, not pre-commit only