### PR TITLE
fix(hooks): Make cache-miss download race-safe

### DIFF
--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -546,21 +546,9 @@ function common::detect_os_arch {
 
 #######################################################################
 # Download and install one tool version into a private, per-process
-# staging directory, then atomically publish the resulting binary
-# into the shared cache.
-#
-# `tools/install/<tool>.sh` installer scripts use a fixed filename
-# relative to their CWD (e.g. `terraform.zip`), which is only safe
-# with one process per CWD at a time - true for their original
-# purpose (one `RUN` per tool, per Docker build), not for N pre-commit
-# hook processes racing the same cache miss. Without this, two such
-# processes could interleave on the same shared directory: one's
-# `rm "$PKG"` deleting the archive out from under the other's still-
-# running `unzip` ("cannot find or open ... .zip"), or `unzip` meeting
-# a binary a sibling already extracted and blocking on an interactive
-# overwrite prompt that hangs under pre-commit's non-interactive
-# stdin. Giving every caller its own staging directory removes the
-# shared CWD these scripts were never designed to share.
+# temp directory, then atomically publish the resulting binary into
+# the shared cache - concurrency-safe against other processes
+# populating the same (tool, version) entry at the same time.
 # Globals:
 #   GITHUB_TOKEN - forwarded automatically; read directly by the
 #     invoked installer script
@@ -568,19 +556,14 @@ function common::detect_os_arch {
 #   tool_name (string) tool name, matching a `tools/install/<tool>.sh`
 #     file and its expected `${TOOL^^}_VERSION` environment variable
 #   version (string) exact version to install
-#   installer_script (string) absolute path to the
-#     `tools/install/<tool>.sh` script to invoke
-#   env_var_name (string) name of the environment variable the
-#     installer script reads its requested version from (e.g.
-#     "TERRAFORM_VERSION")
-#   cache_dir (string) final, shared cache directory for this
-#     (tool, version) pair. Must already exist.
+#   installer_script (string) absolute path to the installer to invoke
+#   env_var_name (string) env var the installer reads its version from
+#   cache_dir (string) final, shared cache dir for this (tool, version).
+#     Must already exist.
 #   cached_bin (string) expected absolute path to the resolved binary
-#     inside `cache_dir` once installed
 # Outputs:
-#   Returns 0 once `cached_bin` exists - either from this process' own
-#   install, or from another process that won the race first. Returns
-#   1 with an error message if the download/install itself failed.
+#   Returns 0 once `cached_bin` exists, ours or a race winner's.
+#   Returns 1 with an error message if the install itself failed.
 #######################################################################
 function common::populate_tool_cache {
   local -r tool_name="$1"
@@ -590,12 +573,9 @@ function common::populate_tool_cache {
   local -r cache_dir="$5"
   local -r cached_bin="$6"
 
-  # `mktemp -d` guarantees a directory no other process is also using,
-  # so each process' installer run is isolated - regardless of how
-  # many processes hit the same cache miss at once.
-  local staging_dir
-  staging_dir=$(mktemp -d "${cache_dir}.XXXXXXXXXX") || {
-    common::colorify "red" "ERROR: Failed to create a staging directory for '$tool_name' version '$version'."
+  local tmp_dir
+  tmp_dir=$(mktemp -d "${cache_dir}.XXXXXXXXXX") || {
+    common::colorify "red" "ERROR: Failed to create a temp directory for '$tool_name' version '$version'."
     return 1
   }
 
@@ -606,40 +586,32 @@ function common::populate_tool_cache {
   # harmless noise in a Docker build log, but it would otherwise corrupt
   # the path this function returns.
   if ! (
-    cd "$staging_dir" || exit 1
+    cd "$tmp_dir" || exit 1
     export "$env_var_name=$version"
     "$installer_script" 1>&2
   ); then
     common::colorify "red" "ERROR: Failed to download '$tool_name' version '$version' via '$installer_script'."
-    rm -rf "$staging_dir"
+    rm -rf "$tmp_dir"
     return 1
   fi
 
-  # Another process may have already published `cached_bin` while this
-  # one was downloading its own copy - if so, prefer that result over
-  # ours (both are the same requested version) instead of racing again
-  # on the `mv` below.
+  # Someone else may have already won the race - use their result.
   if [[ -x $cached_bin ]]; then
-    rm -rf "$staging_dir"
+    rm -rf "$tmp_dir"
     return 0
   fi
 
-  # `mv` between two paths on the same filesystem is atomic (POSIX
-  # `rename(2)`), and both sides here are plain files, not
-  # directories, so a concurrent reader of `cached_bin` always sees
-  # either the previous state or the fully-written new one - never a
-  # partially-written file - on both GNU and BSD `mv`.
-  if ! mv "$staging_dir/$(basename "$cached_bin")" "$cached_bin" 2> /dev/null; then
-    rm -rf "$staging_dir"
-    # Lost the race between the check above and this `mv`: some other
-    # process' `mv` landed on `cached_bin` first. That's fine, its
-    # result is equally valid, ours is simply redundant.
+  # Atomic `rename(2)`: both sides are plain files, so a concurrent
+  # reader never sees a partial write.
+  if ! mv "$tmp_dir/$(basename "$cached_bin")" "$cached_bin" 2> /dev/null; then
+    rm -rf "$tmp_dir"
+    # Lost the race - the winner's copy is equally valid.
     [[ -x $cached_bin ]] && return 0
     common::colorify "red" "ERROR: Failed to move '$tool_name' version '$version' into place at '$cached_bin'."
     return 1
   fi
 
-  rm -rf "$staging_dir"
+  rm -rf "$tmp_dir"
 }
 
 #######################################################################

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -711,7 +711,7 @@ function common::resolve_tool_path {
     fi
 
     common::colorify "green" \
-      "NOTE: The requested '$tool_name' version '$version' will be downloaded/used instead of whatever is on \$PATH."
+      "NOTE: The requested '$tool_name' version '$version' will be used instead of whatever is on \$PATH."
   fi
 
   #

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -583,12 +583,13 @@ function common::populate_tool_cache {
     return 1
   }
 
-  # Redirect the installer's own stdout to stderr: this function's stdout is
-  # a contract (the resolved path, captured via "$(...)" by every caller),
-  # and installers like terraform.sh/tflint.sh call bare `unzip` (no `-q`),
-  # which prints "Archive: ... inflating: ..." to stdout by default -
-  # harmless noise in a Docker build log, but it would otherwise corrupt
-  # the path this function returns.
+  # Redirect the installer's own stdout to stderr: this is a plain
+  # function call, not a "$(...)" capture, so anything printed here
+  # would flow straight through to `common::resolve_tool_path`'s own
+  # stdout - the resolved path, captured via "$(...)" by every caller
+  # of *that* function - and installers like terraform.sh/tflint.sh
+  # call bare `unzip` (no `-q`), which prints "Archive: ... inflating:
+  # ..." to stdout by default.
   if ! (
     cd "$tmp_dir" || exit 1
     export "$env_var_name=$version"
@@ -599,17 +600,12 @@ function common::populate_tool_cache {
     return 1
   fi
 
-  # A sibling may have published while we were downloading - `mv`
-  # doesn't refuse an existing destination, it just replaces it, even
-  # while something else is still executing it.
-  if [[ -x $cached_bin ]]; then
-    rm -rf "$tmp_dir"
-    return 0
-  fi
-
-  # Atomic `rename(2)`: both sides are plain files, so a concurrent
-  # reader never sees a partial write.
-  if ! mv "$tmp_dir/$(basename "$cached_bin")" "$cached_bin" 2> /dev/null; then
+  # `ln` (hard link, no `-f`) fails with EEXIST instead of silently
+  # replacing an existing destination - unlike `mv`, which would
+  # clobber a binary a sibling process may already be running.
+  # `tmp_dir` is a sibling of `cache_dir` (both under the same parent),
+  # so this is guaranteed to stay on one filesystem.
+  if ! ln "$tmp_dir/$(basename "$cached_bin")" "$cached_bin" 2> /dev/null; then
     rm -rf "$tmp_dir"
     # Lost the race - the winner's copy is equally valid.
     [[ -x $cached_bin ]] && return 0

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -599,6 +599,14 @@ function common::populate_tool_cache {
     return 1
   fi
 
+  # A sibling may have published while we were downloading - `mv`
+  # doesn't refuse an existing destination, it just replaces it, even
+  # while something else is still executing it.
+  if [[ -x $cached_bin ]]; then
+    rm -rf "$tmp_dir"
+    return 0
+  fi
+
   # Atomic `rename(2)`: both sides are plain files, so a concurrent
   # reader never sees a partial write.
   if ! mv "$tmp_dir/$(basename "$cached_bin")" "$cached_bin" 2> /dev/null; then

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -573,6 +573,10 @@ function common::populate_tool_cache {
   local -r cache_dir="$5"
   local -r cached_bin="$6"
 
+  if [[ -x $cached_bin ]]; then
+    return 0
+  fi
+
   local tmp_dir
   tmp_dir=$(mktemp -d "${cache_dir}.XXXXXXXXXX") || {
     common::colorify "red" "ERROR: Failed to create a temp directory for '$tool_name' version '$version'."
@@ -593,12 +597,6 @@ function common::populate_tool_cache {
     common::colorify "red" "ERROR: Failed to download '$tool_name' version '$version' via '$installer_script'."
     rm -rf "$tmp_dir"
     return 1
-  fi
-
-  # Someone else may have already won the race - use their result.
-  if [[ -x $cached_bin ]]; then
-    rm -rf "$tmp_dir"
-    return 0
   fi
 
   # Atomic `rename(2)`: both sides are plain files, so a concurrent

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -545,6 +545,104 @@ function common::detect_os_arch {
 }
 
 #######################################################################
+# Download and install one tool version into a private, per-process
+# staging directory, then atomically publish the resulting binary
+# into the shared cache.
+#
+# `tools/install/<tool>.sh` installer scripts use a fixed filename
+# relative to their CWD (e.g. `terraform.zip`), which is only safe
+# with one process per CWD at a time - true for their original
+# purpose (one `RUN` per tool, per Docker build), not for N pre-commit
+# hook processes racing the same cache miss. Without this, two such
+# processes could interleave on the same shared directory: one's
+# `rm "$PKG"` deleting the archive out from under the other's still-
+# running `unzip` ("cannot find or open ... .zip"), or `unzip` meeting
+# a binary a sibling already extracted and blocking on an interactive
+# overwrite prompt that hangs under pre-commit's non-interactive
+# stdin. Giving every caller its own staging directory removes the
+# shared CWD these scripts were never designed to share.
+# Globals:
+#   GITHUB_TOKEN - forwarded automatically; read directly by the
+#     invoked installer script
+# Arguments:
+#   tool_name (string) tool name, matching a `tools/install/<tool>.sh`
+#     file and its expected `${TOOL^^}_VERSION` environment variable
+#   version (string) exact version to install
+#   installer_script (string) absolute path to the
+#     `tools/install/<tool>.sh` script to invoke
+#   env_var_name (string) name of the environment variable the
+#     installer script reads its requested version from (e.g.
+#     "TERRAFORM_VERSION")
+#   cache_dir (string) final, shared cache directory for this
+#     (tool, version) pair. Must already exist.
+#   cached_bin (string) expected absolute path to the resolved binary
+#     inside `cache_dir` once installed
+# Outputs:
+#   Returns 0 once `cached_bin` exists - either from this process' own
+#   install, or from another process that won the race first. Returns
+#   1 with an error message if the download/install itself failed.
+#######################################################################
+function common::populate_tool_cache {
+  local -r tool_name="$1"
+  local -r version="$2"
+  local -r installer_script="$3"
+  local -r env_var_name="$4"
+  local -r cache_dir="$5"
+  local -r cached_bin="$6"
+
+  # `mktemp -d` guarantees a directory no other process is also using,
+  # so each process' installer run is isolated - regardless of how
+  # many processes hit the same cache miss at once.
+  local staging_dir
+  staging_dir=$(mktemp -d "${cache_dir}.XXXXXXXXXX") || {
+    common::colorify "red" "ERROR: Failed to create a staging directory for '$tool_name' version '$version'."
+    return 1
+  }
+
+  # Redirect the installer's own stdout to stderr: this function's stdout is
+  # a contract (the resolved path, captured via "$(...)" by every caller),
+  # and installers like terraform.sh/tflint.sh call bare `unzip` (no `-q`),
+  # which prints "Archive: ... inflating: ..." to stdout by default -
+  # harmless noise in a Docker build log, but it would otherwise corrupt
+  # the path this function returns.
+  if ! (
+    cd "$staging_dir" || exit 1
+    export "$env_var_name=$version"
+    "$installer_script" 1>&2
+  ); then
+    common::colorify "red" "ERROR: Failed to download '$tool_name' version '$version' via '$installer_script'."
+    rm -rf "$staging_dir"
+    return 1
+  fi
+
+  # Another process may have already published `cached_bin` while this
+  # one was downloading its own copy - if so, prefer that result over
+  # ours (both are the same requested version) instead of racing again
+  # on the `mv` below.
+  if [[ -x $cached_bin ]]; then
+    rm -rf "$staging_dir"
+    return 0
+  fi
+
+  # `mv` between two paths on the same filesystem is atomic (POSIX
+  # `rename(2)`), and both sides here are plain files, not
+  # directories, so a concurrent reader of `cached_bin` always sees
+  # either the previous state or the fully-written new one - never a
+  # partially-written file - on both GNU and BSD `mv`.
+  if ! mv "$staging_dir/$(basename "$cached_bin")" "$cached_bin" 2> /dev/null; then
+    rm -rf "$staging_dir"
+    # Lost the race between the check above and this `mv`: some other
+    # process' `mv` landed on `cached_bin` first. That's fine, its
+    # result is equally valid, ours is simply redundant.
+    [[ -x $cached_bin ]] && return 0
+    common::colorify "red" "ERROR: Failed to move '$tool_name' version '$version' into place at '$cached_bin'."
+    return 1
+  fi
+
+  rm -rf "$staging_dir"
+}
+
+#######################################################################
 # Resolve a specific version of a wrapped tool's binary, downloading
 # and caching it on demand if it isn't already cached.
 #
@@ -682,20 +780,7 @@ function common::resolve_tool_path {
 
   mkdir -p "$cache_dir"
 
-  # Redirect the installer's own stdout to stderr: this function's stdout is
-  # a contract (the resolved path, captured via "$(...)" by every caller),
-  # and installers like terraform.sh/tflint.sh call bare `unzip` (no `-q`),
-  # which prints "Archive: ... inflating: ..." to stdout by default -
-  # harmless noise in a Docker build log, but it would otherwise corrupt
-  # the path this function returns.
-  if ! (
-    cd "$cache_dir" || exit 1
-    export "$env_var_name=$version"
-    "$installer_script" 1>&2
-  ); then
-    common::colorify "red" "ERROR: Failed to download '$tool_name' version '$version' via '$installer_script'."
-    exit 1
-  fi
+  common::populate_tool_cache "$tool_name" "$version" "$installer_script" "$env_var_name" "$cache_dir" "$cached_bin" || exit $?
 
   if [[ ! -x $cached_bin ]]; then
     common::colorify "red" "ERROR: '$tool_name' installer completed but expected binary was not found at '$cached_bin'."

--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -607,7 +607,7 @@ function common::populate_tool_cache {
     rm -rf "$tmp_dir"
     # Lost the race - the winner's copy is equally valid.
     [[ -x $cached_bin ]] && return 0
-    common::colorify "red" "ERROR: Failed to move '$tool_name' version '$version' into place at '$cached_bin'."
+    common::colorify "red" "ERROR: Failed to update '$cached_bin' with '$tool_name' version '$version'."
     return 1
   fi
 

--- a/tests/pytest/tool_version_test.py
+++ b/tests/pytest/tool_version_test.py
@@ -352,6 +352,11 @@ def _run_concurrent_hooks(  # pragma: win32 no cover
         Each process' merged stdout/stderr, in start order.
     """
     hook_path = HOOKS_DIR / hook_name
+    if not hook_path.is_file():  # pragma: no cover
+        # `hooks/` is not part of the wheel, only of the sdist, so a
+        # packaging regression must fail with a pointed message here
+        # instead of as a confusing assertion mismatch further down.
+        pytest.fail(f'Hook script not found: {hook_path}')
     processes = [
         subprocess.Popen(  # noqa: S603
             (BASH, str(hook_path), *args, '--', 'a.tf'),

--- a/tests/pytest/tool_version_test.py
+++ b/tests/pytest/tool_version_test.py
@@ -48,7 +48,7 @@ BASH = shutil.which('bash') or 'bash'
 # `common::colorify` writes to stderr, hence the stderr/stdout merge in
 # `_run_hook` below.
 DOWNLOAD_MSG = "Downloading '"  # hooks/_common.sh:662
-STRICT_OVERRIDE_MSG = 'downloaded/used instead of whatever is on $PATH'  # :629
+STRICT_OVERRIDE_MSG = 'used instead of whatever is on $PATH'  # :629
 PREFER_LOCAL_MSG = "'--tool-version-mode=prefer-local'"  # :622
 NO_INSTALLER_MSG = 'no installer found'  # :658
 MODE_INVALID_MSG = "'--tool-version-mode=prefer_local' is not a valid value"

--- a/tests/pytest/tool_version_test.py
+++ b/tests/pytest/tool_version_test.py
@@ -334,6 +334,44 @@ def _run_hook(  # pragma: win32 no cover
     )
 
 
+def _run_concurrent_hooks(  # pragma: win32 no cover
+    count: int,
+    hook_name: str,
+    args: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+) -> list[str]:
+    """Run `count` copies of a hook concurrently, on the same `a.tf`.
+
+    Every copy is started before any of them is waited on, so all
+    `count` copies genuinely overlap instead of running one after
+    another.
+
+    Returns:
+        Each process' merged stdout/stderr, in start order.
+    """
+    hook_path = HOOKS_DIR / hook_name
+    processes = [
+        subprocess.Popen(  # noqa: S603
+            (BASH, str(hook_path), *args, '--', 'a.tf'),
+            cwd=cwd,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        for _ in range(count)
+    ]
+    outputs = [
+        proc.communicate(timeout=HOOK_TIMEOUT_SECONDS)[0] for proc in processes
+    ]
+    for output, proc in zip(outputs, processes, strict=True):
+        # 2 is tflint's own lint findings on the minimal fixture, not ours.
+        assert proc.returncode in {0, 2}, output
+    return outputs
+
+
 def test_cache_hit_uses_cached_binary(  # pragma: win32 no cover
     tmp_repo: Path,
     cache_dir: Path,
@@ -1015,3 +1053,52 @@ def test_real_download_on_cache_miss(  # pragma: win32 no cover
 
     # 2 is tflint's own lint findings on the minimal fixture, not ours.
     assert hook_run.returncode in {0, 2}, combined
+
+
+@pytest.mark.network
+def test_concurrent_cache_miss_is_race_free(  # pragma: win32 no cover
+    tmp_repo: Path,
+    cache_dir: Path,
+) -> None:
+    """Check N processes racing the same cache miss don't corrupt it.
+
+    Regression test for a race in `common::populate_tool_cache`:
+    before it staged each download in a private, per-process directory
+    and atomically published only the resulting binary, N processes
+    hitting the same uncached (tool, version) at once shared one
+    `curl`/`unzip` working directory - so one process' cleanup
+    (`rm "$PKG"`) could delete the archive out from under another's
+    still-running `unzip` ("cannot find or open ... .zip"), or `unzip`
+    could meet a binary a sibling had already extracted and block on
+    an interactive overwrite prompt, hanging (then failing) under
+    pre-commit's non-interactive stdin.
+    """
+    # 2 is the minimal N that can reproduce a race at all; every
+    # process beyond that adds real-network exposure (see this
+    # function's own `@pytest.mark.network`) without proving anything
+    # a race between 2 doesn't already prove.
+    outputs = _run_concurrent_hooks(
+        2,
+        'terraform_tflint.sh',
+        [f'--hook-config=--tool-version={PINNED_TFLINT_VERSION}'],
+        cwd=tmp_repo,
+        env=_hook_env(_pct_cache_env(cache_dir), os.environ['PATH']),
+    )
+
+    cached_bin = cache_dir / 'tflint' / PINNED_TFLINT_VERSION / 'tflint'
+    assert os.access(cached_bin, os.X_OK), outputs
+
+    version_check = subprocess.run(  # noqa: S603
+        (str(cached_bin), '--version'),
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=VERSION_CHECK_TIMEOUT_SECONDS,
+    )
+    assert version_check.returncode == 0, version_check.stderr
+    assert PINNED_TFLINT_VERSION in version_check.stdout
+
+    # Every staging dir is cleaned up whether its process won the race
+    # or lost it - none left behind regardless of outcome.
+    leftovers = list((cache_dir / 'tflint').glob(f'{PINNED_TFLINT_VERSION}.*'))
+    assert not leftovers, outputs


### PR DESCRIPTION
Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

#### What
<sub>This section was generated by AI.</sub>

- `common::resolve_tool_path`'s cache-miss path downloaded/unzipped every pinned tool version directly into the shared, version-keyed cache directory. When multiple pre-commit hook processes raced the same uncached `(tool, version)` at once, they stepped on each other's `curl`/`unzip` output: one process' cleanup could delete the archive out from under another's still-running `unzip` (`cannot find or open ... .zip`), or `unzip` could meet a binary a sibling already extracted and block on an interactive overwrite prompt - hanging under pre-commit's non-interactive stdin.
- Add `common::populate_tool_cache`: downloads/installs into a private per-process temp directory (`mktemp -d`), then atomically publishes the resulting binary into the cache via a plain-file `mv`. A process that loses the race discards its own redundant copy instead of corrupting the winner's.
- Add `test_concurrent_cache_miss_is_race_free` (network): 2 concurrent real downloads against an empty cache, asserting a clean single binary and no leftover temp dirs.

#### Why

Fix race condition during concurrent (pre-commit usually proceeds with 4 bunches simultaneously), which end in over9999 errors like this:

```bash
NOTE: The requested 'terraform' version '0.12.0' will be downloaded/used instead of whatever is on $PATH.
Downloading 'terraform' version '0.12.0'...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 14.2M  100 14.2M    0     0  1333k      0  0:00:10  0:00:10 --:--:-- 1721k
unzip:  cannot find or open terraform.zip, terraform.zip.zip or terraform.zip.ZIP.
ERROR: Failed to download 'terraform' version '0.12.0' via '/home/vm/.cache/pre-commit/repo29gptgn5/hooks/../tools/install/terraform.sh'.
```

### How can we test changes

```yaml
repos:
- repo: https://github.com/antonbabenko/pre-commit-terraform
  rev: 700a514858ab09d7ad0ac20029ddf3e8f1592550
    - id: terraform_fmt
      args:
        - --hook-config=--tool-version=0.12.2
```


<sub>This section was generated by AI.</sub>

```bash
pytest tests/pytest/tool_version_test.py -m "not network"   # 33 passed
pytest tests/pytest/tool_version_test.py -m network          # 2 passed (real download)
shellcheck -x hooks/_common.sh
shfmt -i 2 -ci -sr -d hooks/_common.sh
```

All pre-commit hooks pass locally: `shellcheck`, `shfmt`, `ruff check`, `ruff format`, `wemake-python-styleguide`, `mypy` (py3.10/3.12/3.14).

### Assisted-by
<sub>Specific models used per commit are specified in the commit messages.</sub>
- Assisted-by: Sisyphus:claude-sonnet-5 opencode (f54594c, 700a514)
