### PR TITLE
The `hclfmt` command is no longer supported. Use `terragrunt hcl format` instead.

### DIFF
--- a/hooks/terragrunt_fmt.sh
+++ b/hooks/terragrunt_fmt.sh
@@ -12,7 +12,7 @@ function main {
   common::parse_cmdline "$@"
   common::export_provided_env_vars "${ENV_VARS[@]}"
   common::parse_and_export_env_vars
-  # JFYI: terragrunt hclfmt color already suppressed via PRE_COMMIT_COLOR=never
+  # JFYI: `terragrunt hcl format` color already suppressed via PRE_COMMIT_COLOR=never
 
   # shellcheck disable=SC2153 # False positive
   common::per_dir_hook "$HOOK_ID" "${#ARGS[@]}" "${ARGS[@]}" "${FILES[@]}"
@@ -46,7 +46,7 @@ function per_dir_hook_unique_part {
   local -a -r args=("$@")
 
   # pass the arguments to hook
-  terragrunt hclfmt "${args[@]}"
+  terragrunt hcl format "${args[@]}"
 
   # return exit code to common::per_dir_hook
   local exit_code=$?
@@ -63,7 +63,7 @@ function run_hook_on_whole_repo {
   local -a -r args=("$@")
 
   # pass the arguments to hook
-  terragrunt hclfmt "$(pwd)" "${args[@]}"
+  terragrunt hcl format "$(pwd)" "${args[@]}"
 
   # return exit code to common::per_dir_hook
   local exit_code=$?


### PR DESCRIPTION
The `hclfmt` command is no longer supported by terragrunt. Use `terragrunt hcl format` instead.

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

terragrunt_fmt currently runs `hclfmt` under the hood but that command was changed to `terragrunt hcl format` a while ago.

![CleanShot 2025-05-29 at 08 15 59](https://github.com/user-attachments/assets/54b073f2-43d7-42bb-91e4-a11d5216607a)

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123456":
-->

<!-- Fixes # -->

### How can we test changes

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I applied the PR to pre-commit config locally and it fixed the issue.