### PR TITLE
fix(docker): Drop Mac arm64 build-time hack, needed for `checkov`<3.2.395

### DIFF
--- a/tools/install/checkov.sh
+++ b/tools/install/checkov.sh
@@ -13,24 +13,8 @@ apk add --no-cache \
   libffi-dev=~3 \
   musl-dev=~1
 
-# cargo, gcc, git, musl-dev, rust and CARGO envvar required for compilation of rustworkx@0.13.2
-# no longer required once checkov version depends on rustworkx >0.14.0
-# https://github.com/bridgecrewio/checkov/pull/6045
-# gcc libffi-dev musl-dev required for compilation of cffi, until it contains musl aarch64
-export CARGO_NET_GIT_FETCH_WITH_CLI=true
-apk add --no-cache \
-  cargo=~1 \
-  git=~2 \
-  libgcc=~12 \
-  rust=~1
-
 if [[ $VERSION == latest ]]; then
   pip3 install --no-cache-dir "${TOOL}"
 else
   pip3 install --no-cache-dir "${TOOL}==${VERSION}"
 fi
-
-apk del gcc libffi-dev musl-dev
-# no longer required once checkov version depends on rustworkx >0.14.0
-# https://github.com/bridgecrewio/checkov/pull/6045
-apk del cargo git rust


### PR DESCRIPTION
### Description of your changes

Drop not more needed to hack for `checkov` during docker images installation, as https://github.com/bridgecrewio/checkov/pull/7072 merged 3 months ago as `3.2.395`.

That's make obsolete hack from https://github.com/antonbabenko/pre-commit-terraform/pull/635 as https://github.com/bridgecrewio/checkov/pull/7072 finally closes https://github.com/bridgecrewio/checkov/issues/5608 for Mac arm64, because `checkov` finally uses `rustworkx >= 0.14.0`