### PR TITLE
fix(WSL): Fix parallelism support for WSL systems with enabled systemd

### DIFF
--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -206,8 +206,13 @@ function common::get_cpu_num {
 
   local cpu_quota cpu_period cpu_num
 
+  local wslinterop_path = "/proc/sys/fs/binfmt_misc/WSLInterop"
+
   if [[ -f /sys/fs/cgroup/cpu/cpu.cfs_quota_us &&
-    ! -f /proc/sys/fs/binfmt_misc/WSLInterop ]]; then # WSL have cfs_quota_us, but WSL should be checked as usual Linux host
+    ( # WSL has cfs_quota_us, but WSL should be checked as usual Linux host
+      ! -f "${wslinterop_path}" &&
+      ! -f "${wslinterop_path}-late"
+    ) ]]; then
     # Inside K8s pod or DinD in K8s
     cpu_quota=$(< /sys/fs/cgroup/cpu/cpu.cfs_quota_us)
     cpu_period=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us 2> /dev/null || echo "$cpu_quota")

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -206,7 +206,7 @@ function common::get_cpu_num {
 
   local cpu_quota cpu_period cpu_num
 
-  local wslinterop_path = "/proc/sys/fs/binfmt_misc/WSLInterop"
+  local wslinterop_path="/proc/sys/fs/binfmt_misc/WSLInterop"
 
   if [[ -f /sys/fs/cgroup/cpu/cpu.cfs_quota_us &&
     ( # WSL has cfs_quota_us, but WSL should be checked as usual Linux host

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -209,7 +209,7 @@ function common::get_cpu_num {
   local -r wslinterop_path="/proc/sys/fs/binfmt_misc/WSLInterop"
 
   if [[ -f /sys/fs/cgroup/cpu/cpu.cfs_quota_us &&
-    (! -f "${wslinterop_path}" && ! -f "${wslinterop_path}-late") ]]; then # WSL has cfs_quota_us, but WSL should be checked as usual Linux host
+    (! -f "${wslinterop_path}" && ! -f "${wslinterop_path}-late" && ! -f "/run/WSL") ]]; then # WSL has cfs_quota_us, but WSL should be checked as usual Linux host
     # Inside K8s pod or DinD in K8s
     cpu_quota=$(< /sys/fs/cgroup/cpu/cpu.cfs_quota_us)
     cpu_period=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us 2> /dev/null || echo "$cpu_quota")

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -209,10 +209,7 @@ function common::get_cpu_num {
   local wslinterop_path="/proc/sys/fs/binfmt_misc/WSLInterop"
 
   if [[ -f /sys/fs/cgroup/cpu/cpu.cfs_quota_us &&
-    (
-    ! -f "${wslinterop_path}" &&
-    ! -f "${wslinterop_path}-late") ]] \
-    ; then # WSL has cfs_quota_us, but WSL should be checked as usual Linux host
+    (! -f "${wslinterop_path}" && ! -f "${wslinterop_path}-late") ]]; then # WSL has cfs_quota_us, but WSL should be checked as usual Linux host
     # Inside K8s pod or DinD in K8s
     cpu_quota=$(< /sys/fs/cgroup/cpu/cpu.cfs_quota_us)
     cpu_period=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us 2> /dev/null || echo "$cpu_quota")

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -206,7 +206,7 @@ function common::get_cpu_num {
 
   local cpu_quota cpu_period cpu_num
 
-  local wslinterop_path="/proc/sys/fs/binfmt_misc/WSLInterop"
+  local -r wslinterop_path="/proc/sys/fs/binfmt_misc/WSLInterop"
 
   if [[ -f /sys/fs/cgroup/cpu/cpu.cfs_quota_us &&
     (! -f "${wslinterop_path}" && ! -f "${wslinterop_path}-late") ]]; then # WSL has cfs_quota_us, but WSL should be checked as usual Linux host

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -209,10 +209,10 @@ function common::get_cpu_num {
   local wslinterop_path="/proc/sys/fs/binfmt_misc/WSLInterop"
 
   if [[ -f /sys/fs/cgroup/cpu/cpu.cfs_quota_us &&
-    ( # WSL has cfs_quota_us, but WSL should be checked as usual Linux host
-      ! -f "${wslinterop_path}" &&
-      ! -f "${wslinterop_path}-late"
-    ) ]]; then
+    (
+    ! -f "${wslinterop_path}" &&
+    ! -f "${wslinterop_path}-late") ]] \
+    ; then # WSL has cfs_quota_us, but WSL should be checked as usual Linux host
     # Inside K8s pod or DinD in K8s
     cpu_quota=$(< /sys/fs/cgroup/cpu/cpu.cfs_quota_us)
     cpu_period=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us 2> /dev/null || echo "$cpu_quota")


### PR DESCRIPTION
Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [x] This PR enhances existing functionality.

### Description of your changes

Add a version of `WSLInterop` file that exists in WSL with SystemD enabled.
Ref: https://github.com/Mozilla-Ocho/llamafile/issues/275

Fixes #871 

Or should we better use something like `grep -qi Microsoft /proc/version` (ref: https://github.com/microsoft/WSL/issues/4071) — @MaxymVlasov What do you think? 🤔 