### PR TITLE
fix(`terraform_docs`, `terraform_wrapper_module_for_each`): Improve `.tofu` files support

### DIFF
--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -207,7 +207,7 @@ function terraform_docs {
     #
     if $create_if_not_exist && [[ ! -f "$output_file" ]]; then
       dir_have_tf_files="$(
-        find . -maxdepth 1 -type f \( -name '*.tf' -o -name '*.tofu' -o -name '*.tfvars' \) ||
+        find . -maxdepth 1 -type f \(-o -name '*.tf' -o -name '*.tofu' -o -name '*.tfvars' \) ||
           exit 0
       )"
 

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -207,7 +207,7 @@ function terraform_docs {
     #
     if $create_if_not_exist && [[ ! -f "$output_file" ]]; then
       dir_have_tf_files="$(
-        find . -maxdepth 1 -type f \( -name '*.tf' -o -name '*.tofu' -o -name '*.tfvars' \) ||
+        find . -maxdepth 1 \( -name '*.tf' -o -name '*.tofu' -o -name '*.tfvars' \) -type f ||
           exit 0
       )"
 

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -207,7 +207,7 @@ function terraform_docs {
     #
     if $create_if_not_exist && [[ ! -f "$output_file" ]]; then
       dir_have_tf_files="$(
-        find . -maxdepth 1 -type f | sed 's|.*\.||' | sort -u | grep -oE '^tf$|^tofu$|^tfvars$' ||
+        find . -maxdepth 1 \( -name '*.tf' -o -name '*.tofu' -o -name '*.tfvars' \) ||
           exit 0
       )"
 

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -207,7 +207,7 @@ function terraform_docs {
     #
     if $create_if_not_exist && [[ ! -f "$output_file" ]]; then
       dir_have_tf_files="$(
-        find . -maxdepth 1 -type f \(-o -name '*.tf' -o -name '*.tofu' -o -name '*.tfvars' \) ||
+        find . -maxdepth 1 -type f \(-name '*.tf' -o -name '*.tofu' -o -name '*.tfvars' \) ||
           exit 0
       )"
 

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -207,7 +207,7 @@ function terraform_docs {
     #
     if $create_if_not_exist && [[ ! -f "$output_file" ]]; then
       dir_have_tf_files="$(
-        find . -maxdepth 1 -type f | sed 's|.*\.||' | sort -u | grep -oE '^tf$|^tfvars$' ||
+        find . -maxdepth 1 -type f | sed 's|.*\.||' | sort -u | grep -oE '^tf$|^tofu$|^tfvars$' ||
           exit 0
       )"
 

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -207,7 +207,7 @@ function terraform_docs {
     #
     if $create_if_not_exist && [[ ! -f "$output_file" ]]; then
       dir_have_tf_files="$(
-        find . -maxdepth 1 -type f \(-name '*.tf' -o -name '*.tofu' -o -name '*.tfvars' \) ||
+        find . -maxdepth 1 -type f \( -name '*.tf' -o -name '*.tofu' -o -name '*.tfvars' \) ||
           exit 0
       )"
 

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -207,7 +207,7 @@ function terraform_docs {
     #
     if $create_if_not_exist && [[ ! -f "$output_file" ]]; then
       dir_have_tf_files="$(
-        find . -maxdepth 1 \( -name '*.tf' -o -name '*.tofu' -o -name '*.tfvars' \) ||
+        find . -maxdepth 1 -type f \( -name '*.tf' -o -name '*.tofu' -o -name '*.tfvars' \) ||
           exit 0
       )"
 

--- a/hooks/terraform_wrapper_module_for_each.sh
+++ b/hooks/terraform_wrapper_module_for_each.sh
@@ -312,7 +312,7 @@ EOF
 
     # Read content of all terraform files
     # shellcheck disable=SC2207
-    all_tf_content=$(find "${full_module_dir}" -regex '.*\.(tf|tofu)' -maxdepth 1 -type f -exec cat {} +)
+    all_tf_content=$(find "${full_module_dir}" \( -name '*.tf' -o -name '*.tofu' \) -maxdepth 1 -type f -exec cat {} +)
 
     if [[ ! $all_tf_content ]]; then
       common::colorify "yellow" "Skipping ${full_module_dir} because there are no .tf or .tofu files."

--- a/hooks/terraform_wrapper_module_for_each.sh
+++ b/hooks/terraform_wrapper_module_for_each.sh
@@ -312,10 +312,10 @@ EOF
 
     # Read content of all terraform files
     # shellcheck disable=SC2207
-    all_tf_content=$(find "${full_module_dir}" -name '*.tf' -maxdepth 1 -type f -exec cat {} +)
+    all_tf_content=$(find "${full_module_dir}" -regex '.*\.(tf|tofu)' -maxdepth 1 -type f -exec cat {} +)
 
     if [[ ! $all_tf_content ]]; then
-      common::colorify "yellow" "Skipping ${full_module_dir} because there are no *.tf files."
+      common::colorify "yellow" "Skipping ${full_module_dir} because there are no .tf or .tofu files."
       continue
     fi
 

--- a/hooks/terraform_wrapper_module_for_each.sh
+++ b/hooks/terraform_wrapper_module_for_each.sh
@@ -312,7 +312,7 @@ EOF
 
     # Read content of all terraform files
     # shellcheck disable=SC2207
-    all_tf_content=$(find "${full_module_dir}" \( -name '*.tf' -o -name '*.tofu' \) -maxdepth 1 -type f -exec cat {} +)
+    all_tf_content=$(find "${full_module_dir}" -maxdepth 1 \( -name '*.tf' -o -name '*.tofu' \) -type f -exec cat {} +)
 
     if [[ ! $all_tf_content ]]; then
       common::colorify "yellow" "Skipping ${full_module_dir} because there are no .tf or .tofu files."


### PR DESCRIPTION
Pull-back from fork

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [x] This PR enhances existing functionality.

### Description of your changes

There are a few places inside hooks where search by extension performed, and previously it missed check for `.tofu`
