### PR TITLE
feat(docker): Support execution on repos under `git worktree`

### DIFF
--- a/tools/entrypoint.sh
+++ b/tools/entrypoint.sh
@@ -39,7 +39,7 @@ wdir="$(pwd)"
 if ! su-exec "$USERID" "$BASHPATH" -c "test -w $wdir && test -r $wdir"; then
   echo_error_and_exit "uid:gid $USERID lacks permissions to $wdir/"
 fi
-wdirgitindex="$wdir/.git/index"
+wdirgitindex="$(git rev-parse --git-dir 2>&1)/index" || echo_error_and_exit "${wdirgitindex%/index}"
 if ! su-exec "$USERID" "$BASHPATH" -c "test -w $wdirgitindex && test -r $wdirgitindex"; then
   echo_error_and_exit "uid:gid $USERID cannot write to $wdirgitindex"
 fi


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [x] This PR enhances existing functionality.

### Description of your changes

Get `wdirgitindex` from $(git rev-parse --git-dir) to make it correct for non-worktree repos, and for worktree repos in either the main worktree or linked worktree.
Fixes #844 

<!-- Fixes # -->

### How can we test changes

1. Reproduce the error as per the issue #844 
2. build a new docker image using this PR's change to `entrypoint.sh`
3. run the docker image:
   - without any worktree (use `git worktree remove $br` if you already created one in the repro steps), using the usual docker run command (not the repro one)
   - with a worktree, but from the main repo path, using the usual docker run command (not the repro one)
   - with a worktree, from the worktree path (use the repro steps in the issue to edit the .git file, and mount the /gitcommon mount)
