### PR TITLE
chore(docker): Add integrity validation for separately installed pip packages

### DIFF
--- a/tools/install/checkov.sh
+++ b/tools/install/checkov.sh
@@ -29,6 +29,7 @@ if [[ $VERSION == latest ]]; then
 else
   pip3 install --no-cache-dir "${TOOL}==${VERSION}"
 fi
+pip3 check
 
 apk del gcc libffi-dev musl-dev
 # no longer required once checkov version depends on rustworkx >0.14.0

--- a/tools/install/pre-commit.sh
+++ b/tools/install/pre-commit.sh
@@ -14,3 +14,4 @@ if [[ $VERSION == latest ]]; then
 else
   pip3 install --no-cache-dir "${TOOL}==${VERSION}"
 fi
+pip3 check


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

### Description of your changes
Check `pip` after each installation, to ensure that everything still works correctl

Address https://github.com/antonbabenko/pre-commit-terraform/pull/635#discussion_r1521227039:
> *do not* install distributions with pip separately because it will not take all things installed in the previous session into account when you run a new install command. Enumerate everything and let the dependency resolver know all your requirements together. Ideally, use pip-compile to produce and commit constraint files (lockfiles) and invoke it via `pip install -r direct-deps.txt -c constraint.txt`.
> If you do run separate pip installs, inject a `pip check` invocation at the end to verify integrity.

I suppose it should be runs just once at the end of installation, but it's mostly free to run `pip check` after all pip installations, so I did exactly that 