### PR TITLE
fix(`terraform_wrapper_module_for_each`): Generate right usage example for S3

### DIFF
--- a/hooks/terraform_wrapper_module_for_each.sh
+++ b/hooks/terraform_wrapper_module_for_each.sh
@@ -113,9 +113,9 @@ module "wrapper" {
 
 ```hcl
 terraform {
-  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers"
+  source = "tfr:///MODULE_REPO_ORG/MODULE_REPO_SHORTNAME/MODULE_REPO_PROVIDER//WRAPPER_PATH"
   # Alternative source:
-  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git//wrappers?ref=master"
+  # source = "git::git@github.com:MODULE_REPO_ORG/terraform-MODULE_REPO_PROVIDER-MODULE_REPO_SHORTNAME.git//WRAPPER_PATH?ref=master"
 }
 
 inputs = {


### PR DESCRIPTION
- [x] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

The generator of Terraform module wrappers will create a fixed example and will not honor variables.

### How can we test changes

```
repos:
  - repo: https://github.com/antonbabenko/pre-commit-terraform
    rev: v1.104.0
    hooks:
      - id: terraform_wrapper_module_for_each
        args:
          - --args=--module-dir=.
          - --args=--module-repo-org=terraform-company-modules
          - --args=--module-repo-provider=company
          - --args=--module-repo-shortname=product
          - --args=--verbose
```

This will generate a fixed example like this:

```
## Example: Manage multiple S3 buckets in one Terragrunt layer

`eu-west-1/s3-buckets/terragrunt.hcl`:

```hcl
terraform {
  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers"
  # Alternative source:
  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git//wrappers?ref=master"
}
.
.
```

After this PR, the source examples should be like other examples

```
terraform {
  source = "tfr:///terraform-company-modules/product/company//wrappers/."
  # Alternative source:
  # source = "git::git@github.com:terraform-company-modules/terraform-company-product.git//wrappers/.?ref=master"
}
```