### PR TITLE
fix(terragrunt_providers_lock): Use the updated Terragrunt CLI arguments

### DIFF
--- a/hooks/terragrunt_providers_lock.sh
+++ b/hooks/terragrunt_providers_lock.sh
@@ -51,8 +51,12 @@ function per_dir_hook_unique_part {
   shift 4
   local -a -r args=("$@")
 
-  # pass the arguments to hook
-  terragrunt providers lock "${args[@]}"
+  # pass the arguments to hook  
+  if common::terragrunt_version_ge_0.78; then
+    terragrunt run -- providers lock "${args[@]}"
+  else
+    terragrunt providers lock "${args[@]}"
+  fi
 
   # return exit code to common::per_dir_hook
   local exit_code=$?


### PR DESCRIPTION
Due to an error:
```
ERROR  The `providers` command is no longer supported. Use `terragrunt run -- providers` instead.
```

<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

When the hook was running, it failed
<img width="892" height="108" alt="зображення" src="https://github.com/user-attachments/assets/458905a6-d0d8-40b2-b20e-185a8e7c82de" />

<!-- Fixes # -->

### How can we test changes

When it fixed:
<img width="627" height="25" alt="зображення" src="https://github.com/user-attachments/assets/5e04a65a-93b1-4ef9-87d6-6557da377a5a" />

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
