### PR TITLE
chore(ci): Prepare to switch to Merge Queue for PR merging

### DIFF
--- a/.github/workflows/build-image-test.yaml
+++ b/.github/workflows/build-image-test.yaml
@@ -1,6 +1,7 @@
 name: Build Dockerfile if changed and run smoke tests
 
 on:
+  merge_group:
   pull_request:
 
 permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,6 +15,7 @@ on:
   push:
     branches:
     - master
+  merge_group:
   pull_request:
   schedule:
   - cron: 0 0 * * 1

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,6 +10,7 @@
 name: Dependency Review
 
 on:
+  merge_group:
   pull_request:
 
 permissions:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,6 +1,7 @@
 name: Common issues check
 
 on:
+  merge_group:
   pull_request:
 
 permissions:


### PR DESCRIPTION
### Description of your changes
I previously tried to automate Renovate PR merges, but it works poorly, plus it's time to time violate review process.

So, to address known issues with time-consuming merge of many Renovate PRs at once, make OpenSSF scorecard happier in terms of branch protection rules (https://github.com/antonbabenko/pre-commit-terraform/issues/712) and make finally get ability to merge many Renovate PRs at once - let's enable Merge queue for PRs.
For this, required:
1. Merge this PR
2. Change branch protection ruleset slightly (will send instructions to Anton later)
3. Enable Merge Queue in repo settings.   
    UPD. Merge Queue is accessible only for organizations... So we're can't use it right now, but I'll merge it anyway in case if we will migrate to organization one day