### PR TITLE
docs: Add missed step for init'ed repos and resolve confusion that deps should be find out and installed manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,15 +242,15 @@ Full list of dependencies and where they are used:
 #### 1.1 Custom Terraform binaries and OpenTofu support
 
 It is possible to set custom path to `terraform` binary.  
-This makes it possible to use [OpenTofu](https://opentofu.org) binary `tofu` instead of `terraform`.
+This makes it possible to use [OpenTofu](https://opentofu.org) binary (`tofu`) instead of `terraform`.
 
 How binary discovery works and how you can redefine it (first matched takes precedence):
 
 1. Check if per hook configuration `--hook-config=--tf-path=<path_to_binary_or_binary_name>` is set
 2. Check if `PCT_TFPATH=<path_to_binary_or_binary_name>` environment variable is set
 3. Check if `TERRAGRUNT_TFPATH=<path_to_binary_or_binary_name>` environment variable is set
-4. Check if `terraform` binary can be found in the user's $PATH
-5. Check if `tofu` binary can be found in the user's $PATH
+4. Check if `terraform` binary can be found in the user's `$PATH`
+5. Check if `tofu` binary can be found in the user's `$PATH`
 
 
 ### 2. Install the pre-commit hook globally

--- a/README.md
+++ b/README.md
@@ -83,43 +83,6 @@ If you want to support the development of `pre-commit-terraform` and [many other
 ## How to install
 
 ### 1. Install dependencies
-<!-- (Do not remove html tags here) -->
-* [`pre-commit`](https://pre-commit.com/#install),
-  <sub><sup>[`terraform`](https://www.terraform.io/downloads.html) or [`opentofu`](https://opentofu.org/docs/intro/install/),
-  <sub><sup>[`git`](https://git-scm.com/downloads),
-  <sub><sup>[BASH `3.2.57` or newer](https://www.gnu.org/software/bash/#download),
-  <sub><sup>Internet connection (on first run),
-  <sub><sup>x86_64 or arm64 compatible operating system,
-  <sub><sup>Some hardware where this OS will run,
-  <sub><sup>Electricity for hardware and internet connection,
-  <sub><sup>Some basic physical laws,
-  <sub><sup>Hope that it all will work.
-  </sup></sub></sup></sub></sup></sub></sup></sub></sup></sub></sup></sub></sup></sub></sup></sub></sup></sub><br><br>
-* [`checkov`][checkov repo] required for `terraform_checkov` hook
-* [`terraform-docs`][terraform-docs repo] 0.12.0+ required for `terraform_docs` hook
-* [`terragrunt`][terragrunt repo] required for `terragrunt_validate` and `terragrunt_valid_inputs` hooks
-* [`terrascan`][terrascan repo] required for `terrascan` hook
-* [`TFLint`][tflint repo] required for `terraform_tflint` hook
-* [`TFSec`][tfsec repo] required for `terraform_tfsec` hook
-* [`Trivy`][trivy repo] required for `terraform_trivy` hook
-* [`infracost`][infracost repo] required for `infracost_breakdown` hook
-* [`jq`][jq repo] required for `terraform_validate` with `--retry-once-with-cleanup` flag, and for `infracost_breakdown` hook
-* [`tfupdate`][tfupdate repo] required for `tfupdate` hook
-* [`hcledit`][hcledit repo] required for `terraform_wrapper_module_for_each` hook
-
-
-#### 1.1 Custom Terraform binaries and OpenTofu support
-
-It is possible to set custom path to `terraform` binary.  
-This makes it possible to use [OpenTofu](https://opentofu.org) binary `tofu` instead of `terraform`.
-
-How binary discovery works and how you can redefine it (first matched takes precedence):
-
-1. Check if per hook configuration `--hook-config=--tf-path=<path_to_binary_or_binary_name>` is set
-2. Check if `PCT_TFPATH=<path_to_binary_or_binary_name>` environment variable is set
-3. Check if `TERRAGRUNT_TFPATH=<path_to_binary_or_binary_name>` environment variable is set
-4. Check if `terraform` binary can be found in the user's $PATH
-5. Check if `tofu` binary can be found in the user's $PATH
 
 <details><summary><b>Docker</b></summary><br>
 
@@ -249,6 +212,47 @@ E.g. `C:\Users\USERNAME\AppData\Local\Programs\Python\Python39\Lib\site-packages
 
 </details>
 
+Full list of dependencies and where they used:
+
+<!-- (Do not remove html tags here) -->
+* [`pre-commit`](https://pre-commit.com/#install),
+  <sub><sup>[`terraform`](https://www.terraform.io/downloads.html) or [`opentofu`](https://opentofu.org/docs/intro/install/),
+  <sub><sup>[`git`](https://git-scm.com/downloads),
+  <sub><sup>[BASH `3.2.57` or newer](https://www.gnu.org/software/bash/#download),
+  <sub><sup>Internet connection (on first run),
+  <sub><sup>x86_64 or arm64 compatible operating system,
+  <sub><sup>Some hardware where this OS will run,
+  <sub><sup>Electricity for hardware and internet connection,
+  <sub><sup>Some basic physical laws,
+  <sub><sup>Hope that it all will work.
+  </sup></sub></sup></sub></sup></sub></sup></sub></sup></sub></sup></sub></sup></sub></sup></sub></sup></sub><br><br>
+* [`checkov`][checkov repo] required for `terraform_checkov` hook
+* [`terraform-docs`][terraform-docs repo] 0.12.0+ required for `terraform_docs` hook
+* [`terragrunt`][terragrunt repo] required for `terragrunt_validate` and `terragrunt_valid_inputs` hooks
+* [`terrascan`][terrascan repo] required for `terrascan` hook
+* [`TFLint`][tflint repo] required for `terraform_tflint` hook
+* [`TFSec`][tfsec repo] required for `terraform_tfsec` hook
+* [`Trivy`][trivy repo] required for `terraform_trivy` hook
+* [`infracost`][infracost repo] required for `infracost_breakdown` hook
+* [`jq`][jq repo] required for `terraform_validate` with `--retry-once-with-cleanup` flag, and for `infracost_breakdown` hook
+* [`tfupdate`][tfupdate repo] required for `tfupdate` hook
+* [`hcledit`][hcledit repo] required for `terraform_wrapper_module_for_each` hook
+
+
+#### 1.1 Custom Terraform binaries and OpenTofu support
+
+It is possible to set custom path to `terraform` binary.  
+This makes it possible to use [OpenTofu](https://opentofu.org) binary `tofu` instead of `terraform`.
+
+How binary discovery works and how you can redefine it (first matched takes precedence):
+
+1. Check if per hook configuration `--hook-config=--tf-path=<path_to_binary_or_binary_name>` is set
+2. Check if `PCT_TFPATH=<path_to_binary_or_binary_name>` environment variable is set
+3. Check if `TERRAGRUNT_TFPATH=<path_to_binary_or_binary_name>` environment variable is set
+4. Check if `terraform` binary can be found in the user's $PATH
+5. Check if `tofu` binary can be found in the user's $PATH
+
+
 ### 2. Install the pre-commit hook globally
 
 > [!NOTE]
@@ -274,6 +278,14 @@ repos:
     - id: terraform_fmt
     - id: terraform_docs
 EOF
+```
+
+If this repository was initialized locally via `git init` or `git clone` _before_
+you installed the pre-commit hook globally ([step 2]((#2-install-the-pre-commit-hook-globally))),
+you will need to run:
+
+```bash
+pre-commit install
 ```
 
 ### 4. Run

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ EOF
 ```
 
 If this repository was initialized locally via `git init` or `git clone` _before_
-you installed the pre-commit hook globally ([step 2]((#2-install-the-pre-commit-hook-globally))),
+you installed the pre-commit hook globally ([step 2](#2-install-the-pre-commit-hook-globally)),
 you will need to run:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ E.g. `C:\Users\USERNAME\AppData\Local\Programs\Python\Python39\Lib\site-packages
 
 </details>
 
-Full list of dependencies and where they are used:'
+Full list of dependencies and where they are used:
 
 <!-- (Do not remove html tags here) -->
 * [`pre-commit`](https://pre-commit.com/#install),

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ E.g. `C:\Users\USERNAME\AppData\Local\Programs\Python\Python39\Lib\site-packages
 
 </details>
 
-Full list of dependencies and where they used:
+Full list of dependencies and where they are used:'
 
 <!-- (Do not remove html tags here) -->
 * [`pre-commit`](https://pre-commit.com/#install),


### PR DESCRIPTION

### Description of your changes

* Previously, these docs wrongly assumed that repo was `git init`/`git clone` after setting up of `init.templateDir`, which is not the case for 90%+ of newcomers.
* Installation instructions were too far away for list of dependencies, so it were easy to interpret that you need to install all these deps manually, and only then find out that there are already instructions that cover their installation. Rearranging them slightly, fix that issues

