### PR TITLE
chore: Streamline `cast_to()` into correct type

### DIFF
--- a/src/pre_commit_terraform/terraform_docs_replace.py
+++ b/src/pre_commit_terraform/terraform_docs_replace.py
@@ -78,7 +78,7 @@ def invoke_cli_app(parsed_cli_args: Namespace) -> ReturnCodeType:
                     '>',
                     './{dir}/{dest}'.format(
                         dir=dir,
-                        dest=cast_to('bool', parsed_cli_args.dest),
+                        dest=cast_to('str', parsed_cli_args.dest),
                     ),
                 ),
             )


### PR DESCRIPTION
Follow-up for #863 to correct `cast_to()` cast type for the string arg from `bool` to `str`.