### PR TITLE
fix(tflint-installer): Scope regex to avoid release json overmatches

### DIFF
--- a/tools/install/tflint.sh
+++ b/tools/install/tflint.sh
@@ -9,8 +9,8 @@ readonly SCRIPT_DIR
 #
 
 GH_ORG="terraform-linters"
-GH_RELEASE_REGEX_SPECIFIC_VERSION="https://.+?/v${VERSION}/${TOOL}_${TARGETOS}_${TARGETARCH}.zip"
-GH_RELEASE_REGEX_LATEST="https://.+?_${TARGETOS}_${TARGETARCH}.zip"
+GH_RELEASE_REGEX_SPECIFIC_VERSION="https://[^\"]*/v${VERSION}/${TOOL}_${TARGETOS}_${TARGETARCH}.zip"
+GH_RELEASE_REGEX_LATEST="https://[^\"]*_${TARGETOS}_${TARGETARCH}.zip"
 DISTRIBUTED_AS="zip"
 
 common::install_from_gh_release "$GH_ORG" "$DISTRIBUTED_AS" \


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [X] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

- It looks like the two most recent releases have failed to push Docker containers to the registry. After a little vibe-troubleshooting, this is what I have

<!-- Fixes # -->

- Fixes the Docker image build failure in `/install/tflint.sh` by narrowing the TFLint GitHub release URL regex. The previous `https://.+?...` pattern could overmatch GitHub API JSON and pass curl a malformed URL, causing exit code 3. The new `https://[^\"]*...` pattern stops at the JSON string boundary while still matching the linux amd64/arm64 TFLint zip assets.

### How can we test changes

```sh
docker build \
    --build-arg INSTALL_ALL=true \
    --platform linux/amd64 \
    -t pre-commit-terraform:tflint-fix-test .
```