### PR TITLE
feat: Add support for running hooks on `.tofu` files by default

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -123,7 +123,7 @@
     Static analysis of Terraform templates to spot potential security issues.
   require_serial: true
   entry: hooks/terraform_trivy.sh
-  files: \.(tf|tofu|tfvars)?$
+  files: \.(tf|tofu|tfvars)$
   language: script
 
 - id: checkov

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
   entry: hooks/infracost_breakdown.sh
   language: script
   require_serial: true
-  files: \.(tf(vars)?|hcl)$
+  files: \.(tf|tofu|tfvars|hcl)$
   exclude: \.terraform/.*$
 
 - id: terraform_fmt
@@ -13,7 +13,7 @@
     Rewrites all Terraform configuration files to a canonical format.
   entry: hooks/terraform_fmt.sh
   language: script
-  files: (\.tf|\.tfvars)$
+  files: \.(tf|tofu|tfvars)$
   exclude: \.terraform/.*$
 
 - id: terraform_docs
@@ -24,7 +24,7 @@
   require_serial: true
   entry: hooks/terraform_docs.sh
   language: script
-  files: (\.tf|\.terraform\.lock\.hcl)$
+  files: \.(tf|tofu|terraform\.lock\.hcl)$
   exclude: \.terraform/.*$
 
 - id: terraform_docs_without_aggregate_type_defaults
@@ -35,7 +35,7 @@
   require_serial: true
   entry: hooks/terraform_docs.sh
   language: script
-  files: (\.tf)$
+  files: \.(tf|tofu)$
   exclude: \.terraform/.*$
 
 - id: terraform_docs_replace
@@ -44,7 +44,7 @@
   require_serial: true
   entry: python -Im pre_commit_terraform replace-docs
   language: python
-  files: (\.tf)$
+  files: \.(tf|tofu)$
   exclude: \.terraform/.*$
 
 - id: terraform_validate
@@ -53,7 +53,7 @@
   require_serial: true
   entry: hooks/terraform_validate.sh
   language: script
-  files: \.(tf(vars)?|terraform\.lock\.hcl)$
+  files: \.(tf|tofu|tfvars|terraform\.lock\.hcl)$
   exclude: \.terraform/.*$
 
 - id: terraform_providers_lock
@@ -71,7 +71,7 @@
   require_serial: true
   entry: hooks/terraform_tflint.sh
   language: script
-  files: (\.tf|\.tfvars)$
+  files: \.(tf|tofu|tfvars)$
   exclude: \.terraform/.*$
 
 - id: terragrunt_fmt
@@ -114,7 +114,7 @@
     Static analysis of Terraform templates to spot potential security issues.
   require_serial: true
   entry: hooks/terraform_tfsec.sh
-  files: \.tf(vars)?$
+  files: \.(tf|tofu|tfvars)$
   language: script
 
 - id: terraform_trivy
@@ -123,7 +123,7 @@
     Static analysis of Terraform templates to spot potential security issues.
   require_serial: true
   entry: hooks/terraform_trivy.sh
-  files: \.tf(vars)?$
+  files: \.(tf|tofu|tfvars)?$
   language: script
 
 - id: checkov
@@ -133,7 +133,7 @@
   language: python
   pass_filenames: false
   always_run: false
-  files: \.tf$
+  files: \.(tf|tofu)$
   exclude: \.terraform/.*$
   require_serial: true
 
@@ -143,7 +143,7 @@
   entry: hooks/terraform_checkov.sh
   language: script
   always_run: false
-  files: \.tf$
+  files: \.(tf|tofu)$
   exclude: \.terraform/.*$
   require_serial: true
 
@@ -155,7 +155,7 @@
   pass_filenames: false
   always_run: false
   require_serial: true
-  files: \.tf$
+  files: \.(tf|tofu)$
   exclude: \.terraform/.*$
 
 - id: terrascan
@@ -163,7 +163,7 @@
   description: Runs terrascan on Terraform templates.
   language: script
   entry: hooks/terrascan.sh
-  files: \.tf$
+  files: \.(tf|tofu)$
   exclude: \.terraform/.*$
   require_serial: true
 
@@ -174,5 +174,5 @@
   entry: hooks/tfupdate.sh
   args:
   - --args=terraform
-  files: \.tf$
+  files: \.(tf|tofu)$
   require_serial: true


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [x] This PR enhances existing functionality.

### Description of your changes

Opentofu added `.tofu` extension a some time ago for not supported by vanilla Terraform syntax.

https://github.com/terraform-docs/terraform-docs/releases/tag/v0.20.0 also added support for `.tofu`.
All other hooks should be fine with `.tofu` too.

