### PR TITLE
ci: Split tox posargs into separate CLI args

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -21,6 +21,11 @@ exclude_also =
 
 [run]
 branch = true
+# https://coverage.rtfd.io/en/latest/config.html#run-core
+# `sysmon` (default on Python 3.14+) doesn't support dynamic contexts yet,
+# but `--cov-context=test` (see pytest.ini) relies on them. Pin to `ctrace`
+# so per-test context data keeps working instead of being silently dropped.
+core = ctrace
 cover_pylib = false
 # https://coverage.rtfd.io/en/latest/contexts.html#dynamic-contexts
 # dynamic_context = test_function  # conflicts with `pytest-cov` if set here

--- a/.github/workflows/reusable-tox.yml
+++ b/.github/workflows/reusable-tox.yml
@@ -321,8 +321,9 @@ jobs:
           --quiet
         )
         if [ -n "$INPUT_TOX_RUN_POSARGS" ]; then
+          read -ra tox_run_posargs <<< "$INPUT_TOX_RUN_POSARGS"
           python -Im tox "${tox_common_args[@]}" \
-            -- "$INPUT_TOX_RUN_POSARGS"
+            -- "${tox_run_posargs[@]}"
         else
           python -Im tox "${tox_common_args[@]}"
         fi
@@ -374,17 +375,16 @@ jobs:
       # `exit 1` makes sure that the job remains red with flaky runs
       env:
         INPUT_TOX_RERUN_POSARGS: ${{ inputs.tox-rerun-posargs }}
-      run: >-
-        python -Im
-        tox
-        --parallel auto
-        --parallel-live
-        --skip-missing-interpreters false
-        -vvvvv
-        --skip-pkg-install
-        --
-        $INPUT_TOX_RERUN_POSARGS
-        && exit 1
+      run: |-
+        read -ra tox_rerun_posargs <<< "$INPUT_TOX_RERUN_POSARGS"
+        python -Im tox \
+          --parallel auto \
+          --parallel-live \
+          --skip-missing-interpreters false \
+          -vvvvv \
+          --skip-pkg-install \
+          -- "${tox_rerun_posargs[@]}" \
+          && exit 1
       shell: bash
     - name: Send coverage data to Codecov
       if: >-


### PR DESCRIPTION
Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

#### What
<sub>This section was generated by AI.</sub>

- Split `$INPUT_TOX_RUN_POSARGS` / `$INPUT_TOX_RERUN_POSARGS` into an array (`read -ra ... <<< "$VAR"`) before passing to `tox --`, instead of passing the whole string as a single quoted argument.
- Fixes coverage/JUnit XML report paths getting merged into one garbled argv token whenever a caller passes multiple whitespace-separated posargs flags (e.g. `--cov-report=xml:... --junitxml=...`, as the `tests` job matrix does), which corrupted the `cov-report-files` GHA output and broke the "Send coverage data to Codecov" step with `Error: No coverage reports found.`
- As a side effect, also un-breaks "Upload test results to Codecov" and the JUnit job-summary step, which were silently skipped because `test-result-files` never got set.
- Pins `.coveragerc`'s `[run] core` to `ctrace`. Once the posargs fix above let pytest actually run, a second, unrelated failure surfaced: `coverage`'s newer default `sysmon` core doesn't support dynamic contexts, but `pytest.ini`'s `--cov-context=test` relies on them, and `tox.ini` turns warnings into errors — so every test errored with `CoverageWarning: ... (no-sysmon-context)`. Neither `coverage` nor `pytest-cov` are version-pinned in `pyproject.toml`, so this would have started failing on any fresh CI run regardless of this PR, once that dependency drifted.

#### Why
<!-- Must be written by the human. Do NOT generate this. See below. -->

### How can we test changes

<sub>This section was generated by AI.</sub>

- `bash -n` and `shellcheck -s bash` pass clean on both modified `run:` blocks (checked manually — the repo's `shfmt`/`shellcheck` pre-commit hooks only target `.sh`/shebang files, not embedded workflow scripts).
- Reproduced the exact failing posargs string from a real CI run and confirmed: before the fix, tox.ini's output-extractor produced a single corrupted `cov-report-files` value containing both paths; after the fix, it produces two clean, independent `cov-report-files` / `test-result-files` values.
- Confirmed against this PR's own first CI run (`tests / pytest@3.14@macos-15`): the posargs fix produced a correctly-split `--cov-report=xml:... --junitxml=...` invocation and a correctly-written `test.xml`, but then hit the separate `no-sysmon-context` `CoverageWarning`-as-error described above.
- The `core = ctrace` fix is exactly what [coverage.py's own docs](https://coverage.readthedocs.io/en/7.15.4/messages.html#warning-no-sysmon-context) recommend for that warning ("Change your configuration to use the ctrace core"); validated `.coveragerc` still parses correctly as INI after the change.
- This PR's own `tests` job matrix will now serve as the integration test for both fixes together on the next CI run.

### Assisted-by
<sub>Specific models used per commit are specified in the commit messages.</sub>
- Assisted-by: Sisyphus:claude-sonnet-5 opencode (f7927d2, 85b660b)
