### PR TITLE
docs(`terraform_validate`): Describe that paralelsim is safe to use with tofu 1.10+

### DIFF
--- a/README.md
+++ b/README.md
@@ -971,7 +971,7 @@ To replicate functionality in `terraform_docs` hook:
 
 > [!IMPORTANT]
 > If you use [`TF_PLUGIN_CACHE_DIR`](https://developer.hashicorp.com/terraform/cli/config/config-file#provider-plugin-cache), we recommend enabling `--hook-config=--retry-once-with-cleanup=true` or disabling parallelism (`--hook-config=--parallelism-limit=1`) to avoid [race conditions when `terraform init` writes to it](https://github.com/hashicorp/terraform/issues/31964).  
-> This [issue was fixed in OpenToFu v1.10+](https://opentofu.org/blog/help-us-test-opentofu-1-10-0-alpha2/#global-provider-cache-locking), so it's safe to use parallelism with it.
+> This [issue was fixed in OpenTofu v1.10+](https://opentofu.org/blog/help-us-test-opentofu-1-10-0-alpha2/#global-provider-cache-locking), so it's safe to use parallelism with it.
 
 1. `terraform_validate` supports custom arguments so you can pass supported `-no-color` or `-json` flags:
 


### PR DESCRIPTION
Follow-up to https://github.com/antonbabenko/pre-commit-terraform/pull/956
Relates to https://github.com/antonbabenko/pre-commit-terraform/issues/640