### PR TITLE
feat(`terraform_wrapper_module_for_each`): Strip `provider_meta` blocks from `versions.tf`

### DIFF
--- a/hooks/terraform_wrapper_module_for_each.sh
+++ b/hooks/terraform_wrapper_module_for_each.sh
@@ -398,10 +398,10 @@ EOF
       if [[ -f "${full_module_dir}/versions.tf" ]]; then
         cp "${full_module_dir}/versions.tf" "${output_dir}/versions.tf"
         # Don't propagate redundant `provider_meta` user-agent attrs (#954).
-        hcledit attribute rm "terraform.provider_meta.${module_repo_provider}.user_agent" \
-          -f "${output_dir}/versions.tf" -u
-        hcledit attribute rm "terraform.provider_meta.${module_repo_provider}.module_name" \
-          -f "${output_dir}/versions.tf" -u
+        # sepcific to aws cloud only
+        hcledit attribute rm "terraform.provider_meta.${module_repo_provider}.user_agent" -f "${output_dir}/versions.tf" -u
+        # specific to gcp cloud only
+        hcledit attribute rm "terraform.provider_meta.${module_repo_provider}.module_name" -f "${output_dir}/versions.tf" -u
       else
         echo "$CONTENT_VERSIONS_TF" > "${output_dir}/versions.tf"
       fi

--- a/hooks/terraform_wrapper_module_for_each.sh
+++ b/hooks/terraform_wrapper_module_for_each.sh
@@ -398,9 +398,9 @@ EOF
       if [[ -f "${full_module_dir}/versions.tf" ]]; then
         cp "${full_module_dir}/versions.tf" "${output_dir}/versions.tf"
         # Don't propagate redundant `provider_meta` attributes
-        # AWS specific
+        # AWS-provider specific
         hcledit attribute rm "terraform.provider_meta.${module_repo_provider}.user_agent" -f "${output_dir}/versions.tf" -u
-        # GCP specific
+        # GCP-provider specific
         hcledit attribute rm "terraform.provider_meta.${module_repo_provider}.module_name" -f "${output_dir}/versions.tf" -u
       else
         echo "$CONTENT_VERSIONS_TF" > "${output_dir}/versions.tf"

--- a/hooks/terraform_wrapper_module_for_each.sh
+++ b/hooks/terraform_wrapper_module_for_each.sh
@@ -395,14 +395,13 @@ EOF
       echo "$CONTENT_VARIABLES_TF" > "${output_dir}/variables.tf"
 
       # If the root module has a versions.tf, use that; otherwise, create it.
-      # Strip `provider_meta` blocks so wrappers don't duplicate the module's
-      # user-agent tag on every provider call (see #954).
       if [[ -f "${full_module_dir}/versions.tf" ]]; then
-        awk '
-          /^[[:space:]]*provider_meta[[:space:]]+"[^"]+"[[:space:]]*\{[[:space:]]*$/ { in_block = 1; next }
-          in_block && /^[[:space:]]*\}[[:space:]]*$/ { in_block = 0; next }
-          !in_block { print }
-        ' "${full_module_dir}/versions.tf" > "${output_dir}/versions.tf"
+        cp "${full_module_dir}/versions.tf" "${output_dir}/versions.tf"
+        # Don't propagate redundant `provider_meta` user-agent attrs (#954).
+        hcledit attribute rm "terraform.provider_meta.${module_repo_provider}.user_agent" \
+          -f "${output_dir}/versions.tf" -u
+        hcledit attribute rm "terraform.provider_meta.${module_repo_provider}.module_name" \
+          -f "${output_dir}/versions.tf" -u
       else
         echo "$CONTENT_VERSIONS_TF" > "${output_dir}/versions.tf"
       fi

--- a/hooks/terraform_wrapper_module_for_each.sh
+++ b/hooks/terraform_wrapper_module_for_each.sh
@@ -394,9 +394,15 @@ EOF
 
       echo "$CONTENT_VARIABLES_TF" > "${output_dir}/variables.tf"
 
