### PR TITLE
fix: Regression from (at least) v1.99.0 which incorrectly handle `pre-commit run -a`, that causes multiply hooks runs. `terraform_trivy` from its introduction could always be `Passed` for `pre-commit run -a`

### DIFF
--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -176,9 +176,9 @@ function common::is_hook_run_on_whole_repo {
   local all_files_that_can_be_checked
 
   if [ -z "$excluded_files" ]; then
-    all_files_that_can_be_checked=$(git ls-files | sort | grep -e "$included_files" | tr '\n' ' ')
+    all_files_that_can_be_checked=$(git ls-files | sort | grep -E "$included_files" | tr '\n' ' ')
   else
-    all_files_that_can_be_checked=$(git ls-files | sort | grep -e "$included_files" | grep -v -e "$excluded_files" | tr '\n' ' ')
+    all_files_that_can_be_checked=$(git ls-files | sort | grep -E "$included_files" | grep -v -E "$excluded_files" | tr '\n' ' ')
   fi
 
   if [ "$files_to_check" == "$all_files_that_can_be_checked" ]; then

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -176,9 +176,9 @@ function common::is_hook_run_on_whole_repo {
   local all_files_that_can_be_checked
 
   if [ -z "$excluded_files" ]; then
-    all_files_that_can_be_checked=$(git ls-files | sort | grep -E "$included_files" | tr '\n' ' ')
+    all_files_that_can_be_checked=$(git ls-files | sort | grep -E -- "$included_files" | tr '\n' ' ')
   else
-    all_files_that_can_be_checked=$(git ls-files | sort | grep -E "$included_files" | grep -v -E "$excluded_files" | tr '\n' ' ')
+    all_files_that_can_be_checked=$(git ls-files | sort | grep -E -- "$included_files" | grep -v -E -- "$excluded_files" | tr '\n' ' ')
   fi
 
   if [ "$files_to_check" == "$all_files_that_can_be_checked" ]; then

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -187,7 +187,7 @@ function terraform_docs {
     config_file_no_color="$config_file$(date +%s).yml"
 
     if [ "$PRE_COMMIT_COLOR" = "never" ] &&
-      [[ $(grep -e '^formatter:' "$config_file") == *"pretty"* ]] &&
+      [[ $(grep -E '^formatter:' "$config_file") == *"pretty"* ]] &&
       [[ $(grep '  color: ' "$config_file") != *"false"* ]]; then
 
       cp "$config_file" "$config_file_no_color"

--- a/hooks/terraform_trivy.sh
+++ b/hooks/terraform_trivy.sh
@@ -65,7 +65,7 @@ function run_hook_on_whole_repo {
   local -a -r args=("$@")
 
   # pass the arguments to hook
-  trivy conf "$(pwd)" "${args[@]}"
+  trivy conf "$(pwd)" --exit-code=1 "${args[@]}"
 
   # return exit code to common::per_dir_hook
   local exit_code=$?


### PR DESCRIPTION
Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

Probably introduced in https://github.com/antonbabenko/pre-commit-terraform/pull/875 or even earlier.
There were issue that regex in `.pre-commit-hooks.yaml` specified for Python `re` library, but we also used it with `grep -e`. `grep -e` working slightly different than we expect, so I switched to `grep -E` which have less differences with Python `re`. (step 3 below)

Then I found that there is no [required `--exit-code=1`](https://trivy.dev/latest/docs/configuration/others/#exit-code) in `run_hook_on_whole_repo` from hook introduction 2 years ago https://github.com/antonbabenko/pre-commit-terraform/pull/606. Fixed it too.

From above, I assume that `pre-commit run -a` for 


Fix #908

### How can we test changes

1. Clone https://github.com/pre-commit-terraform/GH-908-reproduce. 
2. Run `pre-commit run -a` - you'll see 2 occurrences of same error.
3. (Optional) Change `.pre-commit-config.yaml` to

    ```yaml
    repos:
      - repo: https://github.com/antonbabenko/pre-commit-terraform
        rev: 48525b2912a56f8b707671ba67d5932549384cce
        hooks:
          - id: terraform_trivy
            args:
              # https://trivy.dev/latest/docs/configuration/others/#exit-code 
              # It wasn't set, when it should be set by default in hook. Another issue.
              - --args=--exit-code=1
    ```
	and run  `pre-commit run -a`
4. Change `.pre-commit-config.yaml` to

    ```yaml
    repos:
      - repo: https://github.com/antonbabenko/pre-commit-terraform
        rev: bafa6635606e8f6f5bd81fe99a391a2b12245768
        hooks:
          - id: terraform_trivy
	```
    and run  `pre-commit run -a`

