### PR TITLE
docs(tflint): Replace deprecated value in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,10 +347,10 @@ Config example:
 - id: terraform_tflint
   args:
   - --args=--config=${CONFIG_NAME}.${CONFIG_EXT}
-  - --args=--module
+  - --args=--call-module-type="all"
 ```
 
-If for config above set up `export CONFIG_NAME=.tflint; export CONFIG_EXT=hcl` before `pre-commit run`, args will be expanded to `--config=.tflint.hcl --module`.
+If for config above set up `export CONFIG_NAME=.tflint; export CONFIG_EXT=hcl` before `pre-commit run`, args will be expanded to `--config=.tflint.hcl --call-module-type="all"`.
 
 ### All hooks: Set env vars inside hook at runtime
 


### PR DESCRIPTION
### Description of your changes

`--module` was deprecated in TFLint v0.50.0 and removed in v0.54.0.

According to https://github.com/antonbabenko/pre-commit-terraform/issues/534#issuecomment-2858451826, it should be replaced to `--call-module-type="all"`
