### PR TITLE
chore(linters): Apply ruff-format

### DIFF
--- a/src/pre_commit_terraform/_cli_parsing.py
+++ b/src/pre_commit_terraform/_cli_parsing.py
@@ -22,7 +22,9 @@ def attach_subcommand_parsers_to(root_cli_parser: ArgumentParser, /) -> None:
         required=True,
     )
     for subcommand_module in SUBCOMMAND_MODULES:
-        subcommand_parser = subcommand_parsers.add_parser(subcommand_module.CLI_SUBCOMMAND_NAME)
+        subcommand_parser = subcommand_parsers.add_parser(
+            subcommand_module.CLI_SUBCOMMAND_NAME
+        )
         subcommand_parser.set_defaults(
             invoke_cli_app=subcommand_module.invoke_cli_app,
         )

--- a/src/pre_commit_terraform/_errors.py
+++ b/src/pre_commit_terraform/_errors.py
@@ -6,8 +6,8 @@ class PreCommitTerraformBaseError(Exception):
 
 
 class PreCommitTerraformRuntimeError(
-        PreCommitTerraformBaseError,
-        RuntimeError,
+    PreCommitTerraformBaseError,
+    RuntimeError,
 ):
     """An exception representing a runtime error condition."""
 

--- a/src/pre_commit_terraform/_types.py
+++ b/src/pre_commit_terraform/_types.py
@@ -18,7 +18,8 @@ class CLISubcommandModuleProtocol(Protocol):
     """This constant contains a CLI."""
 
     def populate_argument_parser(
-            self, subcommand_parser: ArgumentParser,
+        self,
+        subcommand_parser: ArgumentParser,
     ) -> None:
         """Run a module hook for populating the subcommand parser."""
 

--- a/src/pre_commit_terraform/terraform_docs_replace.py
+++ b/src/pre_commit_terraform/terraform_docs_replace.py
@@ -18,14 +18,20 @@ def populate_argument_parser(subcommand_parser: ArgumentParser) -> None:
         'replace the entire README.md file each time.'
     )
     subcommand_parser.add_argument(
-        '--dest', dest='dest', default='README.md',
+        '--dest',
+        dest='dest',
+        default='README.md',
     )
     subcommand_parser.add_argument(
-        '--sort-inputs-by-required', dest='sort', action='store_true',
+        '--sort-inputs-by-required',
+        dest='sort',
+        action='store_true',
         help='[deprecated] use --sort-by-required instead',
     )
     subcommand_parser.add_argument(
-        '--sort-by-required', dest='sort', action='store_true',
+        '--sort-by-required',
+        dest='sort',
+        action='store_true',
     )
     subcommand_parser.add_argument(
         '--with-aggregate-type-defaults',
@@ -51,8 +57,9 @@ def invoke_cli_app(parsed_cli_args: Namespace) -> ReturnCodeType:
 
     dirs: list[str] = []
     for filename in cast_to(list[str], parsed_cli_args.filenames):
-        if (os.path.realpath(filename) not in dirs and
-                (filename.endswith(".tf") or filename.endswith(".tfvars"))):
+        if os.path.realpath(filename) not in dirs and (
+            filename.endswith('.tf') or filename.endswith('.tfvars')
+        ):
             dirs.append(os.path.dirname(filename))
 
     retval = ReturnCode.OK
@@ -64,13 +71,14 @@ def invoke_cli_app(parsed_cli_args: Namespace) -> ReturnCodeType:
             if cast_to(bool, parsed_cli_args.sort):
                 procArgs.append('--sort-by-required')
             procArgs.append('md')
-            procArgs.append("./{dir}".format(dir=dir))
+            procArgs.append('./{dir}'.format(dir=dir))
             procArgs.append('>')
             procArgs.append(
-                './{dir}/{dest}'.
-                format(dir=dir, dest=cast_to(bool, parsed_cli_args.dest)),
+                './{dir}/{dest}'.format(
+                    dir=dir, dest=cast_to(bool, parsed_cli_args.dest)
+                ),
             )
-            subprocess.check_call(" ".join(procArgs), shell=True)
+            subprocess.check_call(' '.join(procArgs), shell=True)
         except subprocess.CalledProcessError as e:
             print(e)
             retval = ReturnCode.ERROR

--- a/tests/pytest/_cli_test.py
+++ b/tests/pytest/_cli_test.py
@@ -42,17 +42,19 @@ pytestmark = pytest.mark.filterwarnings(
     ),
 )
 def test_known_interrupts(
-        capsys: pytest.CaptureFixture[str],
-        expected_stderr: str,
-        monkeypatch: pytest.MonkeyPatch,
-        raised_error: BaseException,
+    capsys: pytest.CaptureFixture[str],
+    expected_stderr: str,
+    monkeypatch: pytest.MonkeyPatch,
+    raised_error: BaseException,
 ) -> None:
     """Check that known interrupts are turned into return code 1."""
