### PR TITLE
chore(AI): Recommend OpenSpec for scoping AI-assisted changes

### DIFF
--- a/.github/AI_POLICY.md
+++ b/.github/AI_POLICY.md
@@ -14,6 +14,14 @@ The contributor — not the AI — is the author of the contribution. Using an L
 
 The LLM types for you. It doesn't think for you.
 
+## Recommended tooling
+
+If you're using an AI coding agent, install [OpenSpec](https://openspec.dev/) (`npm install -g @fission-ai/openspec@latest`, then `openspec init`) and use its spec-driven workflow (`/opsx:propose` → `/opsx:apply`) to scope the change into a reviewable proposal + spec + tasks *before* any code gets written. `openspec init` provisions the matching skills/commands locally — see [`AGENTS.md`](../AGENTS.md#skill-routing).
+
+These skills are not installed in this repo — `.agents/skills/openspec-*`, and `.agents/commands/opsx/` are generated on your own machine by `openspec init` and must never be committed. Provision them locally, keep them out of your diffs and PRs.
+
+Scoping the change up front makes it easier to meet the ownership expectations above: you review and understand the plan before the AI starts typing, instead of reverse-engineering intent from a pile of already-generated code.
+
 ## Disclosure
 
 You are encouraged (but not required) to disclose when AI tools contributed to your work. A short note in the PR description is enough — e.g. *"Tests were initially drafted with an LLM and then reviewed and adjusted by me."*

--- a/.gitignore
+++ b/.gitignore
@@ -178,6 +178,6 @@ pyrightconfig.json
 
 tests/results/*
 
-# Drop openspec.ai generated files to not clutter the repo but still be able to use it locally
+# Ignore OpenSpec-generated files; keep them available for local use without cluttering the repo
 .agents/commands/opsx/*
 .agents/skills/openspec-*

--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,7 @@ pyrightconfig.json
 # End of https://www.toptal.com/developers/gitignore/api/python
 
 tests/results/*
+
+# Drop openspec.ai generated files to not clutter the repo but still be able to use it locally
+.agents/commands/opsx/*
+.agents/skills/openspec-*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,3 +75,9 @@ Load these skills when their triggers match.
 | --- | --- |
 | Creating a new skill: registering in AGENTS.md, choosing script vs SKILL.md | `adding-skills` |
 | Create a commit, GitHub issue, or PR | `git-workflow` |
+| Propose a new OpenSpec change (design, specs, tasks in one step) | `openspec-propose` |
+| Think through an idea/problem before or during an OpenSpec change | `openspec-explore` |
+| Implement tasks from an existing OpenSpec change | `openspec-apply-change` |
+| Revise an OpenSpec change's planning artifacts after edits/new decisions | `openspec-update-change` |
+| Sync delta specs from a change into main specs (without archiving) | `openspec-sync-specs` |
+| Archive a completed OpenSpec change | `openspec-archive-change` |


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [x] This PR enhances existing functionality.

### Description of your changes

#### What
<sub>This section was generated by AI.</sub>

- Split out of [#1002](https://github.com/antonbabenko/pre-commit-terraform/pull/1002)'s OpenSpec-adjacent bits, per [this review](https://github.com/antonbabenko/pre-commit-terraform/pull/1002#pullrequestreview-4800533366), so that PR's tool-version pinning work doesn't have to wait on this.
- Adds a "Recommended tooling" section to `.github/AI_POLICY.md` recommending contributors scope AI-assisted changes with [OpenSpec](https://openspec.dev/)'s propose/apply workflow before code gets written.
- Adds `.agents/skills/openspec-*` and `.agents/commands/opsx/*` to `.gitignore`, since `openspec init` generates those locally per-contributor and they must never be committed.
- Wires the `openspec-*` skills into `AGENTS.md`'s skill-routing table - the skill *files* are gitignored/local-only, but the routing metadata is meant to stay in the shared repo.

#### Why

_<!-- describe why this change is needed -->_

### How can we test changes
<sub>This section was generated by AI.</sub>

Read `.github/AI_POLICY.md` and `.gitignore` - no code/behavior change, documentation and ignore-rules only.

### Assisted-by
<sub>Specific models used per commit are specified in the commit messages.</sub>
- Assisted-by: Sisyphus:claude-sonnet-5 opencode

