### PR TITLE
chore(security): Pin pre-commit hooks by SHA, as it is immutable

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,4 +15,7 @@
   commitMessageLowerCase: "never",
   // Disable auto-rebase on every commit to avoid reaching Github limits on macos runners
   rebaseWhen: "conflicted",
+  "pre-commit": {
+    enabled: false, // Use pre-commit.ci freeze instead
+  },
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ ci:
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v5.0.0
+  rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b  # frozen: v5.0.0
   hooks:
   # Git style
   - id: check-added-large-files
@@ -43,19 +43,19 @@ repos:
 
   # Detect hardcoded secrets
 - repo: https://github.com/gitleaks/gitleaks
-  rev: v8.26.0
+  rev: a248f9279b38aeff5bbd4c85cc6f15b64d27e794  # frozen: v8.27.0
   hooks:
   - id: gitleaks
 
 # Dockerfile
 - repo: https://github.com/hadolint/hadolint
-  rev: v2.13.1-beta
+  rev: c3dc18df7a501f02a560a2cc7ba3c69a85ca01d3  # frozen: v2.13.1-beta
   hooks:
   - id: hadolint
 
 # YAML
 - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
-  rev: 0.2.3
+  rev: 8d1b9cadaf854cb25bb0b0f5870e1cc66a083d6b  # frozen: 0.2.3
   hooks:
   - id: yamlfmt
     args:
@@ -66,7 +66,7 @@ repos:
     - --implicit_start
 
 - repo: https://github.com/adrienverge/yamllint.git
-  rev: v1.37.1
+  rev: 79a6b2b1392eaf49cdd32ac4f14be1a809bbd8f7  # frozen: v1.37.1
   hooks:
   - id: yamllint
     types:
@@ -77,7 +77,7 @@ repos:
 
 # JSON5
 - repo: https://github.com/pre-commit/mirrors-prettier
-  rev: v4.0.0-alpha.8
+  rev: f12edd9c7be1c20cfa42420fd0e6df71e42b51ea  # frozen: v4.0.0-alpha.8
   hooks:
   - id: prettier
     # https://prettier.io/docs/en/options.html#parser
@@ -85,7 +85,7 @@ repos:
 
 # Bash
 - repo: https://github.com/jumanjihouse/pre-commit-hooks
-  rev: 3.0.0
+  rev: 38980559e3a605691d6579f96222c30778e5a69e  # frozen: 3.0.0
   hooks:
   - id: shfmt
     args:
@@ -99,7 +99,7 @@ repos:
 
 # Python
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.11
+  rev: d19233b89771be2d89273f163f5edc5a39bbc34a  # frozen: v0.11.12
   hooks:
   - id: ruff
     args:
@@ -107,7 +107,7 @@ repos:
   - id: ruff-format
 
 - repo: https://github.com/pre-commit/mirrors-mypy.git
-  rev: v1.15.0
+  rev: 7010b10a09f65cd60a23c207349b539aa36dbec1  # frozen: v1.16.0
   hooks:
   - id: mypy
     alias: mypy-py313

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
 
 # Github Action static analysis tool
 - repo: https://github.com/woodruffw/zizmor-pre-commit
-  rev: v1.9.0
+  rev: d2c1833a059c66713cd52c032617766134679a0f  # frozen: v1.9.0
   hooks:
   - id: zizmor
 
@@ -105,7 +105,7 @@ repos:
 
 # Python
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: d19233b89771be2d89273f163f5edc5a39bbc34a  # frozen: v0.11.12
+  rev: 9aeda5d1f4bbd212c557da1ea78eca9e8c829e19  # frozen: v0.11.13
   hooks:
   - id: ruff
     args:


### PR DESCRIPTION
Pinned by `pre-commit autoupdate --freeze` as `pre-commit` in Renovate currently [does not support](https://github.com/renovatebot/renovate/discussions/22488) freezing style used by `pre-commit` 