### PR TITLE
chore(linters): Apply ruff linter semi-automatic linting fixes

### DIFF
--- a/src/pre_commit_terraform/__main__.py
+++ b/src/pre_commit_terraform/__main__.py
@@ -1,6 +1,7 @@
 """A runpy-style CLI entry-point module."""
 
-from sys import argv, exit as exit_with_return_code
+from sys import argv
+from sys import exit as exit_with_return_code
 
 from ._cli import invoke_cli_app
 

--- a/src/pre_commit_terraform/_cli.py
+++ b/src/pre_commit_terraform/_cli.py
@@ -23,7 +23,7 @@ def invoke_cli_app(cli_args: list[str]) -> ReturnCodeType:
     parsed_cli_args = root_cli_parser.parse_args(cli_args)
     invoke_cli_app = cast_to(
         # FIXME: attempt typing per https://stackoverflow.com/a/75666611/595220
-        CLIAppEntryPointCallableType,
+        'CLIAppEntryPointCallableType',
         parsed_cli_args.invoke_cli_app,
     )
 

--- a/src/pre_commit_terraform/_cli_parsing.py
+++ b/src/pre_commit_terraform/_cli_parsing.py
@@ -23,7 +23,7 @@ def attach_subcommand_parsers_to(root_cli_parser: ArgumentParser, /) -> None:
     )
     for subcommand_module in SUBCOMMAND_MODULES:
         subcommand_parser = subcommand_parsers.add_parser(
-            subcommand_module.CLI_SUBCOMMAND_NAME
+            subcommand_module.CLI_SUBCOMMAND_NAME,
         )
         subcommand_parser.set_defaults(
             invoke_cli_app=subcommand_module.invoke_cli_app,

--- a/src/pre_commit_terraform/terraform_docs_replace.py
+++ b/src/pre_commit_terraform/terraform_docs_replace.py
@@ -76,7 +76,7 @@ def invoke_cli_app(parsed_cli_args: Namespace) -> ReturnCodeType:
             procArgs.append('>')
             procArgs.append(
                 './{dir}/{dest}'.format(
-                    dir=dir, dest=cast_to(bool, parsed_cli_args.dest)
+                    dir=dir, dest=cast_to(bool, parsed_cli_args.dest),
                 ),
             )
             subprocess.check_call(' '.join(procArgs), shell=True)

--- a/src/pre_commit_terraform/terraform_docs_replace.py
+++ b/src/pre_commit_terraform/terraform_docs_replace.py
@@ -74,7 +74,7 @@ def invoke_cli_app(parsed_cli_args: Namespace) -> ReturnCodeType:
             procArgs.extend(
                 (
                     'md',
-                    './{dir}'.format(dir=dir),
+                    f'./{dir}',
                     '>',
                     './{dir}/{dest}'.format(
                         dir=dir,

--- a/src/pre_commit_terraform/terraform_docs_replace.py
+++ b/src/pre_commit_terraform/terraform_docs_replace.py
@@ -53,6 +53,7 @@ def invoke_cli_app(parsed_cli_args: Namespace) -> ReturnCodeType:
         'https://github.com/antonbabenko/pre-commit-terraform/issues/248'
         '#issuecomment-1290829226',
         category=UserWarning,
+        stacklevel=2,
     )
 
     dirs: list[str] = []

--- a/src/pre_commit_terraform/terraform_docs_replace.py
+++ b/src/pre_commit_terraform/terraform_docs_replace.py
@@ -59,7 +59,7 @@ def invoke_cli_app(parsed_cli_args: Namespace) -> ReturnCodeType:
     dirs: list[str] = []
     for filename in cast_to(list[str], parsed_cli_args.filenames):
         if os.path.realpath(filename) not in dirs and (
-            filename.endswith('.tf') or filename.endswith('.tfvars')
+            filename.endswith(('.tf', '.tfvars'))
         ):
             dirs.append(os.path.dirname(filename))
 

--- a/src/pre_commit_terraform/terraform_docs_replace.py
+++ b/src/pre_commit_terraform/terraform_docs_replace.py
@@ -53,7 +53,7 @@ def invoke_cli_app(parsed_cli_args: Namespace) -> ReturnCodeType:
         'https://github.com/antonbabenko/pre-commit-terraform/issues/248'
         '#issuecomment-1290829226',
         category=UserWarning,
-        stacklevel=1,
+        stacklevel=1,  # It's should be 2, but tests are failing w/ values >1. As it's deprecated hook, it's safe to leave it as is w/o fixing it later.
     )
 
     dirs: list[str] = []

--- a/src/pre_commit_terraform/terraform_docs_replace.py
+++ b/src/pre_commit_terraform/terraform_docs_replace.py
@@ -53,7 +53,7 @@ def invoke_cli_app(parsed_cli_args: Namespace) -> ReturnCodeType:
         'https://github.com/antonbabenko/pre-commit-terraform/issues/248'
         '#issuecomment-1290829226',
         category=UserWarning,
-        stacklevel=2,
+        stacklevel=1,
     )
 
     dirs: list[str] = []

--- a/src/pre_commit_terraform/terraform_docs_replace.py
+++ b/src/pre_commit_terraform/terraform_docs_replace.py
@@ -71,12 +71,15 @@ def invoke_cli_app(parsed_cli_args: Namespace) -> ReturnCodeType:
             procArgs.append('terraform-docs')
             if cast_to(bool, parsed_cli_args.sort):
                 procArgs.append('--sort-by-required')
-            procArgs.append('md')
-            procArgs.append('./{dir}'.format(dir=dir))
-            procArgs.append('>')
-            procArgs.append(
-                './{dir}/{dest}'.format(
-                    dir=dir, dest=cast_to(bool, parsed_cli_args.dest),
+            procArgs.extend(
+                (
+                    'md',
+                    './{dir}'.format(dir=dir),
+                    '>',
+                    './{dir}/{dest}'.format(
+                        dir=dir,
+                        dest=cast_to(bool, parsed_cli_args.dest),
+                    ),
                 ),
             )
             subprocess.check_call(' '.join(procArgs), shell=True)

--- a/src/pre_commit_terraform/terraform_docs_replace.py
+++ b/src/pre_commit_terraform/terraform_docs_replace.py
@@ -57,7 +57,7 @@ def invoke_cli_app(parsed_cli_args: Namespace) -> ReturnCodeType:
     )
 
     dirs: list[str] = []
-    for filename in cast_to(list[str], parsed_cli_args.filenames):
+    for filename in cast_to('list[str]', parsed_cli_args.filenames):
         if os.path.realpath(filename) not in dirs and (
             filename.endswith(('.tf', '.tfvars'))
         ):
@@ -69,7 +69,7 @@ def invoke_cli_app(parsed_cli_args: Namespace) -> ReturnCodeType:
         try:
             procArgs = []
             procArgs.append('terraform-docs')
-            if cast_to(bool, parsed_cli_args.sort):
+            if cast_to('bool', parsed_cli_args.sort):
                 procArgs.append('--sort-by-required')
             procArgs.extend(
                 (
@@ -78,7 +78,7 @@ def invoke_cli_app(parsed_cli_args: Namespace) -> ReturnCodeType:
                     '>',
                     './{dir}/{dest}'.format(
                         dir=dir,
-                        dest=cast_to(bool, parsed_cli_args.dest),
+                        dest=cast_to('bool', parsed_cli_args.dest),
                     ),
                 ),
             )

--- a/tests/pytest/_cli_test.py
+++ b/tests/pytest/_cli_test.py
@@ -1,13 +1,13 @@
 """Tests for the high-level CLI entry point."""
 
 from argparse import ArgumentParser, Namespace
-import pytest
 
+import pytest
 from pre_commit_terraform import _cli_parsing as _cli_parsing_mod
 from pre_commit_terraform._cli import invoke_cli_app
 from pre_commit_terraform._errors import (
-    PreCommitTerraformExit,
     PreCommitTerraformBaseError,
+    PreCommitTerraformExit,
     PreCommitTerraformRuntimeError,
 )
 from pre_commit_terraform._structs import ReturnCode

--- a/tests/pytest/_cli_test.py
+++ b/tests/pytest/_cli_test.py
@@ -67,7 +67,7 @@ def test_known_interrupts(
         [CustomCmdStub()],
     )
 
-    assert ReturnCode.ERROR == invoke_cli_app(['sentinel'])
+    assert invoke_cli_app(['sentinel']) == ReturnCode.ERROR
 
     captured_outputs = capsys.readouterr()
     assert captured_outputs.err == f'{expected_stderr !s}\n'

--- a/tests/pytest/_cli_test.py
+++ b/tests/pytest/_cli_test.py
@@ -89,7 +89,8 @@ def test_app_exit(
             return None
 
         def invoke_cli_app(self, parsed_cli_args: Namespace) -> ReturnCodeType:
-            raise PreCommitTerraformExit('sentinel')
+            msg = 'sentinel'
+            raise PreCommitTerraformExit(msg)
 
     monkeypatch.setattr(
         _cli_parsing_mod,

--- a/tests/pytest/_cli_test.py
+++ b/tests/pytest/_cli_test.py
@@ -89,8 +89,7 @@ def test_app_exit(
             return None
 
         def invoke_cli_app(self, parsed_cli_args: Namespace) -> ReturnCodeType:
-            msg = 'sentinel'
-            raise PreCommitTerraformExit(msg)
+            raise PreCommitTerraformExit(self.CLI_SUBCOMMAND_NAME)
 
     monkeypatch.setattr(
         _cli_parsing_mod,

--- a/tests/pytest/terraform_docs_replace_test.py
+++ b/tests/pytest/terraform_docs_replace_test.py
@@ -84,7 +84,7 @@ def test_control_flow_positive(
         check_call_mock,
     )
 
-    assert ReturnCode.OK == invoke_cli_app(parsed_cli_args)
+    assert invoke_cli_app(parsed_cli_args) == ReturnCode.OK
 
     executed_commands = [
         cmd for ((cmd,), _shell) in check_call_mock.call_args_list
@@ -119,6 +119,6 @@ def test_control_flow_negative(
         check_call_mock,
     )
 
-    assert ReturnCode.ERROR == invoke_cli_app(parsed_cli_args)
+    assert invoke_cli_app(parsed_cli_args) == ReturnCode.ERROR
 
     check_call_mock.assert_called_once_with(expected_cmd, shell=True)

--- a/tests/pytest/terraform_docs_replace_test.py
+++ b/tests/pytest/terraform_docs_replace_test.py
@@ -3,13 +3,15 @@
 from argparse import ArgumentParser, Namespace
 from subprocess import CalledProcessError
 
-import pytest
 import pytest_mock
 
+import pytest
 from pre_commit_terraform._structs import ReturnCode
 from pre_commit_terraform.terraform_docs_replace import (
     invoke_cli_app,
     populate_argument_parser,
+)
+from pre_commit_terraform.terraform_docs_replace import (
     subprocess as replace_docs_subprocess_mod,
 )
 


### PR DESCRIPTION
### Description of your changes
Subset of #831 

Apply next for each violation:
```yaml
repos:
- repo: https://github.com/astral-sh/ruff-pre-commit
  rev: v0.8.4
  hooks:
  - id: ruff
    args:
      - --fix
      - --unsafe-fixes
      - --select=<rulename>
  - id: ruff-format
```
and commit as separate commit

with same `ruff.toml` as in #831, except 2 last lines which enable ignore of deprecated hooks (https://github.com/antonbabenko/pre-commit-terraform/blob/948a36d52d36270c329028bd27f7a3e999c899ff/ruff.toml)