### PR TITLE
fix(`terraform_validate`): Run hook when TF configuration in `.json` files changed

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -55,7 +55,7 @@
   require_serial: true
   entry: hooks/terraform_validate.sh
   language: script
-  files: \.((tf|tofu)(\.json)?|tfvars|terraform\.lock\.hcl)$
+  files: \.((tf|tofu|tfvars)(\.json)?|terraform\.lock\.hcl)$
   exclude: \.terraform/.*$
 
 - id: terraform_providers_lock

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -55,7 +55,7 @@
   require_serial: true
   entry: hooks/terraform_validate.sh
   language: script
-  files: \.(tf|tofu|tfvars|terraform\.lock\.hcl)$
+  files: \.((tf|tofu)(\.json)?|tfvars|terraform\.lock\.hcl)$
   exclude: \.terraform/.*$
 
 - id: terraform_providers_lock

--- a/hatch.toml
+++ b/hatch.toml
@@ -1,5 +1,6 @@
 [build.targets.sdist]
 include = [
+  '.pre-commit-hooks.yaml',
   '.codecov.yml',
   '.coveragerc',
   'hooks/',

--- a/tests/pytest/pre_commit_hooks_test.py
+++ b/tests/pytest/pre_commit_hooks_test.py
@@ -1,0 +1,55 @@
+"""Tests for hook manifest file-selection patterns."""
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+MANIFEST_PATH = Path(__file__).resolve().parents[2] / '.pre-commit-hooks.yaml'
+
+
+@pytest.mark.parametrize(
+    ('file_name', 'should_match'),
+    (
+        pytest.param('main.tf', True, id='terraform-hcl'),
+        pytest.param('main.tofu', True, id='opentofu-hcl'),
+        pytest.param('main.tf.json', True, id='terraform-json'),
+        pytest.param('main.tofu.json', True, id='opentofu-json'),
+        pytest.param('values.tfvars', True, id='terraform-variables'),
+        pytest.param('.terraform.lock.hcl', True, id='terraform-lock'),
+        pytest.param('README.md', False, id='markdown'),
+        pytest.param('main.txt', False, id='text'),
+        pytest.param('foo.tofu.json.bak', False, id='opentofu-json-backup'),
+        pytest.param('tofu.json', False, id='json-without-tofu-suffix'),
+        pytest.param('main.tf.json.tmp', False, id='terraform-json-temporary'),
+        pytest.param('arbitrary.json', False, id='arbitrary-json'),
+        pytest.param(
+            'main.tofuxjson',
+            False,
+            id='opentofu-wildcard-near-miss',
+        ),
+        pytest.param(
+            'main.tfaxjson',
+            False,
+            id='terraform-wildcard-near-miss',
+        ),
+    ),
+)
+def test_terraform_validate_file_selection(
+    file_name: str,
+    *,
+    should_match: bool,
+) -> None:
+    """Verify the manifest selects only supported configuration filenames."""
+    manifest = MANIFEST_PATH.read_text(encoding='utf-8')
+    hook_block = manifest.split('- id: terraform_validate\n', maxsplit=1)[1]
+    hook_block = hook_block.split('\n- id: ', maxsplit=1)[0]
+    files_line = next(
+        line
+        for line in hook_block.splitlines()
+        if line.startswith('  files: ')
+    )
+    files_pattern = re.compile(files_line.removeprefix('  files: '))
+
+    assert bool(files_pattern.search(file_name)) is should_match

--- a/tests/pytest/pre_commit_hooks_test.py
+++ b/tests/pytest/pre_commit_hooks_test.py
@@ -17,6 +17,11 @@ MANIFEST_PATH = Path(__file__).resolve().parents[2] / '.pre-commit-hooks.yaml'
         pytest.param('main.tf.json', True, id='terraform-json'),
         pytest.param('main.tofu.json', True, id='opentofu-json'),
         pytest.param('values.tfvars', True, id='terraform-variables'),
+        pytest.param(
+            'values.tfvars.json',
+            True,
+            id='terraform-variables-json',
+        ),
         pytest.param('.terraform.lock.hcl', True, id='terraform-lock'),
         pytest.param('README.md', False, id='markdown'),
         pytest.param('main.txt', False, id='text'),
@@ -33,6 +38,11 @@ MANIFEST_PATH = Path(__file__).resolve().parents[2] / '.pre-commit-hooks.yaml'
             'main.tfaxjson',
             False,
             id='terraform-wildcard-near-miss',
+        ),
+        pytest.param(
+            'values.tfvarsxjson',
+            False,
+            id='terraform-variables-json-near-miss',
         ),
     ),
 )


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

#### What
<sub>This section was generated by AI.</sub>

- Extend `terraform_validate` file selection to `.tf.json`, `.tofu.json`, and `.tfvars.json`.
- Add positive and negative regression coverage for the manifest pattern.
- Fixes #1013.

#### Why

terraform_validate currently excludes .tf.json and .tofu.json from its manifest-level file selection, so valid JSON configurations can be skipped before validation runs. This change brings JSON configuration files into the same selection path as their HCL equivalents while excluding similarly named non-configuration files.

### How can we test changes
<sub>This section was generated by AI.</sub>

- `tox -qq -e pytest -- tests/pytest/pre_commit_hooks_test.py --no-cov` (`16 passed`)
- `tox -qq -e pytest` (`68 passed`, `100.00%` coverage)
- Repository pre-commit checks for the changed YAML, TOML, and Python files, including YAML validation, Ruff, wemake-python-styleguide, and MyPy (`Passed`)
- The commit-bound sdist includes `.pre-commit-hooks.yaml`, and its focused manifest-selection test passes (`16 passed`)
- Actual `pre-commit run terraform_validate` integration controls using OpenTofu 1.12.6: invalid `.tofu.json` is selected and rejected, valid `.tofu.json` is selected and passes, and `.tfvars.json` triggers the hook

### Assisted-by
<sub>Specific models used per commit are specified in the commit messages.</sub>

- Assisted-by: Codex:gpt-5 (4485084, c0225b1)
