### PR TITLE
fix(`terraform_wrapper_module_for_each`): Prevent locale-dependent sorting inconsistencies

### DIFF
--- a/hooks/terraform_wrapper_module_for_each.sh
+++ b/hooks/terraform_wrapper_module_for_each.sh
@@ -321,7 +321,7 @@ EOF
 
     # Get names of module variables in all terraform files
     # shellcheck disable=SC2207
-    module_vars=($(echo "$all_tf_content" | hcledit block list | { grep "^variable\." | cut -d'.' -f 2 | sort || true; }))
+    module_vars=($(echo "$all_tf_content" | hcledit block list | { grep "^variable\." | cut -d'.' -f 2 | LC_ALL=C sort || true; }))
 
     # Get names of module outputs in all terraform files
     # shellcheck disable=SC2207


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

I discovered that the hook `terraform_wrapper_module_for_each` produces different outputs on different machines due to locale-dependent sorting behavior and differences between `glibc` versions. And especially for symbols like `_` that can be de-prioritized depending on the locale of the `glibc` version.
I did some digging and found out that the `sort` command uses values from `LC_*` variables to determine the character ordering.

It appears that adding `LC_ALL=C` will prevent any inconsistencies in the future for all users. 

Here is an example of when my local pre-commit run moved `task_tags` to the bottom of the list and pre-commit failed on Github Runner because it tried to put it back: https://github.com/terraform-aws-modules/terraform-aws-ecs/actions/runs/18283659979/job/52056232720?pr=361


Here is more info about my current machine:
```sh
$ getconf GNU_LIBC_VERSION
glibc 2.42

$ sort --version
sort (GNU coreutils) 9.8

$ hcledit version
0.2.17

$ locale
LANG=en_US.UTF-8
LC_CTYPE="en_US.UTF-8"
LC_NUMERIC="en_US.UTF-8"
LC_TIME="en_US.UTF-8"
LC_COLLATE="en_US.UTF-8"
LC_MONETARY="en_US.UTF-8"
LC_MESSAGES="en_US.UTF-8"
LC_PAPER="en_US.UTF-8"
LC_NAME="en_US.UTF-8"
LC_ADDRESS="en_US.UTF-8"
LC_TELEPHONE="en_US.UTF-8"
LC_MEASUREMENT="en_US.UTF-8"
LC_IDENTIFICATION="en_US.UTF-8"
LC_ALL=
```

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123456":
-->

<!-- Fixes # -->

### How can we test changes

I personally tested my changes on the https://github.com/terraform-aws-modules/terraform-aws-ecs repo. Currently, it meets all the requirements for this edge case. 

`LC_ALL=C pre-commit run -a` and `LC_ALL=en_US.UTF-8 pre-commit run -a` produces different outputs for me in this repo. Where the `LC_ALL=C pre-commit run -a` matches the current state of the repo. 

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
