### PR TITLE
feat(`terraform_fmt`): Add support for `.tftest.hcl` and `.tfmock.hcl` formatting

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -13,7 +13,7 @@
     Rewrites all Terraform configuration files to a canonical format.
   entry: hooks/terraform_fmt.sh
   language: script
-  files: \.(tf|tofu|tfvars)$
+  files: \.(tf|tofu|tfvars|tftest\.hcl|tfmock\.hcl)$
   exclude: \.terraform/.*$
 
 - id: terraform_docs

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -13,6 +13,8 @@
     Rewrites all Terraform configuration files to a canonical format.
   entry: hooks/terraform_fmt.sh
   language: script
+  # Supported extensions by Terraform specified in
+  # https://github.com/hashicorp/terraform/blob/0c63fb2b097edcd5cb1a91322765a414206fbea2/internal/command/fmt.go#L30-L35
   files: \.(tf|tofu|tfvars|tftest\.hcl|tfmock\.hcl)$
   exclude: \.terraform/.*$
 


### PR DESCRIPTION
This adds `.tftest.hcl` and `.tfmock.hcl` to the default `files` attribute for the `terraform_fmt` hook config.

Support for formatting these files were added in recent terraform versions


---
Notes by @MaxymVlasov:
* `terraform fmt` definitely supports `.tfmock.hcl` , because not supporting of it was reported as a bug, and now is resolved by addition of such support - https://github.com/hashicorp/terraform/issues/34577 
* And `.tftest.hcl` also mentioned in `fmtSupportedExts` - https://github.com/hashicorp/terraform/blob/0c63fb2b097edcd5cb1a91322765a414206fbea2/internal/command/fmt.go#L30-L35