### PR TITLE
fix: retry plugin cache errors in terraform_validate

### DIFF
--- a/hooks/terraform_validate.sh
+++ b/hooks/terraform_validate.sh
@@ -58,6 +58,10 @@ function match_validate_errors {
       "Could not load plugin") return 1 ;;
       "Missing required provider") return 1 ;;
       *"there is no package for"*"cached in .terraform/providers") return 1 ;;
+      *"could not retrieve the list of available versions for provider"*) return 1 ;;
+      *"unexpected value returned by API"*) return 1 ;;
+      *"plugin is cached but contents have changed"*) return 1 ;;
+      *"the plugin cache directory is invalid"*) return 1 ;;
     esac
   done < <(jq -rc '.diagnostics[]' <<< "$validate_output")
 


### PR DESCRIPTION
When TF_PLUGIN_CACHE_DIR is used with parallelism (from #620), concurrent terraform validate processes can corrupt the plugin cache, causing intermittent failures.

I kept hitting this in our CI where multiple pre-commit hooks run in parallel. The errors look like:

```
could not retrieve the list of available versions for provider
unexpected value returned by API
plugin is cached but contents have changed
the plugin cache directory is invalid
```

All of these go away on retry. The existing `--retry-once-with-cleanup` flag already handles retrying after clearing `.terraform/modules` and `.terraform/providers` -- these errors just weren't in the match list.

This PR adds them to `match_validate_errors` in `hooks/terraform_validate.sh`. That's the same function that already catches "Module source has changed", "Could not load plugin", etc. No other changes to the init or validate flow.

After adding these patterns, our CI runs pass consistently without the 2-3 retries we were seeing before.

Related to #640