### PR TITLE
fix(terragrunt_providers_lock, terragrunt_validate): Proper argument handling

### DIFF
--- a/hooks/terragrunt_providers_lock.sh
+++ b/hooks/terragrunt_providers_lock.sh
@@ -15,7 +15,7 @@ function main {
   # JFYI: terragrunt providers lock color already suppressed via PRE_COMMIT_COLOR=never
 
   if common::terragrunt_version_ge_0.78; then
-    local -ra RUN_ALL_SUBCOMMAND=(run --all providers lock)
+    local -ra RUN_ALL_SUBCOMMAND=(run --all -- providers lock)
   else
     local -ra RUN_ALL_SUBCOMMAND=(run-all providers lock)
   fi

--- a/hooks/terragrunt_validate.sh
+++ b/hooks/terragrunt_validate.sh
@@ -15,7 +15,7 @@ function main {
   # JFYI: terragrunt validate color already suppressed via PRE_COMMIT_COLOR=never
 
   if common::terragrunt_version_ge_0.78; then
-    local -ra RUN_ALL_SUBCOMMAND=(run --all validate)
+    local -ra RUN_ALL_SUBCOMMAND=(run --all -- validate)
   else
     local -ra RUN_ALL_SUBCOMMAND=(run-all validate)
   fi


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

Terragrunt's `run`/`run-all` command requires a `--` before commands that get passed to Terraform to proper handle passed arguments. Without the `--` any arguments passed via `args: [--arg=-foo]` would get interpreted as Terragrunt argument rather than a Terraform argument. 

The currently used way without `--` is just a shortcut:
```
❯ terragrunt run --help
Usage: terragrunt run [options] -- <tofu/terraform command>

...

Examples:
   # Run a plan
   terragrunt run -- plan
   # Shortcut:
   # terragrunt plan
```

### How can we test changes

Try e.g. this configuration:
```yaml
repos:
- repo: https://github.com/antonbabenko/pre-commit-terraform
  hooks:
  - id: terragrunt_providers_lock
    args:
      - --args=-platform=linux_amd64
      - --args=-platform=darwin_arm64
```

Without this PR, the above would fail with:
```
Terragrunt providers lock................................................Failed
- hook id: terragrunt_providers_lock
- exit code: 1

ERRO[0000] flag provided but not defined: -platform
```