### PR TITLE
ci(zizmor): Remove trailing .git from repo URLs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,7 +72,7 @@ repos:
     - --width=75
     - --implicit_start
 
-- repo: https://github.com/adrienverge/yamllint.git
+- repo: https://github.com/adrienverge/yamllint
   rev: cba56bcde1fdd01c1deb3f945e69764c291a6530  # frozen: v1.38.0
   hooks:
   - id: yamllint
@@ -118,7 +118,7 @@ repos:
   hooks:
   - id: wemake-python-styleguide
 
-- repo: https://github.com/pre-commit/mirrors-mypy.git
+- repo: https://github.com/pre-commit/mirrors-mypy
   rev: d2823d321df3af8f878f7ee3414dc94d037145b9  # frozen: v2.1.0
   hooks:
   - id: mypy


### PR DESCRIPTION
Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

#### What
<sub>This section was generated by AI.</sub>

- Remove the trailing `.git` suffix from the `adrienverge/yamllint` and `pre-commit/mirrors-mypy` `repo:` URLs in `.pre-commit-config.yaml`, matching every other entry in the file.

#### Why
<!-- describe why this change is needed -->

### How can we test changes
<sub>This section was generated by AI.</sub>

- Reproduced the failure directly against GitHub's API: `gh api repos/adrienverge/yamllint.git/tags` -> `404 Not Found`, while `gh api repos/adrienverge/yamllint/tags` -> succeeds (same pattern for `pre-commit/mirrors-mypy`).
- Ran `uvx zizmor --format=sarif .` against this repo before/after the fix:
  - **Before**: `fatal: no audit was performed` / `'impostor-commit' audit failed on file://./.pre-commit-config.yaml` / `couldn't list tags for adrienverge/yamllint.git` / `can't access adrienverge/yamllint.git: missing or you have no access` — exit code `1`.
  - **After**: `🌈 completed ./.pre-commit-config.yaml` — exit code `0`.
- This reproduces and fixes the "Lint GitHub Actions" job failure at https://github.com/antonbabenko/pre-commit-terraform/actions/runs/33882687934/job/101110612751 (surfaced on #1014, but unrelated to that PR's own changes — `.pre-commit-config.yaml` is untouched on `master` and in #1014's diff, so this same crash can hit any PR whenever zizmor's fast-path check happens to fall back to listing tags).
- `pre-commit`'s own git hook ran on commit and passed (`yamllint`, `check yaml`, etc.), confirming the URL change does not break hook resolution.

### Assisted-by
- Assisted-by: Sisyphus:claude-sonnet-5 opencode
