### PR TITLE
chore(docker debug): Display opentofu & terraform versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,8 +84,9 @@ RUN /install/trivy.sh
 RUN . /.env && \
     F=tools_versions_info && \
     pre-commit --version >> $F && \
-    (if [ "$OPENTOFU_VERSION"       != "false" ]; then echo "tofu $(./tofu --version | head -n 1)" >> $F;      else echo "opentofu SKIPPED" >> $F      ; fi) && \
-    (if [ "$TERRAFORM_VERSION"      != "false" ]; then echo "terraform $(./terraform --version | head -n 1)" >> $F; else echo "terraform SKIPPED" >> $F     ; fi) && \
+    (if [ "$OPENTOFU_VERSION"       != "false" ]; then ./tofu --version | head -n 1 >> $F;            else echo "opentofu SKIPPED" >> $F       ; fi) && \
+    (if [ "$TERRAFORM_VERSION"      != "false" ]; then ./terraform --version | head -n 1 >> $F;       else echo "terraform SKIPPED" >> $F      ; fi) && \
+
     \
     (if [ "$CHECKOV_VERSION"        != "false" ]; then echo "checkov $(checkov --version)" >> $F;     else echo "checkov SKIPPED" >> $F        ; fi) && \
     (if [ "$HCLEDIT_VERSION"        != "false" ]; then echo "hcledit $(./hcledit version)" >> $F;     else echo "hcledit SKIPPED" >> $F        ; fi) && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,8 +84,8 @@ RUN /install/trivy.sh
 RUN . /.env && \
     F=tools_versions_info && \
     pre-commit --version >> $F && \
-    (if [ "$OPENTOFU_VERSION"       != "false" ]; then echo "./tofu --version | head -n 1" >> $F;      else echo "opentofu SKIPPED" >> $F      ; fi) && \
-    (if [ "$TERRAFORM_VERSION"      != "false" ]; then echo "./terraform --version | head -n 1" >> $F; else echo "terraform SKIPPED" >> $F     ; fi) && \
+    (if [ "$OPENTOFU_VERSION"       != "false" ]; then echo "tofu $(./tofu --version | head -n 1)" >> $F;      else echo "opentofu SKIPPED" >> $F      ; fi) && \
+    (if [ "$TERRAFORM_VERSION"      != "false" ]; then echo "terraform $(./terraform --version | head -n 1)" >> $F; else echo "terraform SKIPPED" >> $F     ; fi) && \
     \
     (if [ "$CHECKOV_VERSION"        != "false" ]; then echo "checkov $(checkov --version)" >> $F;     else echo "checkov SKIPPED" >> $F        ; fi) && \
     (if [ "$HCLEDIT_VERSION"        != "false" ]; then echo "hcledit $(./hcledit version)" >> $F;     else echo "hcledit SKIPPED" >> $F        ; fi) && \


### PR DESCRIPTION
Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

Before
```
$ podman run --rm --entrypoint cat ghcr.io/antonbabenko/pre-commit-terraform:latest less /usr/bin/tools_versions_info
pre-commit 4.1.0
./tofu --version | head -n 1
./terraform --version | head -n 1
checkov 3.2.377
hcledit 0.2.17
Infracost v0.10.40
terraform-docs version v0.19.0 af31cc6 linux/amd64
terragrunt version v0.73.14
terrascan version: v1.19.9
TFLint version 0.55.1
+ ruleset.terraform (0.10.0-bundled)
tfsec v1.28.13
tfupdate 0.8.5
trivy Version: 0.59.1
```

After
```
pre-commit 4.1.0
tofu OpenTofu v1.9.0
terraform (./terraform --version | head -n 1)
checkov 3.2.386
hcledit 0.2.17
Infracost v0.10.41
terraform-docs version v0.19.0 af31cc6 linux/amd64
terragrunt version v0.75.10
terrascan version: v1.19.9
TFLint version 0.55.1
+ ruleset.terraform (0.10.0-bundled)
tfsec v1.28.13
tfupdate 0.8.5
trivy Version: 0.60.0
```


### How can we test changes
```
$ podman run --rm --entrypoint cat ghcr.io/antonbabenko/pre-commit-terraform:latest less /usr/bin/tools_versions_info
```