### PR TITLE
Chore: hclfmt deprecation

### DIFF
--- a/hooks/terragrunt_fmt.sh
+++ b/hooks/terragrunt_fmt.sh
@@ -46,7 +46,7 @@ function per_dir_hook_unique_part {
   local -a -r args=("$@")
 
   # pass the arguments to hook
-  terragrunt hclfmt "${args[@]}"
+  terragrunt hcl format "${args[@]}"
 
   # return exit code to common::per_dir_hook
   local exit_code=$?


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [x] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [x] This PR enhances existing functionality.

### Description of your changes

`hclfmt` is being deprecated and terragrunt produces a warning on execution, 
 See https://github.com/gruntwork-io/terragrunt/releases/tag/v0.78.0
    
Fix :
    ```
    WARN   The `hclfmt` command is deprecated and will be removed in a future version of Terragrunt. Use `terragrunt hcl format` instead.
    ```

### How can we test changes

With terragrunt v0.78 or above the pre-commit hook `terragrunt_fmt` should not emit any warnings.

Note: for version [v0.77.22](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.77.22) and below `hcl format` is just ignored, no error but neither format for broken files.