+
     class CustomCmdStub:
         CLI_SUBCOMMAND_NAME = 'sentinel'
 
         def populate_argument_parser(
-                self, subcommand_parser: ArgumentParser,
+            self,
+            subcommand_parser: ArgumentParser,
         ) -> None:
             return None
 
@@ -72,15 +74,17 @@ def test_known_interrupts(
 
 
 def test_app_exit(
-        capsys: pytest.CaptureFixture[str],
-        monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Check that an exit exception is re-raised."""
+
     class CustomCmdStub:
         CLI_SUBCOMMAND_NAME = 'sentinel'
 
         def populate_argument_parser(
-                self, subcommand_parser: ArgumentParser,
+            self,
+            subcommand_parser: ArgumentParser,
         ) -> None:
             return None
 

--- a/tests/pytest/terraform_docs_replace_test.py
+++ b/tests/pytest/terraform_docs_replace_test.py
@@ -24,8 +24,7 @@ def test_arg_parser_populated() -> None:
 def test_check_is_deprecated() -> None:
     """Verify that `replace-docs` shows a deprecation warning."""
     deprecation_msg_regex = (
-        r'^`terraform_docs_replace` hook is DEPRECATED\.'
-        'For migration.*$'
+        r'^`terraform_docs_replace` hook is DEPRECATED\.' 'For migration.*$'
     )
     with pytest.warns(UserWarning, match=deprecation_msg_regex):
         # not `pytest.deprecated_call()` due to this being a user warning
@@ -70,10 +69,10 @@ def test_check_is_deprecated() -> None:
     'pre_commit_terraform.terraform_docs_replace',
 )
 def test_control_flow_positive(
-        expected_cmds: list[str],
-        mocker: pytest_mock.MockerFixture,
-        monkeypatch: pytest.MonkeyPatch,
-        parsed_cli_args: Namespace,
+    expected_cmds: list[str],
+    mocker: pytest_mock.MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    parsed_cli_args: Namespace,
 ) -> None:
     """Check that the subcommand's happy path works."""
     check_call_mock = mocker.Mock()
@@ -86,7 +85,7 @@ def test_control_flow_positive(
     assert ReturnCode.OK == invoke_cli_app(parsed_cli_args)
 
     executed_commands = [
-        cmd for ((cmd, ), _shell) in check_call_mock.call_args_list
+        cmd for ((cmd,), _shell) in check_call_mock.call_args_list
     ]
 
     assert len(expected_cmds) == check_call_mock.call_count
@@ -98,8 +97,8 @@ def test_control_flow_positive(
     'pre_commit_terraform.terraform_docs_replace',
 )
 def test_control_flow_negative(
-        mocker: pytest_mock.MockerFixture,
-        monkeypatch: pytest.MonkeyPatch,
+    mocker: pytest_mock.MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Check that the subcommand's error processing works."""
     parsed_cli_args = Namespace(

--- a/tests/pytest/terraform_docs_replace_test.py
+++ b/tests/pytest/terraform_docs_replace_test.py
@@ -24,7 +24,7 @@ def test_arg_parser_populated() -> None:
 def test_check_is_deprecated() -> None:
     """Verify that `replace-docs` shows a deprecation warning."""
     deprecation_msg_regex = (
-        r'^`terraform_docs_replace` hook is DEPRECATED\.' 'For migration.*$'
+        r'^`terraform_docs_replace` hook is DEPRECATED\.For migration.*$'
     )
     with pytest.warns(UserWarning, match=deprecation_msg_regex):
         # not `pytest.deprecated_call()` due to this being a user warning


### PR DESCRIPTION
Subset of https://github.com/antonbabenko/pre-commit-terraform/pull/831


Result of run

```yaml
repos:
- repo: https://github.com/astral-sh/ruff-pre-commit
  rev: v0.8.4
  hooks:
  - id: ruff-format
```

with same `ruff.toml` as in #831, exept 2 last lines which enable ignore of deprecated hooks (https://github.com/antonbabenko/pre-commit-terraform/blob/948a36d52d36270c329028bd27f7a3e999c899ff/ruff.toml)