### PR TITLE
docs: Document __GIT_WORKING_DIR__ support for terrascan hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1222,6 +1222,13 @@ If the generated name is incorrect, set them by providing the `module-repo-short
 2. Use the `--args=--verbose` parameter to see the rule ID in the scanning output. Useful to skip validations.
 3. Use `--skip-rules="ruleID1,ruleID2"` parameter to skip one or more rules globally while scanning (e.g.: `--args=--skip-rules="ruleID1,ruleID2"`).
 4. Use the syntax `#ts:skip=RuleID optional_comment` inside a resource to skip the rule for that resource.
+5. To use a config file shared across multiple directories, use the `__GIT_WORKING_DIR__` placeholder (see [Usage of `__GIT_WORKING_DIR__` placeholder in `--args`](#all-hooks-usage-of-__git_working_dir__-placeholder-in---args)). This resolves the "config file doesn't exist" error some users hit when the hook runs from a subdirectory:
+
+    ```yaml
+    - id: terrascan
+      args:
+        - --args=-c __GIT_WORKING_DIR__/.terrascan.toml
+    ```
 
 ### tfupdate
 


### PR DESCRIPTION
## What this does

Documents the `__GIT_WORKING_DIR__` placeholder for the `terrascan` hook, following the same pattern already documented for `terraform_tflint`.

## Context

Closes #492

While investigating this issue, I found that support for `__GIT_WORKING_DIR__` was already implemented in `hooks/terrascan.sh`:

```bash
# Support for setting PATH to repo root.
for i in "${!ARGS[@]}"; do
  ARGS[i]=${ARGS[i]/__GIT_WORKING_DIR__/$(pwd)\/}
done
```

However, this was never documented in the `### terrascan` section of the README, so users hitting the "config file doesn't exist" error (when running the hook from a subdirectory) had no way to know the fix already existed.

## How I tested it

I reproduced the original bug locally on Windows using the `terrascan` binary directly:

- Running `terrascan scan -c .terrascan.toml` from a subdirectory (simulating the hook's per-dir execution) reproduces the exact error from the issue: `config file: .terrascan.toml, doesn't exist`.
- Running the same command with an **absolute path** to the config file (what `__GIT_WORKING_DIR__` resolves to at runtime) no longer produces this error — confirming the fix works as expected.

This is a documentation-only change; no code was modified.