### PR TITLE
feat(`terraform_fmt`): Add support for `.tofutest.hcl` and `.tfquery.hcl` files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -15,7 +15,7 @@
   language: script
   # Supported extensions by Terraform specified in
   # https://github.com/hashicorp/terraform/blob/0c63fb2b097edcd5cb1a91322765a414206fbea2/internal/command/fmt.go#L30-L35
-  files: \.(tf|tofu|tfvars|tftest\.hcl|tfmock\.hcl)$
+  files: \.(tf|tofu|tfvars|(tftest|tofutest|tfmock|tfquery)\.hcl)$
   exclude: \.terraform/.*$
 
 - id: terraform_docs


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123456":
-->
I included supported filenames taken from the [opentofu documentation](https://opentofu.org/docs/cli/commands/test/#the-tftesthcl--tofutesthcl-file-structure) in the terraform_fmt hook.

<!-- Fixes # -->

### How can we test changes
`.pre-commit-config.yaml`
```yaml
---
repos:
  - repo: https://github.com/antonbabenko/pre-commit-terraform
    rev: 460038084e27d0056f34f85ae53fe885a6786173
    hooks:
      - id: terraform_fmt
```

`main.tofutest.hcl`
```tf
run {
  assert {
    condition = false 
    error_message = "This test is supposed to fail."
  }
}
```

`main.tf`
```tf
terraform {
  required_version = "~> 1.10.0"

  required_providers {
    null = {
      source  = "hashicorp/null"
      version = "3.2.4"
    }
  }
}

provider "null" {
  # Configuration options
}

resource "null_resource" "test" {
  x = "1"
  this_is_a_test = "2"
}
```

Run `pre-commit install && pre-commit`
1. Terraform fmt should fail
2. line 17 in main.tf should have the '=' correctly aligned.
3. line 3 in main.tofutest.hcl should have the '=' correctly aligned.
 
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
