### PR TITLE
chore(linters): Manually fix ruff linter issues

### DIFF
--- a/src/pre_commit_terraform/_cli.py
+++ b/src/pre_commit_terraform/_cli.py
@@ -18,6 +18,9 @@ def invoke_cli_app(cli_args: list[str]) -> ReturnCodeType:
 
     Includes initializing parsers of all the sub-apps and
     choosing what to execute.
+
+    Returns:
+        ReturnCodeType: The return code of the app.
     """
     root_cli_parser = initialize_argument_parser()
     parsed_cli_args = root_cli_parser.parse_args(cli_args)

--- a/src/pre_commit_terraform/_cli_parsing.py
+++ b/src/pre_commit_terraform/_cli_parsing.py
@@ -32,7 +32,11 @@ def attach_subcommand_parsers_to(root_cli_parser: ArgumentParser, /) -> None:
 
 
 def initialize_argument_parser() -> ArgumentParser:
-    """Return the root argument parser with sub-commands."""
+    """Return the root argument parser with sub-commands.
+
+    Returns:
+        ReturnCodeType: The return code of the app.
+    """
     root_cli_parser = ArgumentParser(prog=f'python -m {__package__ !s}')
     attach_subcommand_parsers_to(root_cli_parser)
     return root_cli_parser

--- a/src/pre_commit_terraform/terraform_docs_replace.py
+++ b/src/pre_commit_terraform/terraform_docs_replace.py
@@ -65,7 +65,7 @@ def invoke_cli_app(parsed_cli_args: Namespace) -> ReturnCodeType:
 
     retval = ReturnCode.OK
 
-    for dir in dirs:
+    for directory in dirs:
         try:
             procArgs = []
             procArgs.append('terraform-docs')
@@ -74,10 +74,10 @@ def invoke_cli_app(parsed_cli_args: Namespace) -> ReturnCodeType:
             procArgs.extend(
                 (
                     'md',
-                    f'./{dir}',
+                    f'./{directory}',
                     '>',
                     './{dir}/{dest}'.format(
-                        dir=dir,
+                        dir=directory,
                         dest=cast_to('str', parsed_cli_args.dest),
                     ),
                 ),

--- a/src/pre_commit_terraform/terraform_docs_replace.py
+++ b/src/pre_commit_terraform/terraform_docs_replace.py
@@ -59,7 +59,8 @@ def invoke_cli_app(parsed_cli_args: Namespace) -> ReturnCodeType:
         'https://github.com/antonbabenko/pre-commit-terraform/issues/248'
         '#issuecomment-1290829226',
         category=UserWarning,
-        stacklevel=1,  # It's should be 2, but tests are failing w/ values >1. As it's deprecated hook, it's safe to leave it as is w/o fixing it later.
+        stacklevel=1,  # It's should be 2, but tests are failing w/ values >1.
+        # As it's deprecated hook, it's safe to leave it as is w/o fixing it.
     )
 
     dirs: list[str] = []

--- a/src/pre_commit_terraform/terraform_docs_replace.py
+++ b/src/pre_commit_terraform/terraform_docs_replace.py
@@ -12,6 +12,7 @@ CLI_SUBCOMMAND_NAME: str = 'replace-docs'
 
 
 def populate_argument_parser(subcommand_parser: ArgumentParser) -> None:
+    """Populate the parser for the subcommand."""
     subcommand_parser.description = (
         'Run terraform-docs on a set of files. Follows the standard '
         'convention of pulling the documentation from main.tf in order to '
@@ -47,6 +48,11 @@ def populate_argument_parser(subcommand_parser: ArgumentParser) -> None:
 
 
 def invoke_cli_app(parsed_cli_args: Namespace) -> ReturnCodeType:
+    """Run the entry-point of the CLI app.
+
+    Returns:
+        ReturnCodeType: The return code of the app.
+    """
     warnings.warn(
         '`terraform_docs_replace` hook is DEPRECATED.'
         'For migration instructions see '

--- a/src/pre_commit_terraform/terraform_docs_replace.py
+++ b/src/pre_commit_terraform/terraform_docs_replace.py
@@ -74,11 +74,11 @@ def invoke_cli_app(parsed_cli_args: Namespace) -> ReturnCodeType:
 
     for directory in dirs:
         try:
-            procArgs = []
-            procArgs.append('terraform-docs')
+            proc_args = []
+            proc_args.append('terraform-docs')
             if cast_to('bool', parsed_cli_args.sort):
-                procArgs.append('--sort-by-required')
-            procArgs.extend(
+                proc_args.append('--sort-by-required')
+            proc_args.extend(
                 (
                     'md',
                     f'./{directory}',
@@ -89,7 +89,7 @@ def invoke_cli_app(parsed_cli_args: Namespace) -> ReturnCodeType:
                     ),
                 ),
             )
-            subprocess.check_call(' '.join(procArgs), shell=True)
+            subprocess.check_call(' '.join(proc_args), shell=True)
         except subprocess.CalledProcessError as e:
             print(e)
             retval = ReturnCode.ERROR

--- a/tests/pytest/_cli_test.py
+++ b/tests/pytest/_cli_test.py
@@ -23,7 +23,6 @@ pytestmark = pytest.mark.filterwarnings(
 @pytest.mark.parametrize(
     ('raised_error', 'expected_stderr'),
     (
-        # pytest.param(PreCommitTerraformExit('sentinel'), 'App exiting: sentinel', id='app-exit'),
         pytest.param(
             PreCommitTerraformRuntimeError('sentinel'),
             'App execution took an unexpected turn: sentinel. Exiting...',

--- a/tests/pytest/_cli_test.py
+++ b/tests/pytest/_cli_test.py
@@ -97,7 +97,7 @@ def test_app_exit(
         [CustomCmdStub()],
     )
 
-    with pytest.raises(PreCommitTerraformExit, match='^sentinel$'):
+    with pytest.raises(PreCommitTerraformExit, match=r'^sentinel$'):
         invoke_cli_app(['sentinel'])
 
     captured_outputs = capsys.readouterr()


### PR DESCRIPTION
### Description of your changes
Subset of #831 

Run next and fix violations one by one
```yaml
repos:
- repo: https://github.com/astral-sh/ruff-pre-commit
  rev: v0.8.4
  hooks:
  - id: ruff
    args:
      - --fix
  - id: ruff-format
```
and commit as separate commits

with same `ruff.toml` as in #831, except 2 last lines which enable ignore of deprecated hooks (https://github.com/antonbabenko/pre-commit-terraform/blob/948a36d52d36270c329028bd27f7a3e999c899ff/ruff.toml)