### PR TITLE
fix: Skip terragrunt_validate for directories without terragrunt.hcl

### DIFF
--- a/hooks/terragrunt_validate.sh
+++ b/hooks/terragrunt_validate.sh
@@ -53,6 +53,13 @@ function per_dir_hook_unique_part {
   shift 4
   local -a -r args=("$@")
 
+  # terragrunt validate requires a terragrunt.hcl file to be present.
+  # The hook's file pattern (\.hcl)$ matches any .hcl file, so directories
+  # without a terragrunt.hcl will cause a false failure. Skip them.
+  if [ ! -f "terragrunt.hcl" ]; then
+    return 0
+  fi
+
   # pass the arguments to hook
   terragrunt "${SUBCOMMAND[@]}" "${args[@]}"
 


### PR DESCRIPTION
When terragrunt_validate runs against a directory containing only .hcl files but no terragrunt.hcl, it fails with a misleading error since terragrunt validate requires that file. This happened in multi-tier setups where base.hcl or tier.hcl files live alongside module directories. Added a check to skip directories without terragrunt.hcl.