-      # If the root module has a versions.tf, use that; otherwise, create it
+      # If the root module has a versions.tf, use that; otherwise, create it.
+      # Strip `provider_meta` blocks so wrappers don't duplicate the module's
+      # user-agent tag on every provider call (see #954).
       if [[ -f "${full_module_dir}/versions.tf" ]]; then
-        cp "${full_module_dir}/versions.tf" "${output_dir}/versions.tf"
+        awk '
+          /^[[:space:]]*provider_meta[[:space:]]+"[^"]+"[[:space:]]*\{[[:space:]]*$/ { in_block = 1; next }
+          in_block && /^[[:space:]]*\}[[:space:]]*$/ { in_block = 0; next }
+          !in_block { print }
+        ' "${full_module_dir}/versions.tf" > "${output_dir}/versions.tf"
       else
         echo "$CONTENT_VERSIONS_TF" > "${output_dir}/versions.tf"
       fi

--- a/hooks/terraform_wrapper_module_for_each.sh
+++ b/hooks/terraform_wrapper_module_for_each.sh
@@ -397,10 +397,10 @@ EOF
       # If the root module has a versions.tf, use that; otherwise, create it.
       if [[ -f "${full_module_dir}/versions.tf" ]]; then
         cp "${full_module_dir}/versions.tf" "${output_dir}/versions.tf"
-        # Don't propagate redundant `provider_meta` user-agent attrs (#954).
-        # sepcific to aws cloud only
+        # Don't propagate redundant `provider_meta` attributes
+        # AWS specific
         hcledit attribute rm "terraform.provider_meta.${module_repo_provider}.user_agent" -f "${output_dir}/versions.tf" -u
-        # specific to gcp cloud only
+        # GCP specific
         hcledit attribute rm "terraform.provider_meta.${module_repo_provider}.module_name" -f "${output_dir}/versions.tf" -u
       else
         echo "$CONTENT_VERSIONS_TF" > "${output_dir}/versions.tf"


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open pre-commit-terraform issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #123456":
-->

The hook copies the source module's `versions.tf` into the wrapper verbatim. If the source declares a `provider_meta` block (used by terraform-aws-modules to tag the provider's user-agent), the wrapper inherits it. The wrapper makes no provider calls itself, so that propagation is redundant and skews module-usage telemetry.

Uses `hcledit` (already a hook dependency, see `check_dependencies` at `hooks/terraform_wrapper_module_for_each.sh:430`) to remove `user_agent` and `module_name` for the provider configured via `--module-repo-provider`. The edit is structural:

- Modules with no `provider_meta` are untouched.
- Non-AWS `provider_meta` blocks are untouched.
- A future nested block inside `provider_meta` (e.g. if the AWS provider extends the schema) is preserved.

**Cosmetic caveat**: the (possibly now-empty) `provider_meta` block itself remains, because `hcledit` cannot remove nested blocks. Functionally harmless — no attributes ⇒ no user-agent contribution.

<!-- Fixes # -->

Fixes #954

### How can we test changes

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Run the hook against a module whose `versions.tf` has a `provider_meta` block (e.g. any `terraform-aws-modules` repo):

```sh
bash hooks/terraform_wrapper_module_for_each.sh \
  --args=--root-dir=<path> --args=--module-dir=. \
  --args=--module-repo-shortname=<name> <path>/main.tf

Check <path>/wrappers/versions.tf — provider_meta should be gone, everything else intact.
```

Tested against hypothetical value: 

# input
```
terraform {
  provider_meta "aws" {
    user_agent = ["github.com/terraform-aws-modules/terraform-aws-s3-bucket"]

    hypothetical_nested_block {
      key = "value"
    }
  }
}
```
# after the hook
```
terraform {
  provider_meta "aws" {

    hypothetical_nested_block {
      key = "value"
    }
  }
}
```

user_agent cleanly removed, nested block intact.