### PR TITLE
chore(ci): Fix `pre-commit/action`, as v2.x not work anymore

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -56,39 +56,38 @@ jobs:
     - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38  # v5.4.0
       with:
         python-version: '3.13'
+
+    # Need to success pre-commit fix push
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      with:
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.ref }}
+        # Need to trigger pre-commit workflow on autofix commit. Guide:
+        # https://web.archive.org/web/20210731173012/https://github.community/t/required-check-is-expected-after-automated-push/187545/
+        ssh-key: ${{ secrets.GHA_AUTOFIX_COMMIT_KEY }}
+
     - name: Execute pre-commit
-      uses: pre-commit/action@9b88afc9cd57fd75b655d5c71bd38146d07135fe  # v2.0.3
+      uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
       env:
-        SKIP: no-commit-to-branch,hadolint
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        extra_args: >-
-          --color=always
-          --show-diff-on-failure
-          --files ${{ steps.file_changes.outputs.files }}
-    # Run only skipped checks
-    - name: Execute pre-commit check that have no auto-fixes
-      if: always()
-      uses: pre-commit/action@9b88afc9cd57fd75b655d5c71bd38146d07135fe  # v2.0.3
-      env:
-        SKIP: >-
-          check-added-large-files,
-          check-merge-conflict,
-          check-vcs-permalinks,
-          forbid-new-submodules,
-          no-commit-to-branch,
-          end-of-file-fixer,
-          trailing-whitespace,
-          check-yaml,
-          check-merge-conflict,
-          check-executables-have-shebangs,
-          check-case-conflict,mixed-line-ending,
-          detect-aws-credentials,
-          detect-private-key,
-          shfmt,
-          shellcheck,
+        SKIP: no-commit-to-branch
       with:
         extra_args: >-
           --color=always
           --show-diff-on-failure
-          --files ${{ steps.file_changes.outputs.files }}
+          --files ${{ steps.file_changes.outputs.files}}
+
+    # Need to trigger pre-commit workflow on autofix commit.
+    - name: Push fixes
+      if: failure()
+      uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5  # v9.1.4
+      with:
+        # Determines the way the action fills missing author name and email.
+        # Three options are available:
+        # - github_actor -> UserName <UserName@users.noreply.github.com>
+        # - user_info -> Your Display Name <your-actual@email.com>
+        # - github_actions -> github-actions <email associated with the github logo>
+        # Default: github_actor
+        default_author: github_actor
+        # The message for the commit.
+        # Default: 'Commit from GitHub Actions (name of the workflow)'
+        message: '[pre-commit] Autofix violations'

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -90,4 +90,4 @@ jobs:
         default_author: github_actor
         # The message for the commit.
         # Default: 'Commit from GitHub Actions (name of the workflow)'
-        message: '[pre-commit] Fix violations'
+        message: '[pre-commit] Autofix violations'

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -57,12 +57,12 @@ jobs:
       with:
         python-version: '3.13'
 
-    # Need to success pre-commit fix push
+    # Needed for pre-commit fix push to succeed
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       with:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.ref }}
-        # Need to trigger pre-commit workflow on autofix commit. Guide:
+        # Needed to trigger pre-commit workflow on autofix commit. Guide:
         # https://web.archive.org/web/20210731173012/https://github.community/t/required-check-is-expected-after-automated-push/187545/
         ssh-key: ${{ secrets.GHA_AUTOFIX_COMMIT_KEY }}
 
@@ -76,7 +76,7 @@ jobs:
           --show-diff-on-failure
           --files ${{ steps.file_changes.outputs.files}}
 
-    # Need to trigger pre-commit workflow on autofix commit.
+    # Needed to trigger pre-commit workflow on autofix commit
     - name: Push fixes
       if: failure()
       uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5  # v9.1.4
@@ -90,4 +90,4 @@ jobs:
         default_author: github_actor
         # The message for the commit.
         # Default: 'Commit from GitHub Actions (name of the workflow)'
-        message: '[pre-commit] Autofix violations'
+        message: '[pre-commit] Fix violations'


### PR DESCRIPTION
### Description of your changes

Deal with 

> Error: getCacheEntry failed: This legacy service is shutting down, effective April 15, 2025. Migrate to the new service ASAP. For more information: https://gh.io/gha-cache-sunset

https://github.com/antonbabenko/pre-commit-terraform/actions/runs/14755939444/job/41424052063?pr=589


### How can we test changes

@antonbabenko please,
1. run `ssh-keygen -t ed25519` locally
2. Add private key as  repo secret with name exactly  `GHA_AUTOFIX_COMMIT_KEY` at https://github.com/antonbabenko/pre-commit-terraform/settings/secrets/actions
3. Add public key as Deploy key with name like `GHA_AUTOFIX` at https://github.com/antonbabenko/pre-commit-terraform/settings/keys

And then we will be able to test it this PR
