### PR TITLE
chore(deps): Use latest available Python 3.12 base image

### DIFF
--- a/.github/.container-structure-test-config.yaml
+++ b/.github/.container-structure-test-config.yaml
@@ -20,7 +20,7 @@ commandTests:
   args:
   - --version
   expectedOutput:
-  - ^gcc \(Alpine 12\.
+  - ^gcc \(Alpine 14\.
 
 - name: checkov
   command: checkov
@@ -131,7 +131,7 @@ commandTests:
   args:
   - -V
   expectedError:
-  - ^OpenSSH_9\.[0-9]+
+  - ^OpenSSH_10\.[0-9]+
 
 fileExistenceTests:
 - name: terrascan init

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-alpine@sha256:4a1f551c823300739780fb28ad02d8e8861007186c4913b53c0344f8a375b556 AS python_base
+FROM python:3.12-alpine@sha256:9b8808206f4a956130546a32cbdd8633bc973b19db2923b7298e6f90cc26db08 AS python_base
 
 FROM python_base AS builder
 ARG TARGETOS

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,11 +116,11 @@ RUN apk add --no-cache \
     bash=~5 \
     # pre-commit-hooks deps: https://github.com/pre-commit/pre-commit-hooks
     musl-dev=~1 \
-    gcc=~12 \
+    gcc=~14 \
     # entrypoint wrapper deps
     su-exec=~0.2 \
     # ssh-client for external private module in ssh
-    openssh-client=~9
+    openssh-client=~10
 
 # Copy tools
 COPY --from=builder \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.0-alpine3.17@sha256:fc34b07ec97a4f288bc17083d288374a803dd59800399c76b977016c9fe5b8f2 AS python_base
+FROM python:3.12-alpine@sha256:4a1f551c823300739780fb28ad02d8e8861007186c4913b53c0344f8a375b556 AS python_base
 
 FROM python_base AS builder
 ARG TARGETOS

--- a/tools/install/checkov.sh
+++ b/tools/install/checkov.sh
@@ -9,7 +9,7 @@ readonly SCRIPT_DIR
 #
 
 apk add --no-cache \
-  gcc=~12 \
+  gcc=~14 \
   libffi-dev=~3 \
   musl-dev=~1
 


### PR DESCRIPTION
### Description of your changes
In https://github.com/antonbabenko/pre-commit-terraform/pull/915 I find out that current base docker image wasn't updated for 6 months, as Renovate updates SHA, but for some reason doesn't update image tag version (not supported?).

To fix that, I loose tag, to get latest security updates for docker image