### PR TITLE
chore(ci): Pin codecov to latest working release

### DIFF
--- a/.github/workflows/reusable-tox.yml
+++ b/.github/workflows/reusable-tox.yml
@@ -420,4 +420,4 @@ jobs:
           }}
         token: ${{ secrets.codecov-token }}
         # renovate: datasource=github-releases depName=codecov-cli lookupName=codecov/codecov-cli
-        version: v10.2.1
+        version: v10.2.0

--- a/.github/workflows/reusable-tox.yml
+++ b/.github/workflows/reusable-tox.yml
@@ -420,4 +420,4 @@ jobs:
           }}
         token: ${{ secrets.codecov-token }}
         # renovate: datasource=github-releases depName=codecov-cli lookupName=codecov/codecov-cli
-        version: v10.2.0
+        version: v10.1.1

--- a/.github/workflows/reusable-tox.yml
+++ b/.github/workflows/reusable-tox.yml
@@ -419,3 +419,5 @@ jobs:
             steps.python-install.outputs.python-version
           }}
         token: ${{ secrets.codecov-token }}
+        # renovate: datasource=github-releases depName=codecov-cli lookupName=codecov/codecov-cli
+        version: v10.2.1

--- a/.github/workflows/reusable-tox.yml
+++ b/.github/workflows/reusable-tox.yml
@@ -395,6 +395,9 @@ jobs:
             steps.python-install.outputs.python-version
           }}
         token: ${{ secrets.codecov-token }}
+        # renovate: datasource=github-releases depName=codecov-cli lookupName=codecov/codecov-cli
+        version: v10.1.1
+
     - name: Upload test results to Codecov
       if: >-
         !cancelled()


### PR DESCRIPTION
### Description of your changes
By default, codecov pin their codecov-cli which used under the hood for GHA to latest.
https://github.com/codecov/codecov-action/blob/3440e5ef70c638a9f44602a80ab017feee1309fe/action.yml#L163-L166

### How can we test changes

